### PR TITLE
Add protocol versioning and CI improvements

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   update-formula:
-    runs-on: ubuntu-latest
+    runs-on: arc-runner-hle
 
     steps:
       - name: Derive version from tag

--- a/.github/workflows/notify-server.yml
+++ b/.github/workflows/notify-server.yml
@@ -1,0 +1,16 @@
+name: Notify Server Repo
+
+on:
+  push:
+    branches: [main]
+    paths: ['src/hle_common/**']
+
+jobs:
+  notify:
+    runs-on: arc-runner-hle
+    steps:
+      - uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.SERVER_REPO_PAT }}
+          repository: jspanos/hle
+          event-type: common-updated

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: arc-runner-hle
     steps:
       - uses: actions/checkout@v4
 
@@ -40,7 +40,7 @@ jobs:
 
   publish:
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: arc-runner-hle
     environment: pypi
 
     steps:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,100 @@
+name: Security Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly security scan — Monday 06:00 UTC
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  bandit:
+    name: Bandit (Python SAST)
+    runs-on: arc-runner-hle
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install Bandit
+        run: pip install bandit[toml]
+
+      - name: Run Bandit
+        run: |
+          bandit -r src/ \
+            -f json -o bandit-results.json \
+            --severity-level medium \
+            --confidence-level medium \
+            -s B101 \
+            || true
+
+      - name: Display results
+        if: always()
+        run: |
+          if [ -f bandit-results.json ]; then
+            python -c "
+          import json, sys
+          data = json.load(open('bandit-results.json'))
+          results = data.get('results', [])
+          if not results:
+              print('No issues found.')
+              sys.exit(0)
+          for r in results:
+              sev = r['issue_severity']
+              conf = r['issue_confidence']
+              print(f\"[{sev}/{conf}] {r['filename']}:{r['line_number']} -- {r['issue_text']}\")
+          print(f\"\n{len(results)} issue(s) found.\")
+          if any(r['issue_severity'] == 'HIGH' for r in results):
+              sys.exit(1)
+          "
+          fi
+
+  pip-audit:
+    name: pip-audit (Dependencies)
+    runs-on: arc-runner-hle
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: |
+          uv venv
+          uv pip install -e ".[dev]"
+
+      - name: Install pip-audit
+        run: |
+          source .venv/bin/activate
+          pip install pip-audit
+
+      - name: Run pip-audit
+        run: |
+          source .venv/bin/activate
+          pip-audit --desc --fix --dry-run 2>&1 || true
+
+  secrets-scan:
+    name: TruffleHog (Secret Scanning)
+    runs-on: arc-runner-hle
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: TruffleHog scan
+        uses: trufflesecurity/trufflehog@main
+        with:
+          extra_args: --only-verified

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: arc-runner-hle
     strategy:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v1.2.0 — 2026-02-24
+
+Add protocol versioning and CI improvements for two-repo architecture with `jspanos/hle` server.
+
+- Add `PROTOCOL_VERSION = "1.0"` to `hle_common/protocol.py` for wire-format version negotiation
+- Add `protocol_version` field to `TunnelRegistration` (optional, backward compatible with older servers)
+- Client sends `protocol_version` during tunnel registration handshake
+- Bump `hle_common` version to `0.2.0`
+- Add `security.yml` workflow (Bandit SAST, pip-audit, TruffleHog secret scanning)
+- Add `notify-server.yml` workflow (triggers server CI via `repository_dispatch` when `hle_common` changes)
+- Add `test_protocol.py` and `test_models.py` test suites for shared protocol/models
+- Switch all CI workflows from `ubuntu-latest` to `arc-runner-hle` self-hosted runners
+
 ## v1.1.2 — 2026-02-21
 
 Fix README badges: use static license badge (repo is private), bust GitHub camo cache for PyPI version badge.

--- a/src/hle_client/tunnel.py
+++ b/src/hle_client/tunnel.py
@@ -28,7 +28,7 @@ from hle_common.models import (
     WsStreamFrame,
     WsStreamOpen,
 )
-from hle_common.protocol import MessageType, ProtocolMessage
+from hle_common.protocol import PROTOCOL_VERSION, MessageType, ProtocolMessage
 
 logger = logging.getLogger(__name__)
 
@@ -231,6 +231,7 @@ class Tunnel:
                 service_label=self.config.service_label,
                 api_key=api_key,
                 client_version=__version__,
+                protocol_version=PROTOCOL_VERSION,
                 websocket_enabled=self.config.websocket_enabled,
                 auth_mode=self.config.auth_mode,
             )

--- a/src/hle_common/__init__.py
+++ b/src/hle_common/__init__.py
@@ -1,3 +1,3 @@
 """HLE Common — Shared types and utilities between client and server."""
 
-__version__ = "0.1.2"
+__version__ = "0.2.0"

--- a/src/hle_common/models.py
+++ b/src/hle_common/models.py
@@ -25,6 +25,7 @@ class TunnelRegistration(BaseModel):
     service_label: str | None = None  # user-chosen name, e.g. "ha", "jellyfin"
     api_key: str  # required — hle_<32 hex chars>
     client_version: str | None = None
+    protocol_version: str | None = None  # sent by clients >= 0.5.0
     websocket_enabled: bool = True
     auth_mode: str = "none"  # SSO not in POC scope
 

--- a/src/hle_common/protocol.py
+++ b/src/hle_common/protocol.py
@@ -7,6 +7,11 @@ from typing import Any
 
 from pydantic import BaseModel
 
+# Protocol version — bump on wire-format changes.
+# Major bump (1.0 → 2.0): breaking change, server must support both during deprecation.
+# Minor bump (1.0 → 1.1): new optional fields/message types, old clients unaffected.
+PROTOCOL_VERSION = "1.0"
+
 
 class MessageType(StrEnum):
     """Types of messages exchanged between client and relay server."""

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -1,0 +1,234 @@
+"""Tests for the HLE shared Pydantic models (hle_common.models)."""
+
+from __future__ import annotations
+
+import pytest
+
+from hle_common.models import (
+    ProxiedHttpRequest,
+    ProxiedHttpResponse,
+    SpeedTestData,
+    SpeedTestResult,
+    TunnelRegistration,
+    TunnelRegistrationResponse,
+    WsStreamClose,
+    WsStreamFrame,
+    WsStreamOpen,
+)
+
+
+class TestTunnelRegistration:
+    def test_tunnel_registration_defaults(self):
+        reg = TunnelRegistration(
+            service_url="http://localhost:5000",
+            api_key="hle_abc123",
+        )
+        assert reg.service_url == "http://localhost:5000"
+        assert reg.service_label is None
+        assert reg.api_key == "hle_abc123"
+        assert reg.client_version is None
+        assert reg.protocol_version is None
+        assert reg.websocket_enabled is True
+        assert reg.auth_mode == "none"
+
+    def test_tunnel_registration_with_protocol_version(self):
+        reg = TunnelRegistration(
+            service_url="http://localhost:5000",
+            api_key="hle_abc123",
+            protocol_version="1.0",
+        )
+        assert reg.protocol_version == "1.0"
+
+    def test_tunnel_registration_with_overrides(self):
+        reg = TunnelRegistration(
+            service_url="http://localhost:5000",
+            service_label="ha",
+            api_key="hle_mykey123",
+            websocket_enabled=False,
+            auth_mode="token",
+        )
+        assert reg.service_label == "ha"
+        assert reg.api_key == "hle_mykey123"
+        assert reg.websocket_enabled is False
+        assert reg.auth_mode == "token"
+
+    def test_tunnel_registration_requires_api_key(self):
+        with pytest.raises(ValueError):
+            TunnelRegistration(service_url="http://localhost:5000")
+
+    def test_tunnel_registration_service_label_validation(self):
+        with pytest.raises(ValueError, match="service_label"):
+            TunnelRegistration(
+                service_url="http://localhost:5000",
+                api_key="hle_key",
+                service_label="-bad",
+            )
+        with pytest.raises(ValueError, match="service_label"):
+            TunnelRegistration(
+                service_url="http://localhost:5000",
+                api_key="hle_key",
+                service_label="bad-",
+            )
+        with pytest.raises(ValueError, match="service_label"):
+            TunnelRegistration(
+                service_url="http://localhost:5000",
+                api_key="hle_key",
+                service_label="BAD",
+            )
+
+
+class TestTunnelRegistrationResponse:
+    def test_tunnel_registration_response(self):
+        resp = TunnelRegistrationResponse(
+            tunnel_id="t-resp-1",
+            subdomain="resptest.abc",
+            public_url="http://resptest.abc.localhost:8000",
+            websocket_enabled=True,
+            user_code="abc",
+            service_label="resptest",
+        )
+        assert resp.tunnel_id == "t-resp-1"
+        assert resp.subdomain == "resptest.abc"
+        assert resp.websocket_enabled is True
+
+
+class TestProxiedHttpRequest:
+    def test_proxied_http_request_defaults(self):
+        req = ProxiedHttpRequest(
+            request_id="r-proxy-1",
+            method="GET",
+            path="/api/health",
+            headers={"Host": "example.com"},
+        )
+        assert req.query_string == ""
+        assert req.body is None
+
+    def test_proxied_http_request_with_body(self):
+        req = ProxiedHttpRequest(
+            request_id="r-proxy-2",
+            method="POST",
+            path="/api/submit",
+            headers={"Content-Type": "application/json"},
+            body="eyJrZXkiOiAidmFsdWUifQ==",
+            query_string="debug=true",
+        )
+        assert req.body == "eyJrZXkiOiAidmFsdWUifQ=="
+        assert isinstance(req.body, str)
+
+
+class TestProxiedHttpResponse:
+    def test_proxied_http_response(self):
+        resp = ProxiedHttpResponse(
+            request_id="r-resp-1",
+            status_code=200,
+            headers={"Content-Type": "text/html"},
+            body="PGgxPkhlbGxvPC9oMT4=",
+        )
+        assert resp.request_id == "r-resp-1"
+        assert resp.status_code == 200
+
+
+class TestWsStreamOpen:
+    def test_ws_stream_open(self):
+        stream = WsStreamOpen(stream_id="s-open-1", path="/ws/notifications")
+        assert stream.stream_id == "s-open-1"
+        assert stream.headers == {}
+
+    def test_ws_stream_open_with_headers(self):
+        stream = WsStreamOpen(
+            stream_id="s-open-2",
+            path="/ws/chat",
+            headers={"Authorization": "Bearer tok123"},
+        )
+        assert stream.headers == {"Authorization": "Bearer tok123"}
+
+
+class TestWsStreamFrame:
+    def test_ws_stream_frame_text(self):
+        frame = WsStreamFrame(stream_id="s-frame-1", data="hello world")
+        assert frame.is_binary is False
+
+    def test_ws_stream_frame_binary(self):
+        frame = WsStreamFrame(stream_id="s-frame-2", data="AQIDBA==", is_binary=True)
+        assert frame.is_binary is True
+
+
+class TestWsStreamClose:
+    def test_ws_stream_close_defaults(self):
+        close = WsStreamClose(stream_id="s-close-1")
+        assert close.code == 1000
+        assert close.reason == ""
+
+    def test_ws_stream_close_custom(self):
+        close = WsStreamClose(stream_id="s-close-2", code=1001, reason="going away")
+        assert close.code == 1001
+
+
+class TestSpeedTest:
+    def test_speed_test_data(self):
+        data = SpeedTestData(
+            test_id="test-1",
+            direction="download",
+            chunk_index=0,
+            total_chunks=10,
+            data="AAAA",
+        )
+        assert data.test_id == "test-1"
+        assert data.direction == "download"
+
+    def test_speed_test_result(self):
+        result = SpeedTestResult(
+            test_id="test-1",
+            direction="download",
+            total_bytes=1024,
+            duration_seconds=1.5,
+            throughput_mbps=5.46,
+        )
+        assert result.throughput_mbps == 5.46
+
+
+class TestRoundtripSerialization:
+    def test_roundtrip_tunnel_registration(self):
+        original = TunnelRegistration(
+            service_url="http://localhost:5000",
+            service_label="regrt",
+            api_key="hle_roundtrip123",
+            protocol_version="1.0",
+            websocket_enabled=False,
+            auth_mode="token",
+        )
+        data = original.model_dump()
+        restored = TunnelRegistration(**data)
+        assert restored == original
+
+    def test_roundtrip_tunnel_registration_response(self):
+        original = TunnelRegistrationResponse(
+            tunnel_id="t-rt-3",
+            subdomain="resprt.abc",
+            public_url="http://resprt.abc.localhost:8000",
+            websocket_enabled=True,
+            user_code="abc",
+            service_label="resprt",
+        )
+        data = original.model_dump()
+        restored = TunnelRegistrationResponse(**data)
+        assert restored == original
+
+    def test_roundtrip_proxied_http_request(self):
+        original = ProxiedHttpRequest(
+            request_id="r-rt-1",
+            method="POST",
+            path="/api/data",
+            headers={"Content-Type": "application/json"},
+            body="eyJ0ZXN0IjogdHJ1ZX0=",
+            query_string="v=2",
+        )
+        data = original.model_dump()
+        restored = ProxiedHttpRequest(**data)
+        assert restored == original
+
+    def test_roundtrip_ws_stream_close(self):
+        original = WsStreamClose(stream_id="s-rt-3", code=1001, reason="going away")
+        data = original.model_dump()
+        restored = WsStreamClose(**data)
+        assert restored == original

--- a/tests/unit/test_protocol.py
+++ b/tests/unit/test_protocol.py
@@ -1,0 +1,242 @@
+"""Tests for the HLE wire protocol."""
+
+import pytest
+from pydantic import ValidationError
+
+from hle_common.protocol import (
+    PROTOCOL_VERSION,
+    ErrorPayload,
+    HttpRequest,
+    HttpResponse,
+    MessageType,
+    ProtocolMessage,
+    TunnelOpenRequest,
+    TunnelOpenResponse,
+    WsFrame,
+)
+
+
+class TestProtocolVersion:
+    def test_protocol_version_exists(self):
+        assert PROTOCOL_VERSION == "1.0"
+
+    def test_protocol_version_is_string(self):
+        assert isinstance(PROTOCOL_VERSION, str)
+
+
+class TestMessageType:
+    def test_message_types_are_strings(self):
+        assert MessageType.AUTH_REQUEST == "auth_request"
+        assert MessageType.WS_FRAME == "ws_frame"
+        assert MessageType.WEBHOOK_INCOMING == "webhook_incoming"
+
+    def test_tunnel_register_type(self):
+        assert MessageType.TUNNEL_REGISTER == "tunnel_register"
+
+    def test_all_message_types_exist(self):
+        expected = {
+            "auth_request",
+            "auth_response",
+            "tunnel_open",
+            "tunnel_close",
+            "tunnel_ack",
+            "tunnel_register",
+            "http_request",
+            "http_response",
+            "ws_open",
+            "ws_close",
+            "ws_frame",
+            "webhook_incoming",
+            "webhook_response",
+            "speed_test_data",
+            "speed_test_result",
+            "ping",
+            "pong",
+            "error",
+        }
+        actual = {member.value for member in MessageType}
+        assert actual == expected
+
+
+class TestProtocolMessage:
+    def test_minimal_message(self):
+        msg = ProtocolMessage(type=MessageType.PING)
+        assert msg.type == MessageType.PING
+        assert msg.tunnel_id is None
+
+    def test_full_message(self):
+        msg = ProtocolMessage(
+            type=MessageType.HTTP_REQUEST,
+            tunnel_id="t-123",
+            request_id="r-456",
+            payload={"key": "value"},
+        )
+        assert msg.tunnel_id == "t-123"
+        assert msg.payload == {"key": "value"}
+
+    def test_payload_accepts_typed_dict(self):
+        msg = ProtocolMessage(
+            type=MessageType.ERROR,
+            payload={"code": "not_found", "message": "Tunnel not found", "count": 42},
+        )
+        assert msg.payload["code"] == "not_found"
+        assert msg.payload["count"] == 42
+
+    def test_payload_defaults_to_none(self):
+        msg = ProtocolMessage(type=MessageType.PONG)
+        assert msg.payload is None
+
+
+class TestTunnelOpenRequest:
+    def test_defaults(self):
+        req = TunnelOpenRequest(service_url="http://localhost:8080")
+        assert req.auth_mode == "sso"
+        assert req.websocket_enabled is True
+        assert req.domain is None
+
+
+class TestTunnelOpenResponse:
+    def test_all_fields(self):
+        resp = TunnelOpenResponse(
+            tunnel_id="t-abc",
+            subdomain="myapp",
+            public_url="https://myapp.hle.example.com",
+        )
+        assert resp.tunnel_id == "t-abc"
+        assert resp.subdomain == "myapp"
+        assert resp.public_url == "https://myapp.hle.example.com"
+
+    def test_missing_required_field_raises(self):
+        with pytest.raises((TypeError, ValidationError)):
+            TunnelOpenResponse(tunnel_id="t-1", subdomain="sub")  # missing public_url
+
+    def test_roundtrip_serialization(self):
+        resp = TunnelOpenResponse(
+            tunnel_id="t-1",
+            subdomain="demo",
+            public_url="https://demo.hle.example.com",
+        )
+        data = resp.model_dump()
+        restored = TunnelOpenResponse(**data)
+        assert restored == resp
+
+
+class TestHttpRequest:
+    def test_required_fields(self):
+        req = HttpRequest(
+            request_id="r-1",
+            method="GET",
+            path="/api/data",
+            headers={"Host": "example.com"},
+        )
+        assert req.request_id == "r-1"
+        assert req.method == "GET"
+        assert req.body is None
+        assert req.query_string == ""
+
+    def test_with_body_and_query_string(self):
+        req = HttpRequest(
+            request_id="r-2",
+            method="POST",
+            path="/submit",
+            headers={"Content-Type": "application/json"},
+            body="eyJrZXkiOiAidmFsdWUifQ==",  # base64 of {"key": "value"}
+            query_string="page=1&limit=10",
+        )
+        assert req.body == "eyJrZXkiOiAidmFsdWUifQ=="
+        assert req.query_string == "page=1&limit=10"
+
+    def test_body_is_str_not_bytes(self):
+        req = HttpRequest(
+            request_id="r-3",
+            method="PUT",
+            path="/update",
+            headers={},
+            body="base64content",
+        )
+        assert isinstance(req.body, str)
+
+    def test_missing_request_id_raises(self):
+        with pytest.raises((TypeError, ValidationError)):
+            HttpRequest(method="GET", path="/", headers={})
+
+
+class TestHttpResponse:
+    def test_required_fields(self):
+        resp = HttpResponse(
+            request_id="r-1",
+            status_code=200,
+            headers={"Content-Type": "text/plain"},
+        )
+        assert resp.request_id == "r-1"
+        assert resp.status_code == 200
+        assert resp.body is None
+
+    def test_with_body(self):
+        resp = HttpResponse(
+            request_id="r-2",
+            status_code=201,
+            headers={},
+            body="cmVzcG9uc2U=",  # base64 of "response"
+        )
+        assert resp.body == "cmVzcG9uc2U="
+        assert isinstance(resp.body, str)
+
+    def test_missing_request_id_raises(self):
+        with pytest.raises((TypeError, ValidationError)):
+            HttpResponse(status_code=200, headers={})
+
+
+class TestWsFrame:
+    def test_text_frame(self):
+        frame = WsFrame(stream_id="s-1", data="hello")
+        assert frame.is_binary is False
+        assert frame.data == "hello"
+        assert frame.path == ""
+
+    def test_binary_frame(self):
+        frame = WsFrame(stream_id="s-1", data="AAEB", is_binary=True)
+        assert frame.is_binary is True
+        assert isinstance(frame.data, str)
+
+    def test_data_is_str(self):
+        frame = WsFrame(stream_id="s-1", data="text payload")
+        assert isinstance(frame.data, str)
+
+    def test_path_for_ws_open(self):
+        frame = WsFrame(stream_id="s-1", data="", path="/ws/notifications")
+        assert frame.path == "/ws/notifications"
+
+    def test_no_is_close_attribute(self):
+        frame = WsFrame(stream_id="s-1", data="x")
+        assert not hasattr(frame, "is_close") or "is_close" not in frame.model_fields
+
+
+class TestErrorPayload:
+    def test_required_fields(self):
+        err = ErrorPayload(code="tunnel_not_found", message="Tunnel does not exist")
+        assert err.code == "tunnel_not_found"
+        assert err.message == "Tunnel does not exist"
+        assert err.request_id is None
+
+    def test_with_request_id(self):
+        err = ErrorPayload(
+            code="auth_failed",
+            message="Invalid token",
+            request_id="r-99",
+        )
+        assert err.request_id == "r-99"
+
+    def test_missing_code_raises(self):
+        with pytest.raises((TypeError, ValidationError)):
+            ErrorPayload(message="oops")
+
+    def test_missing_message_raises(self):
+        with pytest.raises((TypeError, ValidationError)):
+            ErrorPayload(code="bad")
+
+    def test_roundtrip_serialization(self):
+        err = ErrorPayload(code="rate_limit", message="Too many requests", request_id="r-5")
+        data = err.model_dump()
+        restored = ErrorPayload(**data)
+        assert restored == err


### PR DESCRIPTION
## Summary

- Add `PROTOCOL_VERSION = "1.0"` to `hle_common/protocol.py` for wire-format version negotiation
- Add `protocol_version` field to `TunnelRegistration` (optional, backward compatible with older servers)
- Client sends `protocol_version` during tunnel registration handshake
- Bump `hle_common` version to `0.2.0`
- Add `security.yml` workflow (Bandit SAST, pip-audit, TruffleHog secret scanning)
- Add `notify-server.yml` workflow (triggers server CI via `repository_dispatch` when `hle_common` changes)
- Add `test_protocol.py` and `test_models.py` test suites for shared protocol/models
- Switch all CI workflows from `ubuntu-latest` to `arc-runner-hle` self-hosted runners

## Test plan

- [x] `ruff check` and `ruff format --check` pass
- [x] 138/139 tests pass (1 pre-existing failure in `test_no_api_key` unrelated to these changes)
- [ ] Verify `arc-runner-hle` runners pick up CI jobs
- [ ] After merge, verify `notify-server.yml` triggers server CI when `hle_common` changes