### PR TITLE
Release v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.6.0 — 2026-02-26
+
+<!-- TODO: Fill in release notes before merging -->
+
 ## v1.5.0 — 2026-02-26
 
 Fix auto-release pipeline so GitHub releases trigger PyPI publish.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ curl -fsSL https://get.hle.world | sh
 Installs via pipx (preferred), uv, or pip-in-venv. Supports `--version`:
 
 ```bash
-curl -fsSL https://get.hle.world | sh -s -- --version 1.5.0
+curl -fsSL https://get.hle.world | sh -s -- --version 1.6.0
 ```
 
 ### Homebrew

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # HLE Client installer
 # Usage: curl -fsSL https://get.hle.world | sh
-#        curl -fsSL https://get.hle.world | sh -s -- --version 1.5.0
+#        curl -fsSL https://get.hle.world | sh -s -- --version 1.6.0
 set -e
 
 PACKAGE="hle-client"

--- a/src/hle_client/__init__.py
+++ b/src/hle_client/__init__.py
@@ -1,3 +1,3 @@
 """HLE Client — Home Lab Everywhere tunnel client."""
 
-__version__ = "1.5.0"
+__version__ = "1.6.0"


### PR DESCRIPTION
Bump version to `1.6.0` and update all version references.

When this PR is merged, a GitHub release will be created automatically,
which triggers PyPI publish and Homebrew formula update.