### PR TITLE
Fix speed test upload using server-provided chunk size

### DIFF
--- a/src/hle_client/tunnel.py
+++ b/src/hle_client/tunnel.py
@@ -721,7 +721,8 @@ class Tunnel:
             # Upload start signal — generate and send chunks
             import os as _os
 
-            chunk_data = base64.b64encode(_os.urandom(65536)).decode("ascii")
+            upload_chunk_size = data.chunk_size_bytes or 65536
+            chunk_data = base64.b64encode(_os.urandom(upload_chunk_size)).decode("ascii")
             for i in range(data.total_chunks):
                 chunk = SpeedTestData(
                     test_id=data.test_id,

--- a/src/hle_common/models.py
+++ b/src/hle_common/models.py
@@ -164,6 +164,7 @@ class SpeedTestData(BaseModel):
     chunk_index: int
     total_chunks: int
     data: str  # base64-encoded random payload
+    chunk_size_bytes: int | None = None  # hint for upload start signal
 
 
 class SpeedTestResult(BaseModel):


### PR DESCRIPTION
## Problem

The speed test upload always used hardcoded 64KB chunks (`os.urandom(65536)`) regardless of the chunk size configured by the admin. This caused a data mismatch — e.g., download would transfer 66.7MB but upload only 8.3MB with the same settings.

## Fix

- Added optional `chunk_size_bytes` field to `SpeedTestData` model in `hle_common/models.py`
- Client now reads `chunk_size_bytes` from the upload start signal and uses it for chunk generation
- Falls back to 64KB for backward compatibility with older servers

## Backward Compatible

The `chunk_size_bytes` field is optional (`None` by default), so older servers that don't send it will still work with the existing 64KB behavior.