### PR TITLE
Add custom zone support for enterprise tunnel routing

### DIFF
--- a/src/hle_common/models.py
+++ b/src/hle_common/models.py
@@ -65,6 +65,7 @@ class TunnelRegistrationResponse(BaseModel):
     user_code: str
     service_label: str
     server_capabilities: list[str] = []  # e.g. ["chunked_response"]
+    zone: str | None = None  # custom zone domain if tunnel uses one
 
 
 class RelayDiscoveryResponse(BaseModel):


### PR DESCRIPTION
## Summary

Enterprise feature: allow customers to delegate a subdomain zone (e.g. `project1.t00t.us`) to HLE so their users can create tunnels as `<label>.project1.t00t.us` instead of `<label>-<code>.hle.world`.

- Add optional `zone` field to `TunnelRegistration` and `TunnelRegistrationResponse` in `hle_common` (backward compatible — old clients/servers ignore it)
- Add `zone` to `TunnelConfig` dataclass
- Add `--zone` CLI flag to `hle expose` (also reads `HLE_ZONE` env var)
- Display zone in startup output

## Usage

```bash
hle expose --service http://localhost:8080 --label api --zone project1.t00t.us
# → https://api.project1.t00t.us
```

## Test plan

- [x] All 155 existing tests pass
- [x] Ruff lint clean
- [ ] Server-side support (separate PR on jspanos/hle)
