### PR TITLE
Add managed_by field for operator-managed tunnels

### DIFF
--- a/src/hle_client/tunnel.py
+++ b/src/hle_client/tunnel.py
@@ -141,6 +141,8 @@ class TunnelConfig:
     """Optional (username, password) injected as Authorization: Basic toward the local service."""
     forward_host: bool = False
     """Forward the browser's Host header instead of using the target hostname."""
+    managed_by: str | None = None
+    """Identifies the managing system (e.g. "hle-operator") — disables dashboard edits."""
 
 
 # Hard limits to protect against a malicious or compromised relay server.
@@ -303,6 +305,7 @@ class Tunnel:
                 websocket_enabled=self.config.websocket_enabled,
                 auth_mode=self.config.auth_mode,
                 capabilities=[CAPABILITY_CHUNKED_RESPONSE],
+                managed_by=self.config.managed_by,
             )
             register_msg = ProtocolMessage(
                 type=MessageType.TUNNEL_REGISTER,

--- a/src/hle_common/models.py
+++ b/src/hle_common/models.py
@@ -32,6 +32,7 @@ class TunnelRegistration(BaseModel):
     websocket_enabled: bool = True
     auth_mode: str = "none"  # SSO not in POC scope
     capabilities: list[str] = []  # e.g. ["chunked_response"]
+    managed_by: str | None = None  # e.g. "hle-operator" — locks dashboard edits
 
     @field_validator("service_label")
     @classmethod


### PR DESCRIPTION
## Summary
- Adds `managed_by: str | None` to `TunnelRegistration` (hle_common) and `TunnelConfig`
- Passed through during WebSocket registration handshake
- Enables the hle-operator (K8s operator) to identify itself so the server/dashboard can lock edits for operator-managed tunnels

## Details
- Field is optional, defaults to `None` — no behavioral change for existing clients
- Server-side handling (storing + dashboard read-only state) will be added separately
- The hle-operator sets `managed_by="hle-operator"` for tunnels with `syncPolicy: strict`

## Test plan
- [ ] Existing tests pass (field is optional, backward compatible)
- [ ] Verify `managed_by` appears in the registration JSON payload when set