### PR TITLE
Notify hle-operator on client releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,6 +73,28 @@ jobs:
             https://api.github.com/repos/hle-world/ha-addon/dispatches \
             -d "{\"event_type\":\"hle-client-release\",\"client_payload\":{\"version\":\"${RELEASE_TAG}\"}}"
 
+  notify-operator:
+    name: Notify hle-operator
+    needs: publish
+    runs-on: arc-runner-hle-client
+    container:
+      image: python:3.13-slim
+    env:
+      RELEASE_TAG: ${{ github.event.release.tag_name }}
+    steps:
+      - name: Install curl
+        run: apt-get update && apt-get install -y curl
+
+      - name: Dispatch to hle-operator
+        env:
+          DISPATCH_TOKEN: ${{ secrets.HLE_DOCKER_DISPATCH_TOKEN }}
+        run: |
+          curl -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${DISPATCH_TOKEN}" \
+            https://api.github.com/repos/hle-world/hle-operator/dispatches \
+            -d "{\"event_type\":\"hle-client-release\",\"client_payload\":{\"version\":\"${RELEASE_TAG}\"}}"
+
   sync-hle-docker:
     name: Trigger hle-docker release
     needs: publish


### PR DESCRIPTION
## Summary
- Adds a `notify-operator` job to `publish.yml` that sends a `hle-client-release` dispatch to `hle-world/hle-operator` after PyPI publish
- The operator runs compatibility tests against the new client version to catch breaking changes early
- Reuses `HLE_DOCKER_DISPATCH_TOKEN` (same org, same PAT scope)

## Flow
```
hle-client release merged
  → publish.yml: test → publish to PyPI
    → notify-operator: dispatch to hle-operator
      → compat.yml: install new client + run operator tests
```

## Test plan
- [ ] CI passes on this PR
- [ ] Verify dispatch fires on next release (no way to test without publishing)