### PR TITLE
Fix Host header breaking services behind reverse proxies

### DIFF
--- a/src/hle_client/cli.py
+++ b/src/hle_client/cli.py
@@ -70,6 +70,13 @@ def main(debug: bool) -> None:
     metavar="USER:PASS",
     help="Inject Basic Auth into every request to the local service. Format: USER:PASS",
 )
+@click.option(
+    "--forward-host",
+    is_flag=True,
+    default=False,
+    help="Forward the browser's Host header to the local service "
+    "(for services that validate Host).",
+)
 def expose(
     service: str,
     auth: str,
@@ -78,6 +85,7 @@ def expose(
     websocket: bool,
     verify_ssl: bool,
     upstream_basic_auth: str | None,
+    forward_host: bool,
 ) -> None:
     """Expose a local service to the internet."""
     # Parse --upstream-basic-auth USER:PASS
@@ -97,6 +105,7 @@ def expose(
         websocket_enabled=websocket,
         verify_ssl=verify_ssl,
         upstream_basic_auth=upstream_auth_tuple,
+        forward_host=forward_host,
     )
     tunnel = Tunnel(config=config)
 

--- a/src/hle_client/proxy.py
+++ b/src/hle_client/proxy.py
@@ -27,6 +27,8 @@ class ProxyConfig:
     verify_ssl: bool = False
     upstream_basic_auth: tuple[str, str] | None = field(default=None)
     """Optional (username, password) to inject as Authorization: Basic toward the local service."""
+    forward_host: bool = False
+    """Forward the browser's Host header instead of using the target hostname."""
 
 
 class LocalProxy:
@@ -64,6 +66,25 @@ class LocalProxy:
             await self._http_client.aclose()
             self._http_client = None
         logger.info("Local proxy stopped")
+
+    def _build_forwarded_headers(
+        self,
+        headers: dict[str, str],
+        *,
+        include_host: bool = False,
+    ) -> dict[str, str]:
+        """Build headers to forward, stripping hop-by-hop and optionally Host."""
+        skip = {"transfer-encoding", "connection", "upgrade", "accept-encoding"}
+        if not (self.config.forward_host or include_host):
+            skip.add("host")
+        result = {k: v for k, v in headers.items() if k.lower() not in skip}
+
+        if self.config.upstream_basic_auth is not None:
+            uname, upass = self.config.upstream_basic_auth
+            token = base64.b64encode(f"{uname}:{upass}".encode()).decode()
+            result["authorization"] = f"Basic {token}"
+
+        return result
 
     async def forward_http(
         self,
@@ -112,31 +133,7 @@ class LocalProxy:
         if query_string:
             url = f"{path}?{query_string}"
 
-        # Strip hop-by-hop headers and accept-encoding.  We let httpx handle
-        # content negotiation and auto-decompression itself; forwarding the
-        # browser's accept-encoding would bypass httpx's decompression logic,
-        # leaving gzip-compressed bodies in response.content.
-        #
-        # IMPORTANT: we preserve the original "host" header from the browser
-        # (e.g. "ha-ian.hle.world").  Services like Home Assistant validate the
-        # Host header (HA 2023.6+) and reject requests whose Host doesn't match
-        # their configured external_url.  The TCP connection still goes to the
-        # configured target_url, but the HTTP Host header reflects the public
-        # hostname — exactly what a standard reverse proxy does.
-        forwarded_headers = {
-            k: v
-            for k, v in headers.items()
-            if k.lower() not in {"transfer-encoding", "connection", "upgrade", "accept-encoding"}
-        }
-
-        # Inject Basic Auth toward the upstream local service if configured.
-        # This overrides any Authorization header that came from the browser,
-        # which is intentional: the tunnel may protect the public URL with its
-        # own auth while the local service requires separate credentials.
-        if self.config.upstream_basic_auth is not None:
-            uname, upass = self.config.upstream_basic_auth
-            token = base64.b64encode(f"{uname}:{upass}".encode()).decode()
-            forwarded_headers["authorization"] = f"Basic {token}"
+        forwarded_headers = self._build_forwarded_headers(headers)
 
         try:
             response = await self._http_client.request(
@@ -145,9 +142,41 @@ class LocalProxy:
                 headers=forwarded_headers,
                 content=body,
             )
-            # httpx auto-decompresses gzip/deflate/br, so the body in
-            # response.content is already decompressed.  Strip content-encoding
-            # (and other hop-by-hop) so downstream doesn't try to decompress again.
+
+            # Auto-detect Host header mismatch: if the target returns 502
+            # and we stripped the Host, retry with the original Host forwarded.
+            # Virtual-host reverse proxies (Traefik, nginx) return 502 when
+            # they don't recognize the Host.  Skip retry if --forward-host is
+            # already set or if there's no browser Host to forward.
+            if (
+                response.status_code == 502
+                and not self.config.forward_host
+                and "host" in {k.lower() for k in headers}
+            ):
+                browser_host = next(v for k, v in headers.items() if k.lower() == "host")
+                logger.info(
+                    "Got 502 from target — retrying %s %s with original Host: %s",
+                    method,
+                    url,
+                    browser_host,
+                )
+                retry_headers = self._build_forwarded_headers(headers, include_host=True)
+                retry_resp = await self._http_client.request(
+                    method=method,
+                    url=url,
+                    headers=retry_headers,
+                    content=body,
+                )
+                if retry_resp.status_code != 502:
+                    logger.info(
+                        "Retry with forwarded Host succeeded (status %d). "
+                        "Hint: use --forward-host to skip auto-detection.",
+                        retry_resp.status_code,
+                    )
+                    response = retry_resp
+                else:
+                    logger.debug("Retry with forwarded Host also returned 502")
+
             resp_headers = {
                 k: v
                 for k, v in response.headers.items()
@@ -217,17 +246,7 @@ class LocalProxy:
         if query_string:
             url = f"{path}?{query_string}"
 
-        forwarded_headers = {
-            k: v
-            for k, v in headers.items()
-            if k.lower() not in {"transfer-encoding", "connection", "upgrade", "accept-encoding"}
-        }
-
-        # Inject Basic Auth for streaming path too.
-        if self.config.upstream_basic_auth is not None:
-            uname, upass = self.config.upstream_basic_auth
-            token = base64.b64encode(f"{uname}:{upass}".encode()).decode()
-            forwarded_headers["authorization"] = f"Basic {token}"
+        forwarded_headers = self._build_forwarded_headers(headers)
 
         chunk_size = int(os.environ.get("HLE_HTTP_CHUNK_SIZE", "524288"))
 

--- a/src/hle_client/tunnel.py
+++ b/src/hle_client/tunnel.py
@@ -127,6 +127,8 @@ class TunnelConfig:
     max_reconnect_delay: float = 60.0
     upstream_basic_auth: tuple[str, str] | None = None
     """Optional (username, password) injected as Authorization: Basic toward the local service."""
+    forward_host: bool = False
+    """Forward the browser's Host header instead of using the target hostname."""
 
 
 # Hard limits to protect against a malicious or compromised relay server.
@@ -163,6 +165,7 @@ class Tunnel:
                 websocket_enabled=self.config.websocket_enabled,
                 verify_ssl=self.config.verify_ssl,
                 upstream_basic_auth=self.config.upstream_basic_auth,
+                forward_host=self.config.forward_host,
             )
         )
         self._server_caps: list[str] = []


### PR DESCRIPTION
## Summary

- Strip the browser's Host header by default so httpx sets it from the target URL — fixes 502 errors for services behind Traefik/nginx/Caddy
- Auto-detection: if target returns 502, retry with the original Host forwarded and log the result
- New `--forward-host` flag to explicitly forward the browser's Host header (for services like Home Assistant that validate it)

The v1.6.0 change that forwarded the browser's Host header (for HA compatibility) broke any service behind a virtual-host reverse proxy — a much more common setup.

## Test plan

- [ ] `hle expose --service https://jellyfin.t00t.us --label j` — Traefik-proxied service should work (Host stripped by default)
- [ ] `hle expose --service http://localhost:8123 --forward-host` — HA with external_url should work (Host forwarded)
- [ ] Auto-detection: service behind reverse proxy that initially 502s should auto-retry and succeed
- [ ] Logs show auto-detection messages at INFO level