### PR TITLE
Auto-sanitize labels + HTTP_REQUEST_CANCEL protocol message

### DIFF
--- a/src/hle_client/tunnel.py
+++ b/src/hle_client/tunnel.py
@@ -169,6 +169,9 @@ class Tunnel:
     _ws_streams: dict[str, _ClientConn] = field(default_factory=dict, init=False, repr=False)
     _ws_streams_lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False, repr=False)
     _tasks: set[asyncio.Task[None]] = field(default_factory=set, init=False, repr=False)
+    _active_chunked: dict[str, asyncio.Task[None]] = field(
+        default_factory=dict, init=False, repr=False
+    )
 
     def __post_init__(self) -> None:
         self._proxy = LocalProxy(
@@ -360,6 +363,12 @@ class Tunnel:
                     await ws.send(pong.model_dump_json())
                 case MessageType.SPEED_TEST_DATA:
                     self._spawn(self._handle_speed_test_data(ws, msg))
+                case MessageType.HTTP_REQUEST_CANCEL:
+                    request_id = (msg.payload or {}).get("request_id")
+                    if request_id:
+                        task = self._active_chunked.pop(request_id, None)
+                        if task and not task.done():
+                            task.cancel()
                 case _:
                     logger.debug("Unhandled message type: %s", msg.type)
 
@@ -427,6 +436,11 @@ class Tunnel:
         """Forward HTTP request using chunked streaming response."""
         req = ProxiedHttpRequest.model_validate(msg.payload)
 
+        # Register this task so the server can cancel it via HTTP_REQUEST_CANCEL.
+        current = asyncio.current_task()
+        if current is not None:
+            self._active_chunked[req.request_id] = current
+
         body: bytes | None = None
         if req.body is not None:
             body = base64.b64decode(req.body)
@@ -481,6 +495,20 @@ class Tunnel:
                 payload=end.model_dump(),
             )
             await ws.send(end_msg.model_dump_json())
+        except asyncio.CancelledError:
+            logger.debug("Chunked stream cancelled by server for %s", req.request_id)
+            with contextlib.suppress(Exception):
+                end = HttpResponseEnd(
+                    request_id=req.request_id,
+                    error="cancelled",
+                )
+                end_msg = ProtocolMessage(
+                    type=MessageType.HTTP_RESPONSE_END,
+                    tunnel_id=self._tunnel_id,
+                    request_id=req.request_id,
+                    payload=end.model_dump(),
+                )
+                await ws.send(end_msg.model_dump_json())
         except websockets.exceptions.ConnectionClosed:
             logger.debug(
                 "Connection closed while sending chunked response for %s",
@@ -501,6 +529,8 @@ class Tunnel:
                     payload=end.model_dump(),
                 )
                 await ws.send(end_msg.model_dump_json())
+        finally:
+            self._active_chunked.pop(req.request_id, None)
 
     # ------------------------------------------------------------------
     # WebSocket stream handling

--- a/src/hle_common/models.py
+++ b/src/hle_common/models.py
@@ -37,13 +37,19 @@ class TunnelRegistration(BaseModel):
     @classmethod
     def validate_service_label(cls, v: str | None) -> str | None:
         if v is not None:
+            # Auto-sanitize: lowercase, replace common separators with
+            # hyphens, strip invalid characters, collapse runs.
+            v = v.lower()
+            v = re.sub(r"[_ .]+", "-", v)
+            v = re.sub(r"[^a-z0-9-]", "", v)
+            v = re.sub(r"-{2,}", "-", v)
+            v = v.strip("-")
+            if not v:
+                return None
             if len(v) > 63:
-                raise ValueError("service_label must be at most 63 characters")
+                v = v[:63].rstrip("-")
             if not _SERVICE_LABEL_RE.match(v):
-                raise ValueError(
-                    "service_label must be a valid DNS label "
-                    "(lowercase alphanumeric and hyphens, cannot start/end with hyphen)"
-                )
+                return None
         return v
 
 

--- a/src/hle_common/protocol.py
+++ b/src/hle_common/protocol.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel
 # Protocol version — bump on wire-format changes.
 # Major bump (1.0 → 2.0): breaking change, server must support both during deprecation.
 # Minor bump (1.0 → 1.1): new optional fields/message types, old clients unaffected.
-PROTOCOL_VERSION = "1.1"
+PROTOCOL_VERSION = "1.2"
 
 
 class MessageType(StrEnum):
