### PR TITLE
Add hle-docker dispatch to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -72,3 +72,25 @@ jobs:
             -H "Authorization: Bearer ${HA_ADDON_TOKEN}" \
             https://api.github.com/repos/hle-world/ha-addon/dispatches \
             -d "{\"event_type\":\"hle-client-release\",\"client_payload\":{\"version\":\"${RELEASE_TAG}\"}}"
+
+  sync-hle-docker:
+    name: Trigger hle-docker release
+    needs: publish
+    runs-on: arc-runner-hle-client
+    container:
+      image: python:3.13-slim
+    env:
+      RELEASE_TAG: ${{ github.event.release.tag_name }}
+    steps:
+      - name: Install curl
+        run: apt-get update && apt-get install -y curl
+
+      - name: Dispatch to hle-docker
+        env:
+          HLE_DOCKER_TOKEN: ${{ secrets.HLE_DOCKER_DISPATCH_TOKEN }}
+        run: |
+          curl -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${HLE_DOCKER_TOKEN}" \
+            https://api.github.com/repos/hle-world/hle-docker/dispatches \
+            -d "{\"event_type\":\"hle-client-release\",\"client_payload\":{\"version\":\"${RELEASE_TAG}\"}}"


### PR DESCRIPTION
## Summary
- Adds `sync-hle-docker` job to `publish.yml` that dispatches `hle-client-release` event to `hle-world/hle-docker` after PyPI publish
- Runs in parallel with the existing `sync-ha-addon` job

This completes the automated release chain: when hle-client publishes to PyPI, both ha-addon and hle-docker receive a dispatch to open version sync PRs.

## Required Setup
- **Secret `HLE_DOCKER_DISPATCH_TOKEN`**: A PAT with repo scope on `hle-world/hle-docker` to trigger `repository_dispatch`

## Companion PR
- hle-world/hle-docker — adds the receiving `sync-release.yml` and `auto-release.yml` workflows

## Test plan
- [ ] Create `HLE_DOCKER_DISPATCH_TOKEN` secret on this repo
- [ ] Verify workflow YAML is valid
- [ ] Test end-to-end on next hle-client release