### PR TITLE
Fix auto-release to trigger PyPI publish

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -55,7 +55,10 @@ jobs:
 
       - name: Extract changelog and create release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use a PAT instead of GITHUB_TOKEN so the release event
+          # triggers the publish workflow (GITHUB_TOKEN events are
+          # blocked from triggering other workflows).
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           REPO: ${{ github.repository }}
         run: |
           # Extract changelog entry for this version


### PR DESCRIPTION
## Summary

- Switch `auto-release.yml` from `GITHUB_TOKEN` to `RELEASE_TOKEN` (a PAT) when creating GitHub releases
- Releases created with `GITHUB_TOKEN` don't trigger other workflows (GitHub's anti-infinite-loop protection), which is why v1.4.0's auto-release didn't trigger the PyPI publish workflow

## Prerequisites

A Personal Access Token with `contents: write` scope must be added as a repository secret named `RELEASE_TOKEN`.

## Test plan

- [ ] Add `RELEASE_TOKEN` secret to the repo (fine-grained PAT with Contents read/write)
- [ ] After merge, create a test release (v1.5.0) via `scripts/release.sh` to verify the full pipeline: PR merge → auto-release → GitHub release → PyPI publish