### PR TITLE
Fix SSL verification for homelab services; remove relay host/port CLI flags

### DIFF
--- a/src/hle_client/api.py
+++ b/src/hle_client/api.py
@@ -14,17 +14,16 @@ logger = logging.getLogger(__name__)
 class ApiClientConfig:
     """Configuration for the HLE API client."""
 
-    relay_host: str = "hle.world"
-    relay_port: int = 443
     api_key: str = ""
 
 
 class ApiClient:
     """HTTP client for the HLE server REST API using Bearer auth."""
 
+    _BASE_URL = "https://hle.world"
+
     def __init__(self, config: ApiClientConfig) -> None:
-        scheme = "https" if config.relay_port == 443 else "http"
-        self._base_url = f"{scheme}://{config.relay_host}:{config.relay_port}"
+        self._base_url = self._BASE_URL
         self._headers = {"Authorization": f"Bearer {config.api_key}"}
 
     async def list_tunnels(self) -> list[dict]:

--- a/src/hle_client/cli.py
+++ b/src/hle_client/cli.py
@@ -57,26 +57,28 @@ def main(debug: bool) -> None:
     help="API key (also reads HLE_API_KEY env var, then ~/.config/hle/config.toml)",
 )
 @click.option("--websocket/--no-websocket", default=True, help="Enable WebSocket proxying")
-@click.option("--relay-host", default="hle.world", show_default=True, help="Relay server host")
-@click.option("--relay-port", default=443, show_default=True, type=int, help="Relay server port")
+@click.option(
+    "--verify-ssl",
+    is_flag=True,
+    default=False,
+    help="Enable SSL certificate verification (by default self-signed certs are accepted)",
+)
 def expose(
     service: str,
     auth: str,
     service_label: str | None,
     api_key: str | None,
     websocket: bool,
-    relay_host: str,
-    relay_port: int,
+    verify_ssl: bool,
 ) -> None:
     """Expose a local service to the internet."""
     config = TunnelConfig(
         service_url=service,
-        relay_host=relay_host,
-        relay_port=relay_port,
         auth_mode=auth,
         service_label=service_label,
         api_key=api_key,
         websocket_enabled=websocket,
+        verify_ssl=verify_ssl,
     )
     tunnel = Tunnel(config=config)
 
@@ -88,7 +90,7 @@ def expose(
         )
 
     console.print(f"\n[bold]HLE[/bold] v{__version__}  Exposing [cyan]{service}[/cyan]")
-    console.print(f"     Relay   [dim]{relay_host}:{relay_port}[/dim]")
+    console.print("     Relay   [dim]hle.world[/dim]")
     if service_label:
         console.print(f"     Label   [dim]{service_label}[/dim]")
     console.print(f"     WS      [dim]{'enabled' if websocket else 'disabled'}[/dim]")
@@ -187,18 +189,14 @@ def webhook(path: str, forward_to: str) -> None:
     envvar="HLE_API_KEY",
     help="API key for authentication",
 )
-@click.option("--relay-host", default="hle.world", show_default=True, help="Relay server host")
-@click.option("--relay-port", default=443, show_default=True, type=int, help="Relay server port")
-def tunnels(api_key: str | None, relay_host: str, relay_port: int) -> None:
+def tunnels(api_key: str | None) -> None:
     """List active tunnels for your account."""
     resolved_key = _resolve_api_key(api_key)
 
     async def _run() -> None:
         from hle_client.api import ApiClient, ApiClientConfig
 
-        client = ApiClient(
-            ApiClientConfig(relay_host=relay_host, relay_port=relay_port, api_key=resolved_key)
-        )
+        client = ApiClient(ApiClientConfig(api_key=resolved_key))
         try:
             tunnel_list = await client.list_tunnels()
         except Exception as exc:
@@ -244,18 +242,14 @@ def access() -> None:
     envvar="HLE_API_KEY",
     help="API key for authentication",
 )
-@click.option("--relay-host", default="hle.world", show_default=True, help="Relay server host")
-@click.option("--relay-port", default=443, show_default=True, type=int, help="Relay server port")
-def access_list(subdomain: str, api_key: str | None, relay_host: str, relay_port: int) -> None:
+def access_list(subdomain: str, api_key: str | None) -> None:
     """List access rules for a subdomain."""
     resolved_key = _resolve_api_key(api_key)
 
     async def _run() -> None:
         from hle_client.api import ApiClient, ApiClientConfig
 
