### PR TITLE
Add relay discovery handshake for future multi-server support

### DIFF
--- a/src/hle_client/api.py
+++ b/src/hle_client/api.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from typing import Any
 
 import httpx
+
+from hle_common.models import RelayDiscoveryResponse
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +29,28 @@ class ApiClient:
         self._base_url = self._BASE_URL
         self._headers = {"Authorization": f"Bearer {config.api_key}"}
 
-    async def list_tunnels(self) -> list[dict]:
+    async def discover_relay(self) -> RelayDiscoveryResponse | None:
+        """Call the discovery endpoint to find the optimal relay server.
+
+        Returns ``None`` when the endpoint is unavailable (404, timeout,
+        network error), allowing the caller to fall back to the default relay.
+        """
+        try:
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                resp = await client.get(
+                    f"{self._base_url}/api/v1/connect",
+                    headers=self._headers,
+                )
+                resp.raise_for_status()
+                return RelayDiscoveryResponse.model_validate(resp.json())
+        except (httpx.HTTPStatusError, httpx.ConnectError, httpx.TimeoutException):
+            logger.debug("Relay discovery unavailable, will use default relay", exc_info=True)
+            return None
+        except Exception:
+            logger.debug("Relay discovery failed unexpectedly", exc_info=True)
+            return None
+
+    async def list_tunnels(self) -> list[dict[str, Any]]:
         """List active tunnels for the authenticated user."""
         async with httpx.AsyncClient() as client:
             resp = await client.get(
@@ -34,9 +58,10 @@ class ApiClient:
                 headers=self._headers,
             )
             resp.raise_for_status()
-            return resp.json()
+            result: list[dict[str, Any]] = resp.json()
+            return result
 
-    async def list_access_rules(self, subdomain: str) -> list[dict]:
+    async def list_access_rules(self, subdomain: str) -> list[dict[str, Any]]:
         """List access rules for a subdomain."""
         async with httpx.AsyncClient() as client:
             resp = await client.get(
@@ -44,9 +69,12 @@ class ApiClient:
                 headers=self._headers,
             )
             resp.raise_for_status()
-            return resp.json()
+            result: list[dict[str, Any]] = resp.json()
+            return result
 
-    async def add_access_rule(self, subdomain: str, email: str, provider: str = "any") -> dict:
+    async def add_access_rule(
+        self, subdomain: str, email: str, provider: str = "any"
+    ) -> dict[str, Any]:
         """Add an email to a subdomain's access allow-list."""
         async with httpx.AsyncClient() as client:
             resp = await client.post(
@@ -55,9 +83,10 @@ class ApiClient:
                 json={"email": email, "provider": provider},
             )
             resp.raise_for_status()
-            return resp.json()
+            result: dict[str, Any] = resp.json()
+            return result
 
-    async def delete_access_rule(self, subdomain: str, rule_id: int) -> dict:
+    async def delete_access_rule(self, subdomain: str, rule_id: int) -> dict[str, Any]:
         """Remove an access rule by ID."""
         async with httpx.AsyncClient() as client:
             resp = await client.delete(
@@ -65,9 +94,10 @@ class ApiClient:
                 headers=self._headers,
             )
             resp.raise_for_status()
-            return resp.json()
+            result: dict[str, Any] = resp.json()
+            return result
 
-    async def get_tunnel_pin_status(self, subdomain: str) -> dict:
+    async def get_tunnel_pin_status(self, subdomain: str) -> dict[str, Any]:
         """Get PIN status for a subdomain."""
         async with httpx.AsyncClient() as client:
             resp = await client.get(
@@ -75,9 +105,10 @@ class ApiClient:
                 headers=self._headers,
             )
             resp.raise_for_status()
-            return resp.json()
+            result: dict[str, Any] = resp.json()
+            return result
 
-    async def set_tunnel_pin(self, subdomain: str, pin: str) -> dict:
+    async def set_tunnel_pin(self, subdomain: str, pin: str) -> dict[str, Any]:
         """Set or update the PIN for a subdomain."""
         async with httpx.AsyncClient() as client:
             resp = await client.put(
@@ -86,9 +117,10 @@ class ApiClient:
                 json={"pin": pin},
             )
             resp.raise_for_status()
-            return resp.json()
+            result: dict[str, Any] = resp.json()
+            return result
 
