### PR TITLE
Switch CI runners to arc-runner-hle-client

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   update-formula:
-    runs-on: arc-runner-hle
+    runs-on: arc-runner-hle-client
 
     steps:
       - name: Derive version from tag

--- a/.github/workflows/notify-server.yml
+++ b/.github/workflows/notify-server.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   notify:
-    runs-on: arc-runner-hle
+    runs-on: arc-runner-hle-client
     steps:
       - uses: peter-evans/repository-dispatch@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: arc-runner-hle
+    runs-on: arc-runner-hle-client
     steps:
       - uses: actions/checkout@v4
 
@@ -40,7 +40,7 @@ jobs:
 
   publish:
     needs: test
-    runs-on: arc-runner-hle
+    runs-on: arc-runner-hle-client
     environment: pypi
 
     steps:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   bandit:
     name: Bandit (Python SAST)
-    runs-on: arc-runner-hle
+    runs-on: arc-runner-hle-client
     steps:
       - uses: actions/checkout@v4
 
@@ -59,7 +59,7 @@ jobs:
 
   pip-audit:
     name: pip-audit (Dependencies)
-    runs-on: arc-runner-hle
+    runs-on: arc-runner-hle-client
     steps:
       - uses: actions/checkout@v4
 
@@ -88,7 +88,7 @@ jobs:
 
   secrets-scan:
     name: TruffleHog (Secret Scanning)
-    runs-on: arc-runner-hle
+    runs-on: arc-runner-hle-client
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: arc-runner-hle
+    runs-on: arc-runner-hle-client
     strategy:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]


### PR DESCRIPTION
## Summary

- Replace `arc-runner-hle` with `arc-runner-hle-client` across all 5 workflow files
- Uses the dedicated runner scale set for the client repo instead of sharing the server's runner

## Test plan

- [ ] Verify `arc-runner-hle-client` picks up CI jobs