### PR TITLE
chore: release v1.13.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hle-client"
-version = "1.12.0"
+version = "1.13.0"
 description = "Home Lab Everywhere — Expose homelab services to the internet with built-in SSO"
 readme = "README.md"
 license = "MIT"

--- a/src/hle_client/__init__.py
+++ b/src/hle_client/__init__.py
@@ -1,3 +1,3 @@
 """HLE Client — Home Lab Everywhere tunnel client."""
 
-__version__ = "1.12.0"
+__version__ = "1.13.0"


### PR DESCRIPTION
## Release v1.13.0

### New
- `--allow [PROVIDER:]EMAIL` flag for `hle expose` — set tunnel access rules inline, idempotent

### Docs
- Updated README with `--allow` examples