### PR TITLE
Release v1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.14.0 — 2026-03-06
+
+<!-- TODO: Fill in release notes before merging -->
+
 ## v1.13.1 — 2026-03-04
 
 Fix tunnel limit/auth error UX and CI reliability.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ curl -fsSL https://get.hle.world | sh
 Installs via pipx (preferred), uv, or pip-in-venv. Supports `--version`:
 
 ```bash
-curl -fsSL https://get.hle.world | sh -s -- --version 1.13.1
+curl -fsSL https://get.hle.world | sh -s -- --version 1.14.0
 ```
 
 ### Homebrew

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # HLE Client installer
 # Usage: curl -fsSL https://get.hle.world | sh
-#        curl -fsSL https://get.hle.world | sh -s -- --version 1.13.1
+#        curl -fsSL https://get.hle.world | sh -s -- --version 1.14.0
 set -e
 
 PACKAGE="hle-client"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hle-client"
-version = "1.13.1"
+version = "1.14.0"
 description = "Home Lab Everywhere — Expose homelab services to the internet with built-in SSO"
 readme = "README.md"
 license = "MIT"

--- a/src/hle_client/__init__.py
+++ b/src/hle_client/__init__.py
@@ -1,3 +1,3 @@
 """HLE Client — Home Lab Everywhere tunnel client."""
 
-__version__ = "1.13.1"
+__version__ = "1.14.0"


### PR DESCRIPTION
Bump version to `1.14.0` and update all version references.

When this PR is merged, a GitHub release will be created automatically,
which triggers PyPI publish and Homebrew formula update.