-    async def remove_tunnel_pin(self, subdomain: str) -> dict:
+    async def remove_tunnel_pin(self, subdomain: str) -> dict[str, Any]:
         """Remove the PIN for a subdomain."""
         async with httpx.AsyncClient() as client:
             resp = await client.delete(
@@ -96,7 +128,8 @@ class ApiClient:
                 headers=self._headers,
             )
             resp.raise_for_status()
-            return resp.json()
+            result: dict[str, Any] = resp.json()
+            return result
 
     async def create_share_link(
         self,
@@ -104,9 +137,9 @@ class ApiClient:
         duration: str = "24h",
         label: str = "",
         max_uses: int | None = None,
-    ) -> dict:
+    ) -> dict[str, Any]:
         """Create a temporary share link for a tunnel."""
-        body: dict = {"duration": duration, "label": label}
+        body: dict[str, Any] = {"duration": duration, "label": label}
         if max_uses is not None:
             body["max_uses"] = max_uses
         async with httpx.AsyncClient() as client:
@@ -116,9 +149,10 @@ class ApiClient:
                 json=body,
             )
             resp.raise_for_status()
-            return resp.json()
+            result: dict[str, Any] = resp.json()
+            return result
 
-    async def list_share_links(self, subdomain: str) -> list[dict]:
+    async def list_share_links(self, subdomain: str) -> list[dict[str, Any]]:
         """List share links for a subdomain."""
         async with httpx.AsyncClient() as client:
             resp = await client.get(
@@ -126,9 +160,10 @@ class ApiClient:
                 headers=self._headers,
             )
             resp.raise_for_status()
-            return resp.json()
+            result: list[dict[str, Any]] = resp.json()
+            return result
 
-    async def delete_share_link(self, subdomain: str, link_id: int) -> dict:
+    async def delete_share_link(self, subdomain: str, link_id: int) -> dict[str, Any]:
         """Revoke a share link."""
         async with httpx.AsyncClient() as client:
             resp = await client.delete(
@@ -136,11 +171,12 @@ class ApiClient:
                 headers=self._headers,
             )
             resp.raise_for_status()
-            return resp.json()
+            result: dict[str, Any] = resp.json()
+            return result
 
     # -- Basic Auth ----------------------------------------------------------
 
-    async def get_tunnel_basic_auth_status(self, subdomain: str) -> dict:
+    async def get_tunnel_basic_auth_status(self, subdomain: str) -> dict[str, Any]:
         """Get Basic Auth status for a subdomain."""
         async with httpx.AsyncClient() as client:
             resp = await client.get(
@@ -148,9 +184,12 @@ class ApiClient:
                 headers=self._headers,
             )
             resp.raise_for_status()
-            return resp.json()
+            result: dict[str, Any] = resp.json()
+            return result
 
-    async def set_tunnel_basic_auth(self, subdomain: str, username: str, password: str) -> dict:
+    async def set_tunnel_basic_auth(
+        self, subdomain: str, username: str, password: str
+    ) -> dict[str, Any]:
         """Set or replace Basic Auth credentials for a subdomain."""
         async with httpx.AsyncClient() as client:
             resp = await client.put(
@@ -159,9 +198,10 @@ class ApiClient:
                 json={"username": username, "password": password},
             )
             resp.raise_for_status()
-            return resp.json()
+            result: dict[str, Any] = resp.json()
+            return result
 
-    async def remove_tunnel_basic_auth(self, subdomain: str) -> dict:
+    async def remove_tunnel_basic_auth(self, subdomain: str) -> dict[str, Any]:
         """Remove Basic Auth for a subdomain."""
         async with httpx.AsyncClient() as client:
             resp = await client.delete(
@@ -169,4 +209,5 @@ class ApiClient:
                 headers=self._headers,
             )
             resp.raise_for_status()
-            return resp.json()
+            result: dict[str, Any] = resp.json()
+            return result

--- a/src/hle_client/cli.py
+++ b/src/hle_client/cli.py
@@ -7,10 +7,14 @@ import logging
 import os
 import re
 import webbrowser
+from typing import TYPE_CHECKING
 
 import click
 from rich.console import Console
 from rich.table import Table
+
+if TYPE_CHECKING:
+    from hle_client.api import ApiClient
 
 from hle_client import __version__
 from hle_client.tunnel import Tunnel, TunnelConfig, _load_api_key, _remove_api_key, _save_api_key
