### PR TITLE
Security hardening: governance files + bandit strictness

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @jspanos

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -49,7 +49,7 @@ jobs:
               conf = r['issue_confidence']
               print(f\"[{sev}/{conf}] {r['filename']}:{r['line_number']} -- {r['issue_text']}\")
           print(f\"\n{len(results)} issue(s) found.\")
-          if any(r['issue_severity'] == 'HIGH' for r in results):
+          if any(r['issue_severity'] in ('HIGH', 'MEDIUM') for r in results):
               sys.exit(1)
           "
           fi

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,28 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in hle-client, please report it responsibly.
+
+**Email:** security@hle.world
+
+Please include:
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+
+We will acknowledge your report within 48 hours and aim to provide a fix within 7 days for critical issues.
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| Latest  | Yes       |
+| < Latest | No       |
+
+## Security Measures
+
+- Automated dependency auditing via `pip-audit`
+- Static analysis with Bandit
+- Secret scanning with TruffleHog
+- All releases are tested before publishing to PyPI


### PR DESCRIPTION
## Summary
- **Add governance files**: SECURITY.md, CODEOWNERS, dependabot.yml (GitHub Actions + pip)
- **Bandit now fails on MEDIUM severity** — previously only failed on HIGH, silently passing medium issues

## Test plan
- [ ] Verify dependabot creates PRs for outdated actions/deps
- [ ] Verify bandit catches medium severity issues