-        client = ApiClient(
-            ApiClientConfig(relay_host=relay_host, relay_port=relay_port, api_key=resolved_key)
-        )
+        client = ApiClient(ApiClientConfig(api_key=resolved_key))
         try:
             rules = await client.list_access_rules(subdomain)
         except Exception as exc:
@@ -299,15 +293,11 @@ def access_list(subdomain: str, api_key: str | None, relay_host: str, relay_port
     envvar="HLE_API_KEY",
     help="API key for authentication",
 )
-@click.option("--relay-host", default="hle.world", show_default=True, help="Relay server host")
-@click.option("--relay-port", default=443, show_default=True, type=int, help="Relay server port")
 def access_add(
     subdomain: str,
     email: str,
     provider: str,
     api_key: str | None,
-    relay_host: str,
-    relay_port: int,
 ) -> None:
     """Add an email to a subdomain's access allow-list."""
     resolved_key = _resolve_api_key(api_key)
@@ -315,9 +305,7 @@ def access_add(
     async def _run() -> None:
         from hle_client.api import ApiClient, ApiClientConfig
 
-        client = ApiClient(
-            ApiClientConfig(relay_host=relay_host, relay_port=relay_port, api_key=resolved_key)
-        )
+        client = ApiClient(ApiClientConfig(api_key=resolved_key))
         try:
             rule = await client.add_access_rule(subdomain, email, provider)
         except Exception as exc:
@@ -341,20 +329,14 @@ def access_add(
     envvar="HLE_API_KEY",
     help="API key for authentication",
 )
-@click.option("--relay-host", default="hle.world", show_default=True, help="Relay server host")
-@click.option("--relay-port", default=443, show_default=True, type=int, help="Relay server port")
-def access_remove(
-    subdomain: str, rule_id: int, api_key: str | None, relay_host: str, relay_port: int
-) -> None:
+def access_remove(subdomain: str, rule_id: int, api_key: str | None) -> None:
     """Remove an access rule by ID."""
     resolved_key = _resolve_api_key(api_key)
 
     async def _run() -> None:
         from hle_client.api import ApiClient, ApiClientConfig
 
-        client = ApiClient(
-            ApiClientConfig(relay_host=relay_host, relay_port=relay_port, api_key=resolved_key)
-        )
+        client = ApiClient(ApiClientConfig(api_key=resolved_key))
         try:
             await client.delete_access_rule(subdomain, rule_id)
         except Exception as exc:
@@ -384,9 +366,7 @@ def pin() -> None:
     envvar="HLE_API_KEY",
     help="API key for authentication",
 )
-@click.option("--relay-host", default="hle.world", show_default=True, help="Relay server host")
-@click.option("--relay-port", default=443, show_default=True, type=int, help="Relay server port")
-def pin_set(subdomain: str, api_key: str | None, relay_host: str, relay_port: int) -> None:
+def pin_set(subdomain: str, api_key: str | None) -> None:
     """Set a PIN for a subdomain (prompts for 4-8 digit PIN)."""
     resolved_key = _resolve_api_key(api_key)
 
@@ -403,9 +383,7 @@ def pin_set(subdomain: str, api_key: str | None, relay_host: str, relay_port: in
     async def _run() -> None:
         from hle_client.api import ApiClient, ApiClientConfig
 
-        client = ApiClient(
-            ApiClientConfig(relay_host=relay_host, relay_port=relay_port, api_key=resolved_key)
-        )
+        client = ApiClient(ApiClientConfig(api_key=resolved_key))
         try:
             await client.set_tunnel_pin(subdomain, pin_value)
         except Exception as exc:
@@ -425,18 +403,14 @@ def pin_set(subdomain: str, api_key: str | None, relay_host: str, relay_port: in
     envvar="HLE_API_KEY",
     help="API key for authentication",
 )
-@click.option("--relay-host", default="hle.world", show_default=True, help="Relay server host")
-@click.option("--relay-port", default=443, show_default=True, type=int, help="Relay server port")
-def pin_remove(subdomain: str, api_key: str | None, relay_host: str, relay_port: int) -> None:
+def pin_remove(subdomain: str, api_key: str | None) -> None:
     """Remove the PIN for a subdomain."""
     resolved_key = _resolve_api_key(api_key)
 
     async def _run() -> None:
         from hle_client.api import ApiClient, ApiClientConfig
 
-        client = ApiClient(
-            ApiClientConfig(relay_host=relay_host, relay_port=relay_port, api_key=resolved_key)
-        )
+        client = ApiClient(ApiClientConfig(api_key=resolved_key))
         try:
             await client.remove_tunnel_pin(subdomain)
         except Exception as exc:
@@ -456,18 +430,14 @@ def pin_remove(subdomain: str, api_key: str | None, relay_host: str, relay_port:
     envvar="HLE_API_KEY",
     help="API key for authentication",
 )
-@click.option("--relay-host", default="hle.world", show_default=True, help="Relay server host")
-@click.option("--relay-port", default=443, show_default=True, type=int, help="Relay server port")
-def pin_status(subdomain: str, api_key: str | None, relay_host: str, relay_port: int) -> None:
+def pin_status(subdomain: str, api_key: str | None) -> None:
     """Show PIN status for a subdomain."""
     resolved_key = _resolve_api_key(api_key)
 
     async def _run() -> None:
         from hle_client.api import ApiClient, ApiClientConfig
 
-        client = ApiClient(
-            ApiClientConfig(relay_host=relay_host, relay_port=relay_port, api_key=resolved_key)
-        )
+        client = ApiClient(ApiClientConfig(api_key=resolved_key))
         try:
             data = await client.get_tunnel_pin_status(subdomain)
         except Exception as exc:
@@ -512,16 +482,12 @@ def share() -> None:
     envvar="HLE_API_KEY",
     help="API key for authentication",
 )
