### PR TITLE
Add auto-release on PR merge; fix PyPI publish auth

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,90 @@
+name: Auto Release
+
+# When a release PR (from scripts/release.sh) is merged, automatically
+# create the GitHub release — which triggers PyPI publish + Homebrew update.
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    # Only run when a release PR is merged (not just closed)
+    if: >
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'chore/release-')
+    runs-on: arc-runner-hle-client
+    container:
+      image: python:3.13-slim
+    env:
+      # Use env var for the PR branch name (safe pattern for untrusted input)
+      PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+
+    steps:
+      - name: Install tools
+        run: apt-get update && apt-get install -y git curl
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract and validate version
+        run: |
+          # Extract version from branch name (chore/release-X.Y.Z)
+          VERSION="${PR_BRANCH#chore/release-}"
+
+          # Strict semver validation — reject anything that isn't digits and dots
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "Error: Invalid version format: $VERSION"
+            exit 1
+          fi
+
+          # Cross-check against pyproject.toml
+          TOML_VERSION=$(grep -m1 '^version' pyproject.toml | sed 's/.*"\(.*\)"/\1/')
+          if [ "$TOML_VERSION" != "$VERSION" ]; then
+            echo "Error: Branch version ($VERSION) != pyproject.toml ($TOML_VERSION)"
+            exit 1
+          fi
+
+          echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
+          echo "Verified version: ${VERSION}"
+
+      - name: Extract changelog and create release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Extract changelog entry for this version
+          NOTES=$(sed -n "/^## v$VERSION/,/^## v/{ /^## v$VERSION/d; /^## v/d; p; }" CHANGELOG.md | sed '/^$/{ N; /^\n$/d; }')
+          if [ -z "$NOTES" ]; then
+            NOTES="Release v$VERSION"
+          fi
+
+          # Create release via API using Python for safe JSON encoding
+          python3 -c "
+          import json, os, urllib.request
+          version = os.environ['VERSION']
+          notes = '''$NOTES''' if '''$NOTES''' else f'Release v{version}'
+          data = json.dumps({
+              'tag_name': f'v{version}',
+              'name': f'v{version}',
+              'body': notes.strip(),
+              'target_commitish': 'main'
+          }).encode()
+          req = urllib.request.Request(
+              f'https://api.github.com/repos/{os.environ[\"REPO\"]}/releases',
+              data=data,
+              headers={
+                  'Accept': 'application/vnd.github+json',
+                  'Authorization': f'Bearer {os.environ[\"GH_TOKEN\"]}',
+                  'Content-Type': 'application/json',
+              },
+          )
+          resp = urllib.request.urlopen(req)
+          result = json.loads(resp.read())
+          print(f'Release created: {result[\"html_url\"]}')
+          "

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,6 @@ on:
     types: [published]
 
 permissions:
-  id-token: write
   contents: read
 
 jobs:
@@ -41,16 +40,16 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install build and publish tools
-        run: pip install build twine id
+        run: pip install build twine
 
       - name: Build sdist and wheel
         run: python -m build
 
       - name: Publish to PyPI
-        run: |
-          # Exchange GitHub OIDC token for short-lived PyPI upload token
-          PYPI_TOKEN=$(python -m id pypi)
-          TWINE_USERNAME=__token__ TWINE_PASSWORD="$PYPI_TOKEN" twine upload dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: twine upload dist/*
 
   sync-ha-addon:
     name: Trigger ha-addon release

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -4,14 +4,15 @@
 # Usage:
 #   ./scripts/release.sh 1.3.0
 #   ./scripts/release.sh 1.3.0 --dry-run
+#   ./scripts/release.sh 1.3.0 --tag   (manual fallback if auto-release didn't trigger)
 #
 # What it does:
 #   1. Validates the version format
 #   2. Updates version in pyproject.toml, __init__.py, README.md, install.sh
 #   3. Adds a CHANGELOG.md entry (you fill in the details)
-#   4. Creates a release branch, commits, pushes, opens a PR
-#   5. After you merge the PR, run: ./scripts/release.sh 1.3.0 --tag
-#      to create the GitHub release (triggers PyPI publish + Homebrew update)
+#   4. Creates a chore/release-X.Y.Z branch, commits, pushes, opens a PR
+#   5. When the PR is merged, auto-release.yml creates the GitHub release
+#      which triggers PyPI publish + Homebrew update automatically
 #
 set -euo pipefail
 
@@ -38,7 +39,7 @@ if [[ -z "$VERSION" ]]; then
   echo "Examples:"
   echo "  $0 1.3.0           # Bump version, commit, push, open PR"
   echo "  $0 1.3.0 --dry-run # Show what would change without modifying files"
-  echo "  $0 1.3.0 --tag     # Create GitHub release (after PR is merged)"
+  echo "  $0 1.3.0 --tag     # Manual fallback: create GitHub release"
   exit 1
 fi
 
@@ -54,7 +55,7 @@ echo "New version:     $VERSION"
 echo ""
 
 # ---------------------------------------------------------------------------
-# --tag mode: create GitHub release from current main
+# --tag mode: manual fallback to create GitHub release
 # ---------------------------------------------------------------------------
 if $TAG_ONLY; then
   echo "Creating GitHub release v$VERSION..."
@@ -174,15 +175,12 @@ echo ""
 echo "Opening PR..."
 gh pr create \
   --title "Release v$VERSION" \
-  --body "Bump version to $VERSION and update all version references.
+  --body "Bump version to \`$VERSION\` and update all version references.
 
-**After merging**, create the release:
-\`\`\`bash
-./scripts/release.sh $VERSION --tag
-\`\`\`"
+When this PR is merged, a GitHub release will be created automatically,
+which triggers PyPI publish and Homebrew formula update."
 
 echo ""
 echo "Next steps:"
 echo "  1. Edit CHANGELOG.md in the PR to fill in release notes"
-echo "  2. Merge the PR"
-echo "  3. Run: ./scripts/release.sh $VERSION --tag"
+echo "  2. Merge the PR — release is created automatically"


### PR DESCRIPTION
## Summary

- **Auto-release workflow** (`auto-release.yml`): When a `chore/release-*` PR is merged to main, automatically creates a GitHub release with notes extracted from CHANGELOG.md. This triggers PyPI publish + Homebrew update — no manual `--tag` step needed.
- **Fix PyPI publish** (`publish.yml`): Switch from OIDC token exchange (`python -m id`) to `PYPI_API_TOKEN` secret. The OIDC approach returns 403 on ARC runners.
- **Update release script**: Document the automated flow, keep `--tag` as manual fallback.

## Required setup

Add a `PYPI_API_TOKEN` secret to the `pypi` environment in GitHub repo settings:
1. Go to https://pypi.org/manage/account/token/ and create a token scoped to `hle-client`
2. Go to GitHub repo Settings > Environments > `pypi` > Add secret: `PYPI_API_TOKEN`

## New release flow

```bash
# 1. Run release script (bumps version, opens PR)
./scripts/release.sh 1.4.0

# 2. Fill in CHANGELOG.md in the PR

# 3. Merge the PR — everything else is automatic:
#    PR merge → auto-release.yml → GitHub release → publish.yml → PyPI + Homebrew
```

## Test plan

- [ ] CI passes
- [ ] After merge + PYPI_API_TOKEN setup, delete v1.3.0 release, recreate it, verify PyPI publish succeeds