### PR TITLE
Release v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,17 @@
 # Changelog
 
-## v1.2.0 — 2026-02-24
+## v1.2.0 — 2026-02-26
 
-Add protocol versioning and CI improvements for two-repo architecture with `jspanos/hle` server.
+Accept self-signed SSL certificates by default, simplify CLI by removing internal relay flags, and add protocol versioning.
 
+- **Self-signed SSL support:** SSL certificate verification is now disabled by default — homelab services (Proxmox, Unraid, TrueNAS, etc.) almost always use self-signed certs. Use `--verify-ssl` to opt in to strict checking.
+- **Better error messages:** `ConnectError` now distinguishes SSL failures from TCP connection refused, showing a clear hint instead of a misleading "connection refused" message.
+- **Remove `--relay-host` / `--relay-port`** from all CLI commands — HLE is a hosted service; the relay is always `hle.world`.
 - Add `PROTOCOL_VERSION = "1.0"` to `hle_common/protocol.py` for wire-format version negotiation
 - Add `protocol_version` field to `TunnelRegistration` (optional, backward compatible with older servers)
-- Client sends `protocol_version` during tunnel registration handshake
 - Bump `hle_common` version to `0.2.0`
 - Add `security.yml` workflow (Bandit SAST, pip-audit, TruffleHog secret scanning)
-- Add `notify-server.yml` workflow (triggers server CI via `repository_dispatch` when `hle_common` changes)
-- Add `test_protocol.py` and `test_models.py` test suites for shared protocol/models
-- Switch all CI workflows from `ubuntu-latest` to `arc-runner-hle` self-hosted runners
+- Switch all CI workflows to ARC self-hosted runners with job containers
 
 ## v1.1.2 — 2026-02-21
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hle-client"
-version = "1.1.2"
+version = "1.2.0"
 description = "Home Lab Everywhere — Expose homelab services to the internet with built-in SSO"
 readme = "README.md"
 license = "MIT"

--- a/src/hle_client/__init__.py
+++ b/src/hle_client/__init__.py
@@ -1,3 +1,3 @@
 """HLE Client — Home Lab Everywhere tunnel client."""
 
-__version__ = "1.1.2"
+__version__ = "1.2.0"


### PR DESCRIPTION
## Summary

- Bump version to 1.2.0 in `pyproject.toml` and `__init__.py`
- Update CHANGELOG.md with all changes since v1.1.2

## Test plan

- [ ] CI passes
- [ ] After merge, create GitHub release `v1.2.0`