### PR TITLE
Add --allow flag to hle expose

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,15 @@ hle expose --service http://localhost:8080              # Basic usage
 hle expose --service http://localhost:8080 --label ha   # Custom subdomain label
 hle expose --service http://localhost:3000 --auth none  # Disable SSO
 hle expose --service http://localhost:8080 --no-websocket  # Disable WS proxying
+hle expose --service http://localhost:8080 --allow user@gmail.com  # Allow a specific user
+hle expose --service http://localhost:8080 --allow google:user@gmail.com --allow github:dev@co.com
 ```
 
 Options:
 - `--service` — Local service URL (required)
 - `--label` — Service label for the subdomain (e.g. `ha` → `ha-x7k.hle.world`)
 - `--auth` — Auth mode: `sso` (default) or `none`
+- `--allow` — Allow an email to access the tunnel (repeatable). Format: `email` or `provider:email`
 - `--websocket/--no-websocket` — Enable/disable WebSocket proxying (default: enabled)
 - `--api-key` — API key (also reads `HLE_API_KEY` env var, then config file)
 

--- a/src/hle_client/cli.py
+++ b/src/hle_client/cli.py
@@ -50,6 +50,18 @@ def main(debug: bool) -> None:
     )
 
 
+_VALID_AUTH_PROVIDERS = {"any", "google", "github", "hle"}
+
+
+def _parse_auth_spec(spec: str) -> tuple[str, str]:
+    """Parse ``[provider:]email`` into ``(provider, email)``."""
+    if ":" in spec:
+        prefix, _, rest = spec.partition(":")
+        if prefix in _VALID_AUTH_PROVIDERS:
+            return prefix, rest
+    return "any", spec
+
+
 @main.command()
 @click.option("--service", required=True, help="Local service URL (e.g. http://localhost:8080)")
 @click.option("--auth", type=click.Choice(["sso", "none"]), default="sso", help="Auth mode")
@@ -81,6 +93,15 @@ def main(debug: bool) -> None:
     help="Forward the browser's Host header to the local service "
     "(for services that validate Host).",
 )
+@click.option(
+    "--allow",
+    "allow",
+    multiple=True,
+    metavar="[PROVIDER:]EMAIL",
+    help="Allow an email to access this tunnel via SSO. "
+    "Format: 'email' or 'provider:email'. "
+    "Providers: any (default), google, github, hle. Repeatable.",
+)
 def expose(
     service: str,
     auth: str,
@@ -90,6 +111,7 @@ def expose(
     verify_ssl: bool,
     upstream_basic_auth: str | None,
     forward_host: bool,
+    allow: tuple[str, ...],
 ) -> None:
     """Expose a local service to the internet."""
     # Parse --upstream-basic-auth USER:PASS
@@ -111,7 +133,38 @@ def expose(
         upstream_basic_auth=upstream_auth_tuple,
         forward_host=forward_host,
     )
-    tunnel = Tunnel(config=config)
+
+    # Build post-registration callback for --allow rules
+    auth_specs = [_parse_auth_spec(s) for s in allow]
+    on_registered_cb = None
+    if auth_specs:
+
+        async def _add_auth_callback(subdomain: str) -> None:
+            import httpx
+
+            from hle_client.api import ApiClient, ApiClientConfig
+
+            resolved_key = api_key or _load_api_key()
+            if not resolved_key:
+                console.print("[yellow]Warning:[/yellow] No API key — skipping auth rules")
+                return
+            client = ApiClient(ApiClientConfig(api_key=resolved_key))
+            for prov, email in auth_specs:
+                try:
+                    await client.add_access_rule(subdomain, email, prov)
+                    console.print(f"     Auth   [green]+[/green] {email} [dim]({prov})[/dim]")
+                except httpx.HTTPStatusError as exc:
+                    if exc.response.status_code == 409:
+                        console.print(f"     Auth   [dim]· {email} ({prov}) already exists[/dim]")
+                    else:
+                        console.print(
+                            f"     Auth   [yellow]! {email} failed: "
+                            f"{exc.response.status_code}[/yellow]"
+                        )
+
+        on_registered_cb = _add_auth_callback
+
+    tunnel = Tunnel(config=config, on_registered=on_registered_cb)
 
     # Warn if the API key was passed as a CLI flag (visible in ps/proc).
     if api_key and not os.environ.get("HLE_API_KEY"):

--- a/src/hle_client/tunnel.py
+++ b/src/hle_client/tunnel.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
 if TYPE_CHECKING:
-    from collections.abc import Coroutine
+    from collections.abc import Awaitable, Callable, Coroutine
 
 import websockets
 import websockets.asyncio.client
@@ -154,7 +154,9 @@ class Tunnel:
     """
 
     config: TunnelConfig
+    on_registered: Callable[[str], Awaitable[None]] | None = field(default=None, repr=False)
     _running: bool = field(default=False, init=False, repr=False)
+    _post_register_done: bool = field(default=False, init=False, repr=False)
     _tunnel_id: str | None = field(default=None, init=False, repr=False)
     _public_url: str | None = field(default=None, init=False, repr=False)
     _proxy: LocalProxy = field(init=False, repr=False)
@@ -302,6 +304,14 @@ class Tunnel:
                 self._tunnel_id,
                 self._public_url,
             )
+
+            # Fire post-registration callback (once) for --add-auth etc.
+            if self.on_registered and not self._post_register_done:
+                self._post_register_done = True
+                parsed_host = urlparse(self._public_url).hostname or ""
+                subdomain = parsed_host.split(".")[0]
+                if subdomain:
+                    await self.on_registered(subdomain)
 
             # --- Receive loop ---
             await self._receive_loop(ws)


### PR DESCRIPTION
## Summary

- Add --allow [PROVIDER:]EMAIL flag to hle expose for setting tunnel access rules inline
- Idempotent — safe to include in scripts/startup commands, skips existing rules
- Adds on_registered callback to Tunnel dataclass (fires once after TUNNEL_ACK)

## Usage

hle expose --service http://localhost:8080 --allow user@gmail.com
hle expose --service http://localhost:8080 --allow google:user@gmail.com --allow github:dev@co.com

## Test plan

- [x] 155 tests pass
- [ ] hle expose --service http://localhost:8080 --allow user@gmail.com adds rule after connect
- [ ] Second run shows already exists instead of error
- [ ] hle expose --service http://localhost:8080 (no --allow) works as before