### PR TITLE
Migrate to unified HLE_PAT secret

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -58,7 +58,7 @@ jobs:
           # Use a PAT instead of GITHUB_TOKEN so the release event
           # triggers the publish workflow (GITHUB_TOKEN events are
           # blocked from triggering other workflows).
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GH_TOKEN: ${{ secrets.HLE_PAT }}
           REPO: ${{ github.repository }}
         run: |
           # Extract changelog entry for this version

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: hle-world/homebrew-tap
-          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          token: ${{ secrets.HLE_PAT }}
           path: homebrew-tap
 
       - name: Update formula

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Dispatch to ha-addon
         env:
-          HA_ADDON_TOKEN: ${{ secrets.HA_ADDON_DISPATCH_TOKEN }}
+          HA_ADDON_TOKEN: ${{ secrets.HLE_PAT }}
         run: |
           curl -X POST \
             -H "Accept: application/vnd.github+json" \
@@ -87,7 +87,7 @@ jobs:
 
       - name: Dispatch to hle-docker
         env:
-          HLE_DOCKER_TOKEN: ${{ secrets.HLE_DOCKER_DISPATCH_TOKEN }}
+          HLE_DOCKER_TOKEN: ${{ secrets.HLE_PAT }}
         run: |
           curl -X POST \
             -H "Accept: application/vnd.github+json" \


### PR DESCRIPTION
## Summary
- Replace `RELEASE_TOKEN`, `HA_ADDON_DISPATCH_TOKEN`, `HLE_DOCKER_DISPATCH_TOKEN`, and `HOMEBREW_TAP_TOKEN` with `HLE_PAT`
- 4 scattered secrets consolidated into 1 org-level PAT

## Test plan
- [ ] Verify auto-release creates releases
- [ ] Verify ha-addon and hle-docker dispatches fire on publish
- [ ] Verify homebrew formula updates work