-@click.option("--relay-host", default="hle.world", show_default=True, help="Relay server host")
-@click.option("--relay-port", default=443, show_default=True, type=int, help="Relay server port")
 def share_create(
     subdomain: str,
     duration: str,
     label: str,
     max_uses: int | None,
     api_key: str | None,
-    relay_host: str,
-    relay_port: int,
 ) -> None:
     """Create a temporary share link for a tunnel."""
     resolved_key = _resolve_api_key(api_key)
@@ -529,9 +495,7 @@ def share_create(
     async def _run() -> None:
         from hle_client.api import ApiClient, ApiClientConfig
 
-        client = ApiClient(
-            ApiClientConfig(relay_host=relay_host, relay_port=relay_port, api_key=resolved_key)
-        )
+        client = ApiClient(ApiClientConfig(api_key=resolved_key))
         try:
             result = await client.create_share_link(subdomain, duration, label, max_uses)
         except Exception as exc:
@@ -562,18 +526,14 @@ def share_create(
     envvar="HLE_API_KEY",
     help="API key for authentication",
 )
-@click.option("--relay-host", default="hle.world", show_default=True, help="Relay server host")
-@click.option("--relay-port", default=443, show_default=True, type=int, help="Relay server port")
-def share_list(subdomain: str, api_key: str | None, relay_host: str, relay_port: int) -> None:
+def share_list(subdomain: str, api_key: str | None) -> None:
     """List share links for a tunnel."""
     resolved_key = _resolve_api_key(api_key)
 
     async def _run() -> None:
         from hle_client.api import ApiClient, ApiClientConfig
 
-        client = ApiClient(
-            ApiClientConfig(relay_host=relay_host, relay_port=relay_port, api_key=resolved_key)
-        )
+        client = ApiClient(ApiClientConfig(api_key=resolved_key))
         try:
             links = await client.list_share_links(subdomain)
         except Exception as exc:
@@ -618,20 +578,14 @@ def share_list(subdomain: str, api_key: str | None, relay_host: str, relay_port:
     envvar="HLE_API_KEY",
     help="API key for authentication",
 )
-@click.option("--relay-host", default="hle.world", show_default=True, help="Relay server host")
-@click.option("--relay-port", default=443, show_default=True, type=int, help="Relay server port")
-def share_revoke(
-    subdomain: str, link_id: int, api_key: str | None, relay_host: str, relay_port: int
-) -> None:
+def share_revoke(subdomain: str, link_id: int, api_key: str | None) -> None:
     """Revoke a share link by ID."""
     resolved_key = _resolve_api_key(api_key)
 
     async def _run() -> None:
         from hle_client.api import ApiClient, ApiClientConfig
 
-        client = ApiClient(
-            ApiClientConfig(relay_host=relay_host, relay_port=relay_port, api_key=resolved_key)
-        )
+        client = ApiClient(ApiClientConfig(api_key=resolved_key))
         try:
             await client.delete_share_link(subdomain, link_id)
         except Exception as exc:

--- a/src/hle_client/proxy.py
+++ b/src/hle_client/proxy.py
@@ -18,6 +18,7 @@ class ProxyConfig:
     websocket_enabled: bool = True
     timeout: float = 30.0
     max_retries: int = 3
+    verify_ssl: bool = False
 
 
 class LocalProxy:
@@ -34,10 +35,13 @@ class LocalProxy:
 
     async def start(self) -> None:
         """Initialize the proxy and HTTP client."""
+        if not self.config.verify_ssl:
+            logger.debug("SSL verification disabled for %s", self.config.target_url)
         self._http_client = httpx.AsyncClient(
             base_url=self.config.target_url,
             timeout=self.config.timeout,
             follow_redirects=False,
+            verify=self.config.verify_ssl,
             limits=httpx.Limits(
                 max_connections=200,
                 max_keepalive_connections=50,
@@ -128,7 +132,21 @@ class LocalProxy:
                 not in {"content-encoding", "content-length", "transfer-encoding", "connection"}
             }
             return response.status_code, resp_headers, response.content
-        except httpx.ConnectError:
+        except httpx.ConnectError as exc:
+            exc_str = str(exc).lower()
+            if "ssl" in exc_str or "certificate" in exc_str or "tls" in exc_str:
+                logger.error(
+                    "SSL certificate error connecting to %s %s — "
+                    "if the service uses a self-signed cert, use --no-verify-ssl",
+                    method,
+                    url,
+                )
+                return (
+                    502,
+                    {"content-type": "text/plain"},
+                    b"Bad Gateway: SSL certificate verification failed "
+                    b"(use --no-verify-ssl for self-signed certificates)",
+                )
             logger.error("Connection refused forwarding %s %s to local service", method, url)
             return (
                 502,

--- a/src/hle_client/tunnel.py
+++ b/src/hle_client/tunnel.py
@@ -118,6 +118,7 @@ class TunnelConfig:
     service_label: str | None = None
     api_key: str | None = None
     websocket_enabled: bool = True
+    verify_ssl: bool = False
     reconnect_delay: float = 1.0
     max_reconnect_delay: float = 60.0
 
@@ -154,6 +155,7 @@ class Tunnel:
             ProxyConfig(
                 target_url=self.config.service_url,
                 websocket_enabled=self.config.websocket_enabled,
+                verify_ssl=self.config.verify_ssl,
             )
         )
 

--- a/tests/unit/test_api_client.py
+++ b/tests/unit/test_api_client.py
@@ -13,25 +13,17 @@ from hle_client.api import ApiClient, ApiClientConfig
 class TestApiClientConfig:
     def test_defaults(self) -> None:
         config = ApiClientConfig()
-        assert config.relay_host == "hle.world"
-        assert config.relay_port == 443
         assert config.api_key == ""
 
-    def test_custom_values(self) -> None:
-        config = ApiClientConfig(relay_host="localhost", relay_port=8000, api_key="hle_abc")
-        assert config.relay_host == "localhost"
-        assert config.relay_port == 8000
+    def test_custom_api_key(self) -> None:
+        config = ApiClientConfig(api_key="hle_abc")
         assert config.api_key == "hle_abc"
 
 
-class TestApiClientScheme:
-    def test_https_for_port_443(self) -> None:
-        client = ApiClient(ApiClientConfig(relay_port=443, api_key="hle_test"))
-        assert client._base_url.startswith("https://")
-
-    def test_http_for_other_ports(self) -> None:
-        client = ApiClient(ApiClientConfig(relay_port=8000, api_key="hle_test"))
-        assert client._base_url.startswith("http://")
+class TestApiClientInit:
+    def test_base_url_is_hle_world(self) -> None:
+        client = ApiClient(ApiClientConfig(api_key="hle_test"))
+        assert client._base_url == "https://hle.world"
 
     def test_authorization_header(self) -> None:
         client = ApiClient(ApiClientConfig(api_key="hle_mykey123"))
@@ -41,15 +33,13 @@ class TestApiClientScheme:
 class TestApiClientMethods:
     @pytest.fixture
     def client(self) -> ApiClient:
-        return ApiClient(
-            ApiClientConfig(relay_host="localhost", relay_port=8000, api_key="hle_testkey")
-        )
+        return ApiClient(ApiClientConfig(api_key="hle_testkey"))
 
     async def test_list_tunnels(self, client: ApiClient) -> None:
         mock_response = httpx.Response(
             200,
             json=[{"subdomain": "app-x7k", "service_url": "http://localhost:8080"}],
-            request=httpx.Request("GET", "http://localhost:8000/api/tunnels"),
+            request=httpx.Request("GET", "https://hle.world/api/tunnels"),
         )
         with patch("httpx.AsyncClient.get", new_callable=AsyncMock, return_value=mock_response):
             result = await client.list_tunnels()
@@ -60,7 +50,7 @@ class TestApiClientMethods:
         mock_response = httpx.Response(
             200,
             json=[{"id": 1, "allowed_email": "a@b.com", "provider": "any"}],
-            request=httpx.Request("GET", "http://localhost:8000/api/tunnels/app-x7k/access"),
+            request=httpx.Request("GET", "https://hle.world/api/tunnels/app-x7k/access"),
         )
         with patch("httpx.AsyncClient.get", new_callable=AsyncMock, return_value=mock_response):
             result = await client.list_access_rules("app-x7k")
@@ -71,7 +61,7 @@ class TestApiClientMethods:
         mock_response = httpx.Response(
             200,
             json={"id": 2, "allowed_email": "new@b.com", "provider": "github"},
-            request=httpx.Request("POST", "http://localhost:8000/api/tunnels/app-x7k/access"),
+            request=httpx.Request("POST", "https://hle.world/api/tunnels/app-x7k/access"),
         )
         with patch("httpx.AsyncClient.post", new_callable=AsyncMock, return_value=mock_response):
             result = await client.add_access_rule("app-x7k", "new@b.com", "github")
@@ -82,7 +72,7 @@ class TestApiClientMethods:
         mock_response = httpx.Response(
             200,
             json={"message": "ok"},
-            request=httpx.Request("DELETE", "http://localhost:8000/api/tunnels/app-x7k/access/1"),
+            request=httpx.Request("DELETE", "https://hle.world/api/tunnels/app-x7k/access/1"),
         )
         with patch("httpx.AsyncClient.delete", new_callable=AsyncMock, return_value=mock_response):
             result = await client.delete_access_rule("app-x7k", 1)
@@ -92,7 +82,7 @@ class TestApiClientMethods:
         mock_response = httpx.Response(
             401,
             text="Not authenticated",
-            request=httpx.Request("GET", "http://localhost:8000/api/tunnels"),
+            request=httpx.Request("GET", "https://hle.world/api/tunnels"),
         )
         with (
             patch("httpx.AsyncClient.get", new_callable=AsyncMock, return_value=mock_response),
@@ -104,7 +94,7 @@ class TestApiClientMethods:
         mock_response = httpx.Response(
             403,
             text="You do not own this subdomain",
-            request=httpx.Request("GET", "http://localhost:8000/api/tunnels/other-abc/access"),
+            request=httpx.Request("GET", "https://hle.world/api/tunnels/other-abc/access"),
         )
         with (
             patch("httpx.AsyncClient.get", new_callable=AsyncMock, return_value=mock_response),
@@ -116,7 +106,7 @@ class TestApiClientMethods:
         mock_response = httpx.Response(
             404,
             text="Access rule not found",
-            request=httpx.Request("DELETE", "http://localhost:8000/api/tunnels/app-x7k/access/999"),
+            request=httpx.Request("DELETE", "https://hle.world/api/tunnels/app-x7k/access/999"),
         )
         with (
             patch("httpx.AsyncClient.delete", new_callable=AsyncMock, return_value=mock_response),

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -276,7 +276,7 @@ class TestErrorHandling:
 
     def test_no_api_key(self) -> None:
         runner = CliRunner()
-        with patch("hle_client.tunnel._load_api_key", return_value=None):
+        with patch("hle_client.cli._load_api_key", return_value=None):
             result = runner.invoke(main, ["tunnels"], env={"HLE_API_KEY": ""})
         assert result.exit_code == 1
         assert "No API key found" in result.output


### PR DESCRIPTION
## Summary

- SSL certificate verification is now **disabled by default** — homelab services (Proxmox, Unraid, TrueNAS, etc.) almost always use self-signed certs. Use `--verify-ssl` to opt in to strict checking.
- Improved error messages: `ConnectError` now distinguishes SSL failures from TCP connection refused, so users see a clear hint about `--verify-ssl` instead of a misleading "connection refused" message.
- Removed `--relay-host` and `--relay-port` from all subcommands (`expose`, `tunnels`, `access`, `pin`, `share`) — HLE is a hosted service; the relay is always `hle.world`.
- `ApiClientConfig` simplified: `relay_host`/`relay_port` fields removed, base URL hardcoded to `https://hle.world`.

## Test plan

- [ ] `pytest tests/ -q` — all 138 tests pass
- [ ] `hle expose --label px --service https://192.168.2.200:8006/` — Proxmox works without SSL error
- [ ] `hle expose --service https://localhost:8443/ --verify-ssl` — self-signed cert fails with clear error message
- [ ] `hle expose --help` — shows `--verify-ssl` flag, no `--relay-host`/`--relay-port`
- [ ] `hle tunnels --help` — no `--relay-host`/`--relay-port`