@@ -34,6 +34,9 @@ class MessageType(StrEnum):
     HTTP_RESPONSE_START = "http_response_start"
     HTTP_RESPONSE_CHUNK = "http_response_chunk"
     HTTP_RESPONSE_END = "http_response_end"
+
+    # Server → client: abort an in-flight chunked request
+    HTTP_REQUEST_CANCEL = "http_request_cancel"
 
     # WebSocket proxying
     WS_OPEN = "ws_open"

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -57,25 +57,47 @@ class TestTunnelRegistration:
         with pytest.raises(ValueError):
             TunnelRegistration(service_url="http://localhost:5000")
 
-    def test_tunnel_registration_service_label_validation(self):
-        with pytest.raises(ValueError, match="service_label"):
-            TunnelRegistration(
-                service_url="http://localhost:5000",
-                api_key="hle_key",
-                service_label="-bad",
-            )
-        with pytest.raises(ValueError, match="service_label"):
-            TunnelRegistration(
-                service_url="http://localhost:5000",
-                api_key="hle_key",
-                service_label="bad-",
-            )
-        with pytest.raises(ValueError, match="service_label"):
-            TunnelRegistration(
-                service_url="http://localhost:5000",
-                api_key="hle_key",
-                service_label="BAD",
-            )
+    def test_tunnel_registration_service_label_sanitization(self):
+        """Labels are auto-sanitized instead of rejected."""
+        # Underscores → hyphens
+        reg = TunnelRegistration(
+            service_url="http://localhost:5000",
+            api_key="hle_key",
+            service_label="ha_office",
+        )
+        assert reg.service_label == "ha-office"
+
+        # Uppercase → lowercase
+        reg = TunnelRegistration(
+            service_url="http://localhost:5000",
+            api_key="hle_key",
+            service_label="BAD",
+        )
+        assert reg.service_label == "bad"
+
+        # Leading/trailing hyphens stripped
+        reg = TunnelRegistration(
+            service_url="http://localhost:5000",
+            api_key="hle_key",
+            service_label="-bad-",
+        )
+        assert reg.service_label == "bad"
+
+        # Spaces → hyphens
+        reg = TunnelRegistration(
+            service_url="http://localhost:5000",
+            api_key="hle_key",
+            service_label="my app",
+        )
+        assert reg.service_label == "my-app"
+
+        # All-invalid chars → None (server auto-generates)
+        reg = TunnelRegistration(
+            service_url="http://localhost:5000",
+            api_key="hle_key",
+            service_label="!!!",
+        )
+        assert reg.service_label is None
 
 
 class TestTunnelRegistrationResponse:

--- a/tests/unit/test_protocol.py
+++ b/tests/unit/test_protocol.py
@@ -18,7 +18,7 @@ from hle_common.protocol import (
 
 class TestProtocolVersion:
     def test_protocol_version_exists(self):
-        assert PROTOCOL_VERSION == "1.1"
+        assert PROTOCOL_VERSION == "1.2"
 
     def test_protocol_version_is_string(self):
         assert isinstance(PROTOCOL_VERSION, str)
@@ -46,6 +46,7 @@ class TestMessageType:
             "http_response_start",
             "http_response_chunk",
             "http_response_end",
+            "http_request_cancel",
             "ws_open",
             "ws_close",
             "ws_frame",


### PR DESCRIPTION
## Summary

Two changes bundled:

### 1. Auto-sanitize service labels
- Labels like `ha_office` (underscore), `My App` (space/uppercase) now auto-sanitize instead of crashing with a Pydantic `ValidationError`
- Reported by HA addon user who set label `ha_office` and got a traceback
- Transforms: lowercase, `_`/spaces → hyphens, strip invalid chars, collapse runs
- All-invalid labels fall back to `None` (server auto-generates)

### 2. HTTP_REQUEST_CANCEL protocol message (v1.2)
- New server→client message type to abort orphaned chunked streams
- When a browser disconnects mid-stream, the server had no way to tell the client to stop — client kept sending chunks that produced warning log spam
- Client now tracks active chunked tasks in `_active_chunked` dict
- On cancel: task is cancelled, error END sent, cleanup in `finally`
- Backward compatible: old clients ignore unknown message types

## Test plan

- [x] 155 tests pass
- [x] Ruff lint + format clean
- [ ] CI (test + security)
- [ ] Label sanitization: `ha_office` → `ha-office`, `BAD` → `bad`, `-bad-` → `bad`, `!!!` → `None`
- [ ] Cancel: mock chunked stream, cancel mid-stream, verify END with error="cancelled"