### PR TITLE
Add webhook signature verification reminder

### DIFF
--- a/src/hle_client/cli.py
+++ b/src/hle_client/cli.py
@@ -398,6 +398,12 @@ def webhook(
     if resolved_zone:
         console.print(f"     Zone    [dim]{resolved_zone}[/dim]")
     console.print()
+    console.print(
+        "[yellow]Tip:[/yellow] Always verify webhook signatures from your provider "
+        "(e.g. GitHub X-Hub-Signature-256, Stripe Stripe-Signature) "
+        "in your application to authenticate requests."
+    )
+    console.print()
 
     try:
         asyncio.run(tunnel.connect())


### PR DESCRIPTION
## Summary

- The `hle webhook` command now prints a tip after startup reminding users to verify webhook signatures from their provider (e.g. GitHub `X-Hub-Signature-256`, Stripe `Stripe-Signature`)
- This is part of a broader webhook security hardening effort — the server-side fixes (randomized subdomain, path enforcement) are in a separate PR on the `hle` repo

## Test plan

- [ ] Run `hle webhook /gh http://localhost:8080` and verify the signature tip is printed
- [ ] Confirm existing webhook functionality is unchanged