@@ -256,7 +260,7 @@ def tunnels(api_key: str | None) -> None:
 # ---------------------------------------------------------------------------
 
 
-async def _warn_if_basic_auth_active(client: object, subdomain: str) -> None:
+async def _warn_if_basic_auth_active(client: ApiClient, subdomain: str) -> None:
     """Warn the user if Basic Auth is active (it will override PIN/email rules)."""
     try:
         data = await client.get_tunnel_basic_auth_status(subdomain)
@@ -276,7 +280,7 @@ async def _warn_if_basic_auth_active(client: object, subdomain: str) -> None:
         pass  # If the status check fails (network error etc.), proceed without warning
 
 
-async def _warn_if_pin_or_rules_exist(client: object, subdomain: str) -> None:
+async def _warn_if_pin_or_rules_exist(client: ApiClient, subdomain: str) -> None:
     """Warn the user if PIN or email rules exist (Basic Auth will override them)."""
     conflicts: list[str] = []
     try:

--- a/src/hle_client/tunnel.py
+++ b/src/hle_client/tunnel.py
@@ -10,9 +10,14 @@ import os
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
+if TYPE_CHECKING:
+    from collections.abc import Coroutine
+
 import websockets
+import websockets.asyncio.client
 import websockets.exceptions
 
 from hle_client import __version__
@@ -35,6 +40,8 @@ from hle_common.models import (
 from hle_common.protocol import PROTOCOL_VERSION, MessageType, ProtocolMessage
 
 logger = logging.getLogger(__name__)
+
+_ClientConn = websockets.asyncio.client.ClientConnection
 
 # Default config directory for persisting settings.
 _CONFIG_DIR = Path.home() / ".config" / "hle"
@@ -151,12 +158,10 @@ class Tunnel:
     _tunnel_id: str | None = field(default=None, init=False, repr=False)
     _public_url: str | None = field(default=None, init=False, repr=False)
     _proxy: LocalProxy = field(init=False, repr=False)
-    _ws: websockets.WebSocketClientProtocol | None = field(default=None, init=False, repr=False)
-    _ws_streams: dict[str, websockets.WebSocketClientProtocol] = field(
-        default_factory=dict, init=False, repr=False
-    )
+    _ws: _ClientConn | None = field(default=None, init=False, repr=False)
+    _ws_streams: dict[str, _ClientConn] = field(default_factory=dict, init=False, repr=False)
     _ws_streams_lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False, repr=False)
