### PR TITLE
Fix PyPI publish for ARC runner container jobs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,24 +40,36 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install build tools
-        run: pip install build
+      - name: Install build and publish tools
+        run: pip install build twine id
 
       - name: Build sdist and wheel
         run: python -m build
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        run: |
+          # Exchange GitHub OIDC token for short-lived PyPI upload token
+          PYPI_TOKEN=$(python -m id pypi)
+          TWINE_USERNAME=__token__ TWINE_PASSWORD="$PYPI_TOKEN" twine upload dist/*
 
   sync-ha-addon:
     name: Trigger ha-addon release
     needs: publish
-    runs-on: ubuntu-latest
+    runs-on: arc-runner-hle-client
+    container:
+      image: python:3.13-slim
+    env:
+      RELEASE_TAG: ${{ github.event.release.tag_name }}
     steps:
+      - name: Install curl
+        run: apt-get update && apt-get install -y curl
+
       - name: Dispatch to ha-addon
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ secrets.HA_ADDON_DISPATCH_TOKEN }}
-          repository: hle-world/ha-addon
-          event-type: hle-client-release
-          client-payload: '{"version": "${{ github.event.release.tag_name }}"}'
+        env:
+          HA_ADDON_TOKEN: ${{ secrets.HA_ADDON_DISPATCH_TOKEN }}
+        run: |
+          curl -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${HA_ADDON_TOKEN}" \
+            https://api.github.com/repos/hle-world/ha-addon/dispatches \
+            -d "{\"event_type\":\"hle-client-release\",\"client_payload\":{\"version\":\"${RELEASE_TAG}\"}}"


### PR DESCRIPTION
## Summary

- Replace `pypa/gh-action-pypi-publish` (Docker container action) with direct `twine upload` using OIDC token exchange via `python -m id`. Docker container actions can't run inside ARC runner container jobs.
- Replace `peter-evans/repository-dispatch` with `curl` for the ha-addon dispatch step.
- Add `container:` to the `sync-ha-addon` job for ARC runner compatibility.

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, delete the v1.2.0 release, re-create it, and verify PyPI publish succeeds