### PR TITLE
Fix homebrew workflow checkout path

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           repository: hle-world/homebrew-tap
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-tap
 
       - name: Update formula
         run: |
@@ -51,8 +52,8 @@ jobs:
           SHA256=$(sha256sum /tmp/hle-sdist/*.tar.gz | cut -d' ' -f1)
           SDIST_URL="https://files.pythonhosted.org/packages/source/h/hle-client/hle_client-${VERSION}.tar.gz"
 
-          mkdir -p Formula
-          cat > Formula/hle-client.rb << FORMULA
+          mkdir -p homebrew-tap/Formula
+          cat > homebrew-tap/Formula/hle-client.rb << FORMULA
           class HleClient < Formula
             include Language::Python::Virtualenv
 
@@ -77,6 +78,7 @@ jobs:
           FORMULA
 
       - name: Commit and push
+        working-directory: homebrew-tap
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Summary

- Fix `fatal: not in a git directory` error in the homebrew workflow's commit/push step
- Add explicit `path: homebrew-tap` to the checkout action so files land in a known directory
- Add `working-directory: homebrew-tap` to the commit/push step
- Update formula generation to write to `homebrew-tap/Formula/` instead of `Formula/`

The workflow was failing because ARC container runners don't preserve the working directory between steps after `actions/checkout`.

## Test plan

- [ ] Merge this PR, then re-run the homebrew workflow for v1.12.0