-    _tasks: set[asyncio.Task] = field(default_factory=set, init=False, repr=False)  # type: ignore[type-arg]
+    _tasks: set[asyncio.Task[None]] = field(default_factory=set, init=False, repr=False)
 
     def __post_init__(self) -> None:
         self._proxy = LocalProxy(
@@ -222,18 +227,45 @@ class Tunnel:
     # Connection lifecycle
     # ------------------------------------------------------------------
 
-    async def _connect_once(self) -> None:
-        """Single connection attempt: register, then enter the receive loop."""
-        scheme = "wss" if self.config.relay_port == 443 else "ws"
-        relay_uri = f"{scheme}://{self.config.relay_host}:{self.config.relay_port}/_hle/tunnel"
-        logger.info("Connecting to relay at %s", relay_uri)
+    async def _discover_relay_uri(self, api_key: str) -> str:
+        """Resolve the relay WebSocket URI via the discovery endpoint.
 
-        # Resolve API key: CLI flag > env var > config file
+        Falls back to building the URI from ``self.config`` defaults when
+        the discovery endpoint is unavailable (e.g. the server hasn't
+        implemented it yet).
+        """
+        from hle_client.api import ApiClient, ApiClientConfig
+
+        try:
+            client = ApiClient(ApiClientConfig(api_key=api_key))
+            discovery = await client.discover_relay()
+        except Exception:
+            discovery = None
+
+        if discovery is not None:
+            logger.info(
+                "Relay discovery: url=%s region=%s ttl=%ds",
+                discovery.relay_url,
+                discovery.relay_region,
+                discovery.ttl,
+            )
+            return discovery.relay_url
+
+        # Fallback: build URL from config defaults (current behaviour)
+        scheme = "wss" if self.config.relay_port == 443 else "ws"
+        return f"{scheme}://{self.config.relay_host}:{self.config.relay_port}/_hle/tunnel"
+
+    async def _connect_once(self) -> None:
+        """Single connection attempt: discover relay, register, then enter the receive loop."""
+        # Resolve API key early — needed for both discovery and registration
         api_key = self.config.api_key or _load_api_key()
         if not api_key:
             raise ConnectionError(
                 "No API key found. Run 'hle auth login', set HLE_API_KEY, or pass --api-key."
             )
+
+        relay_uri = await self._discover_relay_uri(api_key)
+        logger.info("Connecting to relay at %s", relay_uri)
 
         async with websockets.connect(relay_uri) as ws:
             self._ws = ws
@@ -274,7 +306,7 @@ class Tunnel:
             # --- Receive loop ---
             await self._receive_loop(ws)
 
-    async def _receive_loop(self, ws: websockets.WebSocketClientProtocol) -> None:
+    async def _receive_loop(self, ws: _ClientConn) -> None:
         """Process incoming messages from the relay server."""
         async for raw in ws:
             try:
@@ -309,7 +341,7 @@ class Tunnel:
 
     async def _handle_http_request(
         self,
-        ws: websockets.WebSocketClientProtocol,
+        ws: _ClientConn,
         msg: ProtocolMessage,
     ) -> None:
         """Forward an HTTP request to the local service and return the response."""
@@ -320,7 +352,7 @@ class Tunnel:
 
     async def _handle_http_request_buffered(
         self,
-        ws: websockets.WebSocketClientProtocol,
+        ws: _ClientConn,
         msg: ProtocolMessage,
     ) -> None:
         """Forward HTTP request using the original single-message response path."""
@@ -361,7 +393,7 @@ class Tunnel:
 
     async def _handle_http_request_chunked(
         self,
-        ws: websockets.WebSocketClientProtocol,
+        ws: _ClientConn,
         msg: ProtocolMessage,
     ) -> None:
         """Forward HTTP request using chunked streaming response."""
@@ -448,7 +480,7 @@ class Tunnel:
 
     async def _handle_ws_open(
         self,
-        ws: websockets.WebSocketClientProtocol,
+        ws: _ClientConn,
         msg: ProtocolMessage,
     ) -> None:
         """Open a WebSocket connection to the local service and bridge frames."""
@@ -555,15 +587,19 @@ class Tunnel:
 
     async def _ws_local_reader(
         self,
-        relay_ws: websockets.WebSocketClientProtocol,
-        local_ws: websockets.WebSocketClientProtocol,
+        relay_ws: _ClientConn,
+        local_ws: _ClientConn,
         stream_id: str,
     ) -> None:
         """Read frames from a local WS and forward them to the relay."""
         try:
             async for frame_data in local_ws:
-                is_binary = isinstance(frame_data, bytes)
-                data_str = base64.b64encode(frame_data).decode("ascii") if is_binary else frame_data
+                if isinstance(frame_data, bytes):
+                    data_str = base64.b64encode(frame_data).decode("ascii")
+                    is_binary = True
+                else:
+                    data_str = frame_data
+                    is_binary = False
 
                 frame_payload = WsStreamFrame(
                     stream_id=stream_id,
@@ -629,7 +665,7 @@ class Tunnel:
 
     async def _handle_speed_test_data(
         self,
-        ws: websockets.WebSocketClientProtocol,
+        ws: _ClientConn,
         msg: ProtocolMessage,
     ) -> None:
         """Handle a speed test data message from the server."""
@@ -646,7 +682,7 @@ class Tunnel:
         if data.direction == "download":
             # Receiving download test chunks — track timing
             if not hasattr(self, "_speed_test_state"):
-                self._speed_test_state: dict = {}
+                self._speed_test_state: dict[str, dict[str, Any]] = {}
 
             if data.test_id not in self._speed_test_state:
                 self._speed_test_state[data.test_id] = {
@@ -709,9 +745,9 @@ class Tunnel:
     # Helpers
     # ------------------------------------------------------------------
 
-    def _spawn(self, coro: object) -> None:
+    def _spawn(self, coro: Coroutine[Any, Any, None]) -> None:
         """Schedule a coroutine as a fire-and-forget task, tracked for cleanup."""
-        task = asyncio.ensure_future(coro)  # type: ignore[arg-type]
+        task = asyncio.ensure_future(coro)
         self._tasks.add(task)
         task.add_done_callback(self._tasks.discard)
 

--- a/src/hle_common/models.py
+++ b/src/hle_common/models.py
@@ -59,6 +59,21 @@ class TunnelRegistrationResponse(BaseModel):
     server_capabilities: list[str] = []  # e.g. ["chunked_response"]
 
 
+class RelayDiscoveryResponse(BaseModel):
+    """Server response from the relay discovery endpoint (GET /api/v1/connect).
+
+    Tells the client which relay server to connect to.  Only ``relay_url`` is
+    required; every other field has a sensible default so the server can start
+    simple and add routing metadata over time.
+    """
+
+    relay_url: str  # e.g. "wss://us-east.hle.world:443/_hle/tunnel"
+    relay_region: str = ""  # informational, e.g. "us-east-1"
+    ttl: int = 300  # seconds the assignment is considered valid
+    fallback_urls: list[str] = []  # backup relay URLs for future failover
+    metadata: dict[str, str] = {}  # reserved for future use
+
+
 # ---------------------------------------------------------------------------
 # HTTP proxying (server <-> client, carried inside ProtocolMessage.payload)
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_discovery.py
+++ b/tests/unit/test_discovery.py
@@ -1,0 +1,127 @@
+"""Unit tests for relay discovery (ApiClient.discover_relay and Tunnel._discover_relay_uri)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from hle_client.api import ApiClient, ApiClientConfig
+from hle_client.tunnel import Tunnel, TunnelConfig
+from hle_common.models import RelayDiscoveryResponse
+
+# ---------------------------------------------------------------------------
+# ApiClient.discover_relay
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverRelay:
+    @pytest.fixture
+    def client(self) -> ApiClient:
+        return ApiClient(ApiClientConfig(api_key="hle_testkey"))
+
+    async def test_success(self, client: ApiClient) -> None:
+        body = {
+            "relay_url": "wss://us-east.hle.world:443/_hle/tunnel",
+            "relay_region": "us-east-1",
+            "ttl": 600,
+            "fallback_urls": ["wss://eu-west.hle.world:443/_hle/tunnel"],
+            "metadata": {"version": "2"},
+        }
+        mock_resp = httpx.Response(
+            200,
+            json=body,
+            request=httpx.Request("GET", "https://hle.world/api/v1/connect"),
+        )
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock, return_value=mock_resp):
+            result = await client.discover_relay()
+
+        assert result is not None
+        assert result.relay_url == "wss://us-east.hle.world:443/_hle/tunnel"
+        assert result.relay_region == "us-east-1"
+        assert result.ttl == 600
+        assert result.fallback_urls == ["wss://eu-west.hle.world:443/_hle/tunnel"]
+        assert result.metadata == {"version": "2"}
+
+    async def test_404_returns_none(self, client: ApiClient) -> None:
+        mock_resp = httpx.Response(
+            404,
+            text="Not Found",
+            request=httpx.Request("GET", "https://hle.world/api/v1/connect"),
+        )
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock, return_value=mock_resp):
+            result = await client.discover_relay()
+
+        assert result is None
+
+    async def test_network_error_returns_none(self, client: ApiClient) -> None:
+        with patch(
+            "httpx.AsyncClient.get",
+            new_callable=AsyncMock,
+            side_effect=httpx.ConnectError("connection refused"),
+        ):
+            result = await client.discover_relay()
+
+        assert result is None
+
+    async def test_timeout_returns_none(self, client: ApiClient) -> None:
+        with patch(
+            "httpx.AsyncClient.get",
+            new_callable=AsyncMock,
+            side_effect=httpx.TimeoutException("timed out"),
+        ):
+            result = await client.discover_relay()
+
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Tunnel._discover_relay_uri
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoverRelayUri:
+    def _make_tunnel(self) -> Tunnel:
+        config = TunnelConfig(
+            service_url="http://localhost:8080",
+            api_key="hle_testkey",
+        )
+        return Tunnel(config=config)
+
+    async def test_uses_discovery_url(self) -> None:
+        tunnel = self._make_tunnel()
+        discovery = RelayDiscoveryResponse(
+            relay_url="wss://us-east.hle.world:443/_hle/tunnel",
+            relay_region="us-east-1",
+        )
+        with patch(
+            "hle_client.api.ApiClient.discover_relay",
+            new_callable=AsyncMock,
+            return_value=discovery,
+        ):
+            uri = await tunnel._discover_relay_uri("hle_testkey")
+
+        assert uri == "wss://us-east.hle.world:443/_hle/tunnel"
+
+    async def test_falls_back_on_none(self) -> None:
+        tunnel = self._make_tunnel()
+        with patch(
+            "hle_client.api.ApiClient.discover_relay",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            uri = await tunnel._discover_relay_uri("hle_testkey")
+
+        assert uri == "wss://hle.world:443/_hle/tunnel"
+
+    async def test_falls_back_on_exception(self) -> None:
+        tunnel = self._make_tunnel()
+        with patch(
+            "hle_client.api.ApiClient.discover_relay",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("unexpected"),
+        ):
+            uri = await tunnel._discover_relay_uri("hle_testkey")
+
+        assert uri == "wss://hle.world:443/_hle/tunnel"

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -7,6 +7,7 @@ import pytest
 from hle_common.models import (
     ProxiedHttpRequest,
     ProxiedHttpResponse,
+    RelayDiscoveryResponse,
     SpeedTestData,
     SpeedTestResult,
     TunnelRegistration,
@@ -90,6 +91,32 @@ class TestTunnelRegistrationResponse:
         assert resp.tunnel_id == "t-resp-1"
         assert resp.subdomain == "resptest.abc"
         assert resp.websocket_enabled is True
+
+
+class TestRelayDiscoveryResponse:
+    def test_defaults(self):
+        resp = RelayDiscoveryResponse(relay_url="wss://us-east.hle.world:443/_hle/tunnel")
+        assert resp.relay_url == "wss://us-east.hle.world:443/_hle/tunnel"
+        assert resp.relay_region == ""
+        assert resp.ttl == 300
+        assert resp.fallback_urls == []
+        assert resp.metadata == {}
+
+    def test_requires_relay_url(self):
+        with pytest.raises(ValueError):
+            RelayDiscoveryResponse()
+
+    def test_roundtrip(self):
+        original = RelayDiscoveryResponse(
+            relay_url="wss://eu-west.hle.world:443/_hle/tunnel",
+            relay_region="eu-west-1",
+            ttl=600,
+            fallback_urls=["wss://us-east.hle.world:443/_hle/tunnel"],
+            metadata={"routing": "geo"},
+        )
+        data = original.model_dump()
+        restored = RelayDiscoveryResponse(**data)
+        assert restored == original
 
 
 class TestProxiedHttpRequest:


### PR DESCRIPTION
## Summary

- Adds a relay discovery step before WebSocket tunnel connection: the client calls `GET /api/v1/connect` to learn which relay server to connect to
- Introduces `RelayDiscoveryResponse` model in `hle_common` (shared with server) with fields: `relay_url`, `relay_region`, `ttl`, `fallback_urls`, `metadata`
- Gracefully falls back to `hle.world` when the endpoint isn't available (404, timeout, network error) — fully backward-compatible
- Fixes all 43 pre-existing mypy errors across `api.py`, `tunnel.py`, and `cli.py`

## Motivation

Prepares the client for future multi-server relay infrastructure without requiring additional client-side changes later. Once the backend implements `GET /api/v1/connect`, it can route clients based on:

- Geolocation (nearest relay)
- Latency measurements
- Per-user/per-API-key forced server assignment
- Load balancing across relay servers
- Graceful maintenance (drain a relay by not assigning new clients)

## Backend requirements

The server needs to implement `GET /api/v1/connect` (Bearer auth) returning:

```json
{
  "relay_url": "wss://us-east.hle.world:443/_hle/tunnel",
  "relay_region": "us-east-1",
  "ttl": 300,
  "fallback_urls": [],
  "metadata": {}
}
```

Only `relay_url` is required. The simplest initial implementation can just return the current `wss://hle.world:443/_hle/tunnel`. The `hle_common` submodule in the server repo needs to be updated to get the new `RelayDiscoveryResponse` model.

## Test plan

- [x] 7 new discovery tests (success, 404, network error, timeout, integration, fallback, exception fallback)
- [x] 3 new model tests for `RelayDiscoveryResponse`
- [x] All 155 tests pass
- [x] mypy: 0 errors (was 43)
- [x] ruff: all checks pass
- [x] ruff format: all files formatted
- [ ] Manual smoke test: `hle expose --service http://localhost:8080` — should fall back gracefully since server doesn't have the endpoint yet