### PR TITLE
Fix ruff formatting and Host header test for v1.6.0

### DIFF
--- a/src/hle_client/proxy.py
+++ b/src/hle_client/proxy.py
@@ -118,8 +118,7 @@ class LocalProxy:
         forwarded_headers = {
             k: v
             for k, v in headers.items()
-            if k.lower()
-            not in {"transfer-encoding", "connection", "upgrade", "accept-encoding"}
+            if k.lower() not in {"transfer-encoding", "connection", "upgrade", "accept-encoding"}
         }
 
         try:

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -251,7 +251,7 @@ class TestLocalProxyForwardHttp:
         )
 
         forwarded = proxy._http_client.request.call_args.kwargs["headers"]
-        assert "Host" not in forwarded
+        assert forwarded["Host"] == "evil.example.com"
         assert "Transfer-Encoding" not in forwarded
         assert "Connection" not in forwarded
         assert "Upgrade" not in forwarded


### PR DESCRIPTION
## Summary
- Fix `ruff format` failure in `proxy.py` — removing `"host"` from the set made the line short enough to fit on one line
- Update test to assert `Host` header is now forwarded (not stripped), matching the behavior change from PR #13

## Test plan
- [x] `ruff format --check src/ tests/` passes
- [x] `ruff check src/ tests/` passes
- [x] `pytest tests/ -v` — all 138 tests pass