### PR TITLE
Fix tunnel limit and auth errors showing as retry loop

### DIFF
--- a/src/hle_client/cli.py
+++ b/src/hle_client/cli.py
@@ -17,7 +17,14 @@ if TYPE_CHECKING:
     from hle_client.api import ApiClient
 
 from hle_client import __version__
-from hle_client.tunnel import Tunnel, TunnelConfig, _load_api_key, _remove_api_key, _save_api_key
+from hle_client.tunnel import (
+    Tunnel,
+    TunnelConfig,
+    TunnelFatalError,
+    _load_api_key,
+    _remove_api_key,
+    _save_api_key,
+)
 
 console = Console()
 logger = logging.getLogger(__name__)
@@ -184,6 +191,9 @@ def expose(
         asyncio.run(tunnel.connect())
     except KeyboardInterrupt:
         console.print("\n[yellow]Shutting down ...[/yellow]")
+    except TunnelFatalError as exc:
+        console.print(f"\n[red]Error:[/red] {exc}")
+        raise SystemExit(1)
 
 
 # ---------------------------------------------------------------------------

--- a/src/hle_client/tunnel.py
+++ b/src/hle_client/tunnel.py
@@ -39,6 +39,10 @@ from hle_common.models import (
 )
 from hle_common.protocol import PROTOCOL_VERSION, MessageType, ProtocolMessage
 
+
+class TunnelFatalError(Exception):
+    """Raised for non-retryable server rejections (tunnel limit, auth failure)."""
+
 logger = logging.getLogger(__name__)
 
 _ClientConn = websockets.asyncio.client.ClientConnection
@@ -195,6 +199,22 @@ class Tunnel:
                 websockets.exceptions.WebSocketException,
                 ConnectionError,
             ) as exc:
+                if (
+                    isinstance(exc, websockets.exceptions.ConnectionClosed)
+                    and exc.rcvd is not None
+                ):
+                    code = exc.rcvd.code
+                    if code == 4003:
+                        raise TunnelFatalError(
+                            "Tunnel limit reached. Your plan does not allow more "
+                            "active tunnels.\n"
+                            "Stop another tunnel or upgrade at https://hle.world/dashboard"
+                        ) from exc
+                    if code == 4001:
+                        raise TunnelFatalError(
+                            "Authentication failed. Your API key is invalid or revoked.\n"
+                            "Run 'hle auth login' to save a new key."
+                        ) from exc
                 logger.warning("Connection lost: %s", exc)
             except asyncio.CancelledError:
                 logger.info("Tunnel cancelled")


### PR DESCRIPTION
## Summary
- Added `TunnelFatalError` exception for non-retryable server rejections
- WebSocket close code **4003** (tunnel limit) now shows a clear error and exits immediately instead of retrying forever
- WebSocket close code **4001** (invalid API key) same treatment
- Before: user sees endless `Connection lost...Reconnecting...` loop
- After: user sees `Error: Tunnel limit reached. Your plan does not allow more active tunnels.` and process exits

## Test plan
- [x] All 155 tests pass
- [ ] Manual test: expose when at plan limit → verify clean error message