### PR TITLE
Add hle-webapp to client release dispatch chain

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -120,3 +120,15 @@ jobs:
             -H "Authorization: Bearer ${HLE_DOCKER_TOKEN}" \
             https://api.github.com/repos/hle-world/hle-docker/dispatches \
             -d @-
+
+      - name: Dispatch to hle-webapp
+        env:
+          HLE_PAT: ${{ secrets.HLE_DOCKER_DISPATCH_TOKEN }}
+        run: |
+          jq -n --arg version "$RELEASE_TAG" \
+            '{"event_type":"hle-client-release","client_payload":{"version":$version}}' | \
+          curl -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${HLE_PAT}" \
+            https://api.github.com/repos/hle-world/hle-webapp/dispatches \
+            -d @-


### PR DESCRIPTION
## Summary

- Adds `repository_dispatch` to `hle-world/hle-webapp` when a new client version is published on PyPI
- Uses the same `HLE_DOCKER_DISPATCH_TOKEN` (PAT has org-wide access)
- hle-webapp is the new pre-built web UI package for bare-metal installs (Proxmox LXC, Raspberry Pi, etc.)

## Test plan

- [ ] Verify dispatch fires on next client release
- [ ] Verify hle-webapp `sync-release.yml` receives the event and opens a PR