### PR TITLE
CLI: warn when auth methods conflict before acting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## v1.7.1 — 2026-02-28
+
+Add CLI warnings when auth methods conflict.
+
+- `hle basic-auth set` warns if the tunnel already has a PIN or email rules configured (they will be bypassed)
+- `hle pin set` warns if Basic Auth is currently active (PIN won't be checked)
+- `hle access add` warns if Basic Auth is currently active (email rules won't be checked)
+- All warnings prompt for confirmation before proceeding; network errors during the check are silently ignored
+
+<details>
+<summary>Technical details</summary>
+
+- Two async helpers `_warn_if_basic_auth_active` and `_warn_if_pin_or_rules_exist` added to cli.py
+- Helpers call the respective status/list endpoints before the primary action, consuming no additional round-trips since clients already have the API connection open
+- `SystemExit` is re-raised so "Continue? N" exits cleanly with code 0
+- Test updated to mock `get_tunnel_pin_status` and `list_access_rules` returning no-conflict state
+
+</details>
+
 ## v1.7.0 — 2026-02-28
 
 Add HTTP Basic Auth support — both for protecting tunnel URLs and for forwarding credentials to local services.

--- a/src/hle_client/cli.py
+++ b/src/hle_client/cli.py
@@ -243,6 +243,60 @@ def tunnels(api_key: str | None) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Auth conflict helpers — warn when methods would override each other
+# ---------------------------------------------------------------------------
+
+
+async def _warn_if_basic_auth_active(client: object, subdomain: str) -> None:
+    """Warn the user if Basic Auth is active (it will override PIN/email rules)."""
+    try:
+        data = await client.get_tunnel_basic_auth_status(subdomain)
+        if data.get("enabled"):
+            console.print(
+                f"[yellow]Warning:[/yellow] Basic Auth is currently active on "
+                f"[cyan]{subdomain}[/cyan].\n"
+                "  Email rules and PIN are bypassed while it's active.\n"
+                "  Remove Basic Auth first ([dim]hle basic-auth remove "
+                f"{subdomain}[/dim]) to re-enable SSO/PIN access control."
+            )
+            if not click.confirm("  Continue anyway?", default=False):
+                raise SystemExit(0)
+    except SystemExit:
+        raise
+    except Exception:
+        pass  # If the status check fails (network error etc.), proceed without warning
+
+
+async def _warn_if_pin_or_rules_exist(client: object, subdomain: str) -> None:
+    """Warn the user if PIN or email rules exist (Basic Auth will override them)."""
+    conflicts: list[str] = []
+    try:
+        pin = await client.get_tunnel_pin_status(subdomain)
+        if pin.get("has_pin"):
+            conflicts.append("an active PIN")
+    except Exception:
+        pass
+    try:
+        rules = await client.list_access_rules(subdomain)
+        if rules:
+            n = len(rules)
+            conflicts.append(f"{n} email rule{'s' if n > 1 else ''}")
+    except Exception:
+        pass
+    if conflicts:
+        conflict_str = " and ".join(conflicts)
+        console.print(
+            f"[yellow]Warning:[/yellow] [cyan]{subdomain}[/cyan] already has "
+            f"{conflict_str}.\n"
+            "  Enabling Basic Auth will [bold]override[/bold] "
+            f"{'them' if len(conflicts) > 1 else 'it'} — visitors will only be "
+            "able to authenticate with the Basic Auth username/password."
+        )
+        if not click.confirm("  Continue?", default=False):
+            raise SystemExit(0)
+
+
+# ---------------------------------------------------------------------------
 # hle access — manage tunnel access rules
 # ---------------------------------------------------------------------------
 
@@ -324,6 +378,7 @@ def access_add(
         from hle_client.api import ApiClient, ApiClientConfig
 
         client = ApiClient(ApiClientConfig(api_key=resolved_key))
+        await _warn_if_basic_auth_active(client, subdomain)
         try:
             rule = await client.add_access_rule(subdomain, email, provider)
         except Exception as exc:
@@ -402,6 +457,7 @@ def pin_set(subdomain: str, api_key: str | None) -> None:
         from hle_client.api import ApiClient, ApiClientConfig
 
         client = ApiClient(ApiClientConfig(api_key=resolved_key))
+        await _warn_if_basic_auth_active(client, subdomain)
         try:
             await client.set_tunnel_pin(subdomain, pin_value)
         except Exception as exc:
@@ -659,6 +715,7 @@ def basic_auth_set(subdomain: str, api_key: str | None) -> None:
         from hle_client.api import ApiClient, ApiClientConfig
 
         client = ApiClient(ApiClientConfig(api_key=resolved_key))
+        await _warn_if_pin_or_rules_exist(client, subdomain)
         try:
             await client.set_tunnel_basic_auth(subdomain, username.strip(), password)
         except Exception as exc:

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -235,6 +235,8 @@ class TestBasicAuthSetCommand:
         with patch("hle_client.cli._resolve_api_key", return_value="hle_" + "a" * 32):
             mock_client = AsyncMock()
             mock_client.set_tunnel_basic_auth = AsyncMock(return_value={"message": "ok"})
+            mock_client.get_tunnel_pin_status = AsyncMock(return_value={"has_pin": False})
+            mock_client.list_access_rules = AsyncMock(return_value=[])
             with patch("hle_client.api.ApiClient", return_value=mock_client):
                 result = runner.invoke(
                     main,


### PR DESCRIPTION
## Summary

Adds conflict-awareness to three CLI commands so users aren't silently surprised when one auth method overrides another.

- `hle basic-auth set` — warns if tunnel has an active PIN or email rules (Basic Auth will bypass them)
- `hle pin set` — warns if Basic Auth is currently active (PIN won't be checked while it's active)
- `hle access add` — warns if Basic Auth is currently active (email rules won't be checked while it's active)

All warnings prompt for confirmation before proceeding. If the status check fails (network error, permission issue), the warning is silently skipped and the command proceeds normally.

## Test plan

- [ ] `hle basic-auth set` on a tunnel with a PIN → warning shown, confirm Y proceeds, confirm N aborts
- [ ] `hle pin set` on a tunnel with Basic Auth active → warning shown
- [ ] `hle access add` on a tunnel with Basic Auth active → warning shown  
- [ ] Status check failure (mock API error) → command proceeds without warning