### PR TITLE
Fix subdomain extraction for custom domain support

### DIFF
--- a/src/hle_client/tunnel.py
+++ b/src/hle_client/tunnel.py
@@ -443,10 +443,8 @@ class Tunnel:
             # Fire post-registration callback (once) for --add-auth etc.
             if self.on_registered and not self._post_register_done:
                 self._post_register_done = True
-                parsed_host = urlparse(self._public_url).hostname or ""
-                subdomain = parsed_host.split(".")[0]
-                if subdomain:
-                    await self.on_registered(subdomain)
+                if ack_data.subdomain:
+                    await self.on_registered(ack_data.subdomain)
 
             # --- Receive loop ---
             await self._receive_loop(ws)


### PR DESCRIPTION
## Summary
- Use `ack_data.subdomain` from the server's `TunnelRegistrationResponse` instead of parsing the subdomain from the public URL
- The old code (`urlparse(public_url).hostname.split(".")[0]`) assumed `*.hle.world` URL structure and would break for enterprise custom domain tunnels (e.g. `app.acme.com`)

## Test plan
- [ ] Verify `on_registered` callback receives correct subdomain with standard `*.hle.world` URLs
- [ ] Verify correct behavior when `public_url` is a custom domain