### PR TITLE
Fix: forward original Host header to local service (v1.6.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hle-client"
-version = "1.5.0"
+version = "1.6.0"
 description = "Home Lab Everywhere — Expose homelab services to the internet with built-in SSO"
 readme = "README.md"
 license = "MIT"

--- a/src/hle_client/proxy.py
+++ b/src/hle_client/proxy.py
@@ -108,11 +108,18 @@ class LocalProxy:
         # content negotiation and auto-decompression itself; forwarding the
         # browser's accept-encoding would bypass httpx's decompression logic,
         # leaving gzip-compressed bodies in response.content.
+        #
+        # IMPORTANT: we preserve the original "host" header from the browser
+        # (e.g. "ha-ian.hle.world").  Services like Home Assistant validate the
+        # Host header (HA 2023.6+) and reject requests whose Host doesn't match
+        # their configured external_url.  The TCP connection still goes to the
+        # configured target_url, but the HTTP Host header reflects the public
+        # hostname — exactly what a standard reverse proxy does.
         forwarded_headers = {
             k: v
             for k, v in headers.items()
             if k.lower()
-            not in {"host", "transfer-encoding", "connection", "upgrade", "accept-encoding"}
+            not in {"transfer-encoding", "connection", "upgrade", "accept-encoding"}
         }
 
         try:


### PR DESCRIPTION
## Problem

Home Assistant (2023.6+) validates the `Host` header of incoming requests and returns `400 Bad Request` if the host doesn't match its configured `external_url` or known-good internal hosts.

Previously, the local proxy stripped the `Host` header before forwarding to the local service. This caused httpx to set it from the `base_url` (e.g. `homeassistant.local.hass.io:8123`), which HA rejects.

## Fix

- **`proxy.py`**: Remove `host` from the header strip list. The original `Host: ha-ian.hle.world` from the browser now passes through to the local service — matching standard reverse-proxy behaviour (nginx, Traefik, etc. all do this).
- The TCP connection still goes to the configured `target_url` (no SSRF risk); only the HTTP Host header changes.

## Version strategy

hle-client releases at `1.x.0` (1.6.0, 1.7.0...) to leave room for ha-addon patch versions (1.6.0, 1.6.1, 1.6.2...) within each minor.

## Required HA configuration

Users exposing Home Assistant must add to `configuration.yaml`:

```yaml
homeassistant:
  external_url: "https://<subdomain>.hle.world"   # replace with your tunnel URL

http:
  use_x_forwarded_for: true
  trusted_proxies:
    - 172.30.32.0/23   # HA Supervisor addon network
```

Then restart Home Assistant core (Settings → System → Restart).