### PR TITLE
Add programmatic hook support for tunnel lifecycle events

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Options:
 - `--upstream-basic-auth USER:PASS` — Inject Basic Auth into requests forwarded to the local service
 - `--forward-host` — Forward the browser's Host header to the local service
 - `--api-key` — API key (also reads `HLE_API_KEY` env var, then config file)
+- `--hook NAME=SCRIPT` — Execute SCRIPT when lifecycle event NAME fires (repeatable, one per hook name)
 
 ### `hle auth`
 
@@ -165,6 +166,46 @@ API key resolution order:
 1. `--api-key` CLI flag
 2. `HLE_API_KEY` environment variable
 3. `~/.config/hle/config.toml`
+
+## Hooks
+
+Hooks let you run external scripts at key tunnel lifecycle events. Pass one or
+more `--hook NAME=SCRIPT` flags to `hle expose` or `hle webhook`:
+
+```bash
+hle expose --service http://127.0.0.1:80 --auth none \
+  --hook "tunnel_established=/usr/local/bin/on-tunnel-up.sh" \
+  --hook "tunnel_dismantled=/usr/local/bin/on-tunnel-down.sh"
+```
+
+Each hook name may only be specified once. The script is invoked with
+positional arguments specific to the event:
+
+| Hook name            | Arguments                            | Fired when                        |
+| -------------------- | ------------------------------------ | --------------------------------- |
+| `tunnel_established` | `subdomain` `public_url` `tunnel_id` | Tunnel is registered and ready    |
+| `tunnel_dismantled`  | `subdomain` `public_url` `tunnel_id` | Tunnel is being torn down         |
+
+**Example hook script** (`/usr/local/bin/on-tunnel-up.sh`):
+
+```bash
+#!/bin/sh
+SUBDOMAIN="$1"
+PUBLIC_URL="$2"
+TUNNEL_ID="$3"
+echo "Tunnel $SUBDOMAIN is live at $PUBLIC_URL (id=$TUNNEL_ID)"
+```
+
+## Running as a systemd Service
+
+A sample unit file is provided in [`contrib/hle.service`](contrib/hle.service).
+Copy it into place and adjust `ExecStart` for your setup:
+
+```bash
+sudo cp contrib/hle.service /etc/systemd/system/hle.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now hle
+```
 
 ## Development
 

--- a/contrib/hle.service
+++ b/contrib/hle.service
@@ -1,0 +1,25 @@
+# Sample systemd service for HLE client.
+#
+# 1. Copy to /etc/systemd/system/hle.service
+# 2. Adjust ExecStart, Environment, and User to match your setup.
+# 3. sudo systemctl daemon-reload
+# 4. sudo systemctl enable --now hle
+#
+# Hooks can be added to ExecStart, e.g.:
+#   --hook "tunnel_established=/usr/local/bin/on-tunnel-up.sh"
+
+[Unit]
+Description=HLE Client — expose a local service to the internet
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=hle
+Environment=HLE_API_KEY=hle_your_key_here
+ExecStart=/usr/local/bin/hle expose --service http://127.0.0.1:80 --auth sso
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/src/hle_client/cli.py
+++ b/src/hle_client/cli.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import os
 import re
+import signal
 import webbrowser
 from typing import TYPE_CHECKING
 
@@ -17,6 +18,7 @@ if TYPE_CHECKING:
     from hle_client.api import ApiClient
 
 from hle_client import __version__
+from hle_client.hooks import parse_hooks
 from hle_client.tunnel import (
     Tunnel,
     TunnelConfig,
@@ -119,6 +121,15 @@ def _parse_auth_spec(spec: str) -> tuple[str, str]:
     help="Custom zone domain for enterprise tunnel routing (e.g. project1.t00t.us). "
     "Falls back to ~/.config/hle/config.toml if not set.",
 )
+@click.option(
+    "--hook",
+    "hooks",
+    multiple=True,
+    metavar="NAME=SCRIPT",
+    help="Execute SCRIPT when lifecycle event NAME fires. "
+    "Format: hook_name=/path/to/script. "
+    "Available hooks: tunnel_established, tunnel_dismantled. Repeatable.",
+)
 def expose(
     service: str,
     auth: str,
@@ -130,6 +141,7 @@ def expose(
     forward_host: bool,
     allow: tuple[str, ...],
     zone: str | None,
+    hooks: tuple[str, ...],
 ) -> None:
     """Expose a local service to the internet."""
     # Resolve zone: --zone flag > HLE_ZONE env > config.toml
@@ -144,6 +156,9 @@ def expose(
         u, _, p = upstream_basic_auth.partition(":")
         upstream_auth_tuple = (u, p)
 
+    # Parse hooks
+    parsed_hooks = parse_hooks(hooks)
+
     config = TunnelConfig(
         service_url=service,
         auth_mode=auth,
@@ -154,6 +169,7 @@ def expose(
         upstream_basic_auth=upstream_auth_tuple,
         forward_host=forward_host,
         zone=resolved_zone,
+        hooks=parsed_hooks,
     )
 
     # Build post-registration callback for --allow rules
@@ -204,8 +220,25 @@ def expose(
     console.print(f"     WS      [dim]{'enabled' if websocket else 'disabled'}[/dim]")
     console.print()
 
+    async def _run() -> None:
+        loop = asyncio.get_running_loop()
+        task = asyncio.current_task()
+        assert task is not None
+
+        def _on_sigterm() -> None:
+            asyncio.ensure_future(tunnel.disconnect())
+            task.cancel()
+
+        try:
+            loop.add_signal_handler(signal.SIGTERM, _on_sigterm)
+        except (NotImplementedError, RuntimeError):
+            # Signal handlers are not supported on all platforms
+            # (e.g., Windows) or event loop implementations.
+            logger.debug("SIGTERM handler not supported on this platform, skipping")
+        await tunnel.connect()
+
     try:
-        asyncio.run(tunnel.connect())
+        asyncio.run(_run())
     except KeyboardInterrupt:
         console.print("\n[yellow]Shutting down ...[/yellow]")
     except TunnelFatalError as exc:
@@ -339,12 +372,22 @@ def zone_clear() -> None:
     help="API key. Falls back to ~/.config/hle/config.toml if not set.",
 )
 @click.option("--zone", default=None, help="Custom zone domain for routing.")
+@click.option(
+    "--hook",
+    "hooks",
+    multiple=True,
+    metavar="NAME=SCRIPT",
+    help="Execute SCRIPT when lifecycle event NAME fires. "
+    "Format: hook_name=/path/to/script. "
+    "Available hooks: tunnel_established, tunnel_dismantled. Repeatable.",
+)
 def webhook(
     path: str,
     forward_to: str,
     service_label: str | None,
     api_key: str | None,
     zone: str | None,
+    hooks: tuple[str, ...],
 ) -> None:
     """Forward incoming webhooks to a local service.
 
@@ -371,6 +414,7 @@ def webhook(
         raise SystemExit(1)
 
     resolved_zone = zone or _load_zone()
+    parsed_hooks = parse_hooks(hooks)
 
     config = TunnelConfig(
         service_url=forward_to,
@@ -381,6 +425,7 @@ def webhook(
         verify_ssl=False,
         zone=resolved_zone,
         webhook_path=path,
+        hooks=parsed_hooks,
     )
 
     tunnel = Tunnel(config=config)
@@ -399,8 +444,25 @@ def webhook(
         console.print(f"     Zone    [dim]{resolved_zone}[/dim]")
     console.print()
 
+    async def _run() -> None:
+        loop = asyncio.get_running_loop()
+        task = asyncio.current_task()
+        assert task is not None
+
+        def _on_sigterm() -> None:
+            asyncio.ensure_future(tunnel.disconnect())
+            task.cancel()
+
+        try:
+            loop.add_signal_handler(signal.SIGTERM, _on_sigterm)
+        except (NotImplementedError, RuntimeError):
+            # Signal handlers are not supported on all platforms
+            # (e.g., Windows) or event loop implementations.
+            logger.debug("SIGTERM handler not supported on this platform, skipping")
+        await tunnel.connect()
+
     try:
-        asyncio.run(tunnel.connect())
+        asyncio.run(_run())
     except KeyboardInterrupt:
         console.print("\n[yellow]Shutting down ...[/yellow]")
     except TunnelFatalError as exc:

--- a/src/hle_client/hooks.py
+++ b/src/hle_client/hooks.py
@@ -1,0 +1,124 @@
+"""Programmatic hook support — execute user scripts at tunnel lifecycle events."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import shlex
+from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Hook registry — known hook names and the arguments they provide.
+# ---------------------------------------------------------------------------
+
+HOOK_DEFINITIONS: dict[str, list[str]] = {
+    "tunnel_established": ["subdomain", "public_url", "tunnel_id"],
+    "tunnel_dismantled": ["subdomain", "public_url", "tunnel_id"],
+}
+"""Mapping of hook name → list of positional argument names passed to the script."""
+
+
+# ---------------------------------------------------------------------------
+# Parsing and validation
+# ---------------------------------------------------------------------------
+
+
+def parse_hooks(raw: tuple[str, ...] | list[str]) -> dict[str, str]:
+    """Parse ``--hook`` values of the form ``name=/path/to/script`` into a dict.
+
+    Raises ``SystemExit`` on invalid input:
+
+    * Duplicate hook names are rejected.
+    * Unknown hook names are rejected.
+    """
+    hooks: dict[str, str] = {}
+    for item in raw:
+        if "=" not in item:
+            raise SystemExit(f"Invalid --hook format: {item!r}. Expected hook_name=/path/to/script")
+        name, _, script = item.partition("=")
+        name = name.strip()
+        script = script.strip()
+        if not name or not script:
+            raise SystemExit(
+                f"Invalid --hook format: {item!r}. Both hook name and script path are required."
+            )
+        if name not in HOOK_DEFINITIONS:
+            valid = ", ".join(sorted(HOOK_DEFINITIONS))
+            raise SystemExit(f"Unknown hook name: {name!r}. Valid hooks: {valid}")
+        if name in hooks:
+            raise SystemExit(f"Duplicate hook: {name!r} specified more than once.")
+        hooks[name] = script
+    return hooks
+
+
+# ---------------------------------------------------------------------------
+# Hook manager
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class HookRunner:
+    """Stores parsed hooks and executes them at the appropriate lifecycle points."""
+
+    hooks: dict[str, str] = field(default_factory=dict)
+
+    async def fire(self, hook_name: str, **kwargs: str) -> None:
+        """Execute the script registered for *hook_name*, if any.
+
+        Keyword arguments are passed as positional arguments to the script in
+        the order defined by ``HOOK_DEFINITIONS[hook_name]``.
+        """
+        script = self.hooks.get(hook_name)
+        if not script:
+            return
+
+        arg_names = HOOK_DEFINITIONS.get(hook_name, [])
+        args = []
+        for name in arg_names:
+            if name not in kwargs:
+                logger.warning("Hook %s: missing expected argument %r, passing empty string", hook_name, name)
+            args.append(kwargs.get(name, ""))
+
+        try:
+            cmd = shlex.split(script) + args
+        except ValueError as exc:
+            logger.error("Hook %s: invalid script quoting: %s", hook_name, exc)
+            return
+
+        logger.debug("Firing hook %s: %s", hook_name, cmd)
+
+        try:
+            process = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            try:
+                stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=30.0)
+            except asyncio.TimeoutError:
+                process.kill()
+                await process.wait()
+                logger.warning("Hook %s timed out after 30s and was killed", hook_name)
+                return
+            if process.returncode != 0:
+                logger.warning(
+                    "Hook %s exited with code %d: %s",
+                    hook_name,
+                    process.returncode,
+                    stderr.decode(errors="replace").strip(),
+                )
+                if stdout:
+                    logger.warning("Hook %s stdout: %s", hook_name, stdout.decode(errors="replace").strip())
+            else:
+                if stdout:
+                    logger.debug("Hook %s output: %s", hook_name, stdout.decode(errors="replace").strip())
+                logger.debug("Hook %s completed successfully", hook_name)
+        except FileNotFoundError:
+            logger.error("Hook %s: script not found: %s", hook_name, cmd[0])
+        except PermissionError:
+            logger.error("Hook %s: permission denied: %s", hook_name, cmd[0])
+        except Exception:
+            logger.exception("Hook %s failed unexpectedly", hook_name)

--- a/src/hle_client/tunnel.py
+++ b/src/hle_client/tunnel.py
@@ -22,6 +22,7 @@ import websockets.asyncio.client
 import websockets.exceptions
 
 from hle_client import __version__
+from hle_client.hooks import HookRunner
 from hle_client.proxy import LocalProxy, ProxyConfig
 from hle_common.models import (
     CAPABILITY_CHUNKED_RESPONSE,
@@ -218,6 +219,8 @@ class TunnelConfig:
     """Identifier for the system managing this tunnel (e.g. 'hle-operator')."""
     webhook_path: str | None = None
     """When set, only forward requests matching this path prefix (webhook mode)."""
+    hooks: dict[str, str] = field(default_factory=dict)
+    """Hook name → script path mapping, fired at tunnel lifecycle events."""
 
 
 # Hard limits to protect against a malicious or compromised relay server.
@@ -257,9 +260,11 @@ class Tunnel:
     config: TunnelConfig
     on_registered: Callable[[str], Awaitable[None]] | None = field(default=None, repr=False)
     _running: bool = field(default=False, init=False, repr=False)
+    _connect_running: bool = field(default=False, init=False, repr=False)
     _post_register_done: bool = field(default=False, init=False, repr=False)
     _tunnel_id: str | None = field(default=None, init=False, repr=False)
     _public_url: str | None = field(default=None, init=False, repr=False)
+    _subdomain: str | None = field(default=None, init=False, repr=False)
     _proxy: LocalProxy = field(init=False, repr=False)
     _ws: _ClientConn | None = field(default=None, init=False, repr=False)
     _ws_streams: dict[str, _ClientConn] = field(default_factory=dict, init=False, repr=False)
@@ -280,6 +285,7 @@ class Tunnel:
             )
         )
         self._server_caps: list[str] = []
+        self._hook_runner = HookRunner(hooks=self.config.hooks)
 
     # ------------------------------------------------------------------
     # Public interface
@@ -288,50 +294,77 @@ class Tunnel:
     async def connect(self) -> None:
         """Establish tunnel connection to the relay server with reconnection."""
         self._running = True
+        self._connect_running = True
         delay = self.config.reconnect_delay
+        _final = False
 
-        while self._running:
-            try:
-                await self._proxy.start()
-                await self._connect_once()
-            except (
-                OSError,
-                websockets.exceptions.WebSocketException,
-                ConnectionError,
-            ) as exc:
-                if isinstance(exc, websockets.exceptions.ConnectionClosed) and exc.rcvd is not None:
-                    code = exc.rcvd.code
-                    if code == 4003:
-                        raise TunnelFatalError(
-                            "Tunnel limit reached. Your plan does not allow more "
-                            "active tunnels.\n"
-                            "Stop another tunnel or upgrade at https://hle.world/dashboard"
-                        ) from exc
-                    if code == 4001:
-                        raise TunnelFatalError(
-                            "Authentication failed. Your API key is invalid or revoked.\n"
-                            "Run 'hle auth login' to save a new key."
-                        ) from exc
-                logger.warning("Connection lost: %s", exc)
-            except asyncio.CancelledError:
-                logger.info("Tunnel cancelled")
-                break
-            finally:
-                await self._cleanup()
+        try:
+            while self._running:
+                try:
+                    await self._proxy.start()
+                    await self._connect_once()
+                except (
+                    OSError,
+                    websockets.exceptions.WebSocketException,
+                    ConnectionError,
+                ) as exc:
+                    if isinstance(exc, websockets.exceptions.ConnectionClosed) and exc.rcvd is not None:
+                        code = exc.rcvd.code
+                        if code == 4003:
+                            # Mark as final exit so cleanup/hooks run before raising
+                            _final = True
+                            self._running = False
+                            raise TunnelFatalError(
+                                "Tunnel limit reached. Your plan does not allow more "
+                                "active tunnels.\n"
+                                "Stop another tunnel or upgrade at https://hle.world/dashboard"
+                            ) from exc
+                        if code == 4001:
+                            # Mark as final exit so cleanup/hooks run before raising
+                            _final = True
+                            self._running = False
+                            raise TunnelFatalError(
+                                "Authentication failed. Your API key is invalid or revoked.\n"
+                                "Run 'hle auth login' to save a new key."
+                            ) from exc
+                    logger.warning("Connection lost: %s", exc)
+                except TunnelFatalError as exc:
+                    # Treat TunnelFatalError as a permanent exit so final cleanup and
+                    # tunnel_dismantled hooks run exactly once for established tunnels.
+                    _final = True
+                    self._running = False
+                    logger.error("%s", exc)
+                    raise
+                except asyncio.CancelledError:
+                    _final = True
+                    logger.info("Tunnel cancelled")
+                    break
+                finally:
+                    # Pass final=True when this is a permanent exit:
+                    #   - _final is True  → CancelledError or TunnelFatalError path
+                    #   - _running is False → disconnect() cleared it before closing the socket
+                    await self._cleanup(final=_final or not self._running)
 
-            if not self._running:
-                break
+                if not self._running:
+                    break
 
-            logger.info("Reconnecting in %.1fs ...", delay)
-            await asyncio.sleep(delay)
-            delay = min(delay * 2, self.config.max_reconnect_delay)
+                logger.info("Reconnecting in %.1fs ...", delay)
+                await asyncio.sleep(delay)
+                delay = min(delay * 2, self.config.max_reconnect_delay)
+        finally:
+            self._connect_running = False
 
     async def disconnect(self) -> None:
         """Gracefully disconnect the tunnel."""
         self._running = False
         if self._ws:
             await self._ws.close()
-        await self._cleanup()
+        # If connect() is not running (never started, or already exited), we are
+        # the terminal shutdown path and must drive cleanup ourselves so that
+        # background tasks, proxy, WS streams, and the tunnel_dismantled hook
+        # are all properly torn down.
+        if not self._connect_running:
+            await self._cleanup(final=True)
         logger.info("Tunnel disconnected")
 
     @property
@@ -433,6 +466,7 @@ class Tunnel:
             ack_data = TunnelRegistrationResponse.model_validate(ack_msg.payload)
             self._tunnel_id = ack_data.tunnel_id
             self._public_url = ack_data.public_url
+            self._subdomain = ack_data.subdomain
             self._server_caps = getattr(ack_data, "server_capabilities", []) or []
             logger.info(
                 "Tunnel registered: id=%s  url=%s",
@@ -445,6 +479,14 @@ class Tunnel:
                 self._post_register_done = True
                 if ack_data.subdomain:
                     await self.on_registered(ack_data.subdomain)
+
+            # Fire tunnel_established hook
+            await self._hook_runner.fire(
+                "tunnel_established",
+                subdomain=ack_data.subdomain or "",
+                public_url=self._public_url or "",
+                tunnel_id=self._tunnel_id or "",
+            )
 
             # --- Receive loop ---
             await self._receive_loop(ws)
@@ -948,8 +990,21 @@ class Tunnel:
         self._tasks.add(task)
         task.add_done_callback(self._tasks.discard)
 
-    async def _cleanup(self) -> None:
+    async def _cleanup(self, final: bool = False) -> None:
         """Close all local WS streams, cancel background tasks, and stop the proxy."""
+        # Fire tunnel_dismantled hook before tearing down state.
+        if final and self._tunnel_id:
+            await self._hook_runner.fire(
+                "tunnel_dismantled",
+                subdomain=self._subdomain or "",
+                public_url=self._public_url or "",
+                tunnel_id=self._tunnel_id,
+            )
+            # Clear identity/state to guarantee the hook runs at most once per tunnel lifecycle.
+            self._tunnel_id = None
+            self._public_url = None
+            self._subdomain = None
+
         async with self._ws_streams_lock:
             for _stream_id, local_ws in list(self._ws_streams.items()):
                 with contextlib.suppress(Exception):

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -447,6 +447,46 @@ class TestTunnelRegistrationHandshake:
                 await tunnel._connect_once()
             await tunnel._proxy.stop()
 
+    async def test_successful_ack_fires_tunnel_established_hook(self):
+        tunnel = _tunnel(api_key="hle_testkey_for_hook")
+
+        mock_ws = AsyncMock()
+        mock_ws.send = AsyncMock()
+        ack = ProtocolMessage(
+            type=MessageType.TUNNEL_ACK,
+            payload={
+                "tunnel_id": "t-hook-1",
+                "subdomain": "app-hook",
+                "public_url": "https://app-hook.hle.world",
+                "websocket_enabled": True,
+                "user_code": "abc",
+                "service_label": "myapp",
+            },
+        )
+        mock_ws.recv = AsyncMock(return_value=ack.model_dump_json())
+        mock_ws.__aiter__ = MagicMock(return_value=_AsyncIter([]))
+
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=mock_ws)
+        mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch("hle_client.tunnel.websockets.connect", return_value=mock_ctx),
+            patch("hle_client.tunnel.HookRunner.fire", new_callable=AsyncMock) as mock_fire,
+        ):
+            await tunnel._proxy.start()
+            await tunnel._connect_once()
+            await tunnel._proxy.stop()
+
+        assert mock_fire.await_count == 1
+        called_args, called_kwargs = mock_fire.await_args
+        assert "tunnel_established" in called_args
+        assert called_kwargs == {
+            "subdomain": "app-hook",
+            "public_url": "https://app-hook.hle.world",
+            "tunnel_id": "t-hook-1",
+        }
+
 
 class TestTunnelHandleHttpRequest:
     """Test _handle_http_request: forwards to proxy, sends response back."""
@@ -902,6 +942,81 @@ class TestTunnelProperties:
         tunnel = _tunnel()
         tunnel._public_url = "https://myapp.relay.hle.world"
         assert tunnel.public_url == "https://myapp.relay.hle.world"
+
+
+class TestTunnelDisconnect:
+    """Test disconnect() — graceful shutdown and cleanup ownership."""
+
+    async def test_disconnect_sets_running_false(self):
+        tunnel = _tunnel()
+        tunnel._running = True
+        await tunnel.disconnect()
+        assert tunnel._running is False
+
+    async def test_disconnect_closes_ws_when_present(self):
+        tunnel = _tunnel()
+        mock_ws = AsyncMock()
+        tunnel._ws = mock_ws
+        await tunnel.disconnect()
+        mock_ws.close.assert_awaited_once()
+
+    async def test_disconnect_skips_ws_close_when_none(self):
+        tunnel = _tunnel()
+        tunnel._ws = None
+        # Should not raise.
+        await tunnel.disconnect()
+
+    async def test_disconnect_calls_cleanup_when_connect_not_running(self):
+        """When connect() is not active, disconnect() must drive cleanup itself."""
+        tunnel = _tunnel()
+        tunnel._connect_running = False
+        cleanup_called_with: list = []
+
+        async def _fake_cleanup(final: bool = False) -> None:
+            cleanup_called_with.append(final)
+
+        tunnel._cleanup = _fake_cleanup  # type: ignore[method-assign]
+        await tunnel.disconnect()
+
+        assert cleanup_called_with == [True]
+
+    async def test_disconnect_skips_cleanup_when_connect_is_running(self):
+        """When connect() is active it owns cleanup; disconnect() must not double-clean."""
+        tunnel = _tunnel()
+        tunnel._connect_running = True
+        cleanup_called_with: list = []
+
+        async def _fake_cleanup(final: bool = False) -> None:
+            cleanup_called_with.append(final)
+
+        tunnel._cleanup = _fake_cleanup  # type: ignore[method-assign]
+        await tunnel.disconnect()
+
+        assert cleanup_called_with == []
+
+    async def test_disconnect_without_connect_fires_dismantled_hook(self):
+        """tunnel_dismantled hook must fire when disconnect() owns the cleanup path."""
+        tunnel = _tunnel()
+        tunnel._connect_running = False
+        tunnel._tunnel_id = "t-hook"
+        tunnel._subdomain = "app-abc"
+        tunnel._public_url = "https://app-abc.hle.world"
+
+        fired: list[dict] = []
+
+        async def _fake_fire(event: str, **kwargs) -> None:
+            fired.append({"event": event, **kwargs})
+
+        tunnel._hook_runner.fire = _fake_fire  # type: ignore[method-assign]
+        await tunnel.disconnect()
+
+        assert len(fired) == 1
+        assert fired[0]["event"] == "tunnel_dismantled"
+        assert fired[0]["tunnel_id"] == "t-hook"
+
+    async def test_connect_running_starts_false(self):
+        tunnel = _tunnel()
+        assert tunnel._connect_running is False
 
 
 class TestTunnelReceiveLoopDispatch:

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -1,0 +1,255 @@
+"""Unit tests for hle_client.hooks — programmatic hook support."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import stat
+import tempfile
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from hle_client.hooks import HOOK_DEFINITIONS, HookRunner, parse_hooks
+
+# ---------------------------------------------------------------------------
+# parse_hooks
+# ---------------------------------------------------------------------------
+
+
+class TestParseHooks:
+    def test_empty_input(self) -> None:
+        assert parse_hooks(()) == {}
+
+    def test_single_hook(self) -> None:
+        result = parse_hooks(("tunnel_established=/usr/bin/my-script.sh",))
+        assert result == {"tunnel_established": "/usr/bin/my-script.sh"}
+
+    def test_multiple_hooks(self) -> None:
+        result = parse_hooks(
+            (
+                "tunnel_established=/usr/bin/up.sh",
+                "tunnel_dismantled=/usr/bin/down.sh",
+            )
+        )
+        assert result == {
+            "tunnel_established": "/usr/bin/up.sh",
+            "tunnel_dismantled": "/usr/bin/down.sh",
+        }
+
+    def test_rejects_missing_equals(self) -> None:
+        with pytest.raises(SystemExit, match="Invalid --hook format"):
+            parse_hooks(("tunnel_established",))
+
+    def test_rejects_empty_name(self) -> None:
+        with pytest.raises(SystemExit, match="Both hook name and script path"):
+            parse_hooks(("=/usr/bin/script.sh",))
+
+    def test_rejects_empty_script(self) -> None:
+        with pytest.raises(SystemExit, match="Both hook name and script path"):
+            parse_hooks(("tunnel_established=",))
+
+    def test_rejects_unknown_hook(self) -> None:
+        with pytest.raises(SystemExit, match="Unknown hook name"):
+            parse_hooks(("made_up_event=/usr/bin/script.sh",))
+
+    def test_rejects_duplicate_hook(self) -> None:
+        with pytest.raises(SystemExit, match="Duplicate hook"):
+            parse_hooks(
+                (
+                    "tunnel_established=/a.sh",
+                    "tunnel_established=/b.sh",
+                )
+            )
+
+    def test_script_path_with_equals(self) -> None:
+        """Script path may contain '=' characters (e.g. env vars in path)."""
+        result = parse_hooks(("tunnel_established=/opt/x=1/script.sh",))
+        assert result == {"tunnel_established": "/opt/x=1/script.sh"}
+
+
+# ---------------------------------------------------------------------------
+# HOOK_DEFINITIONS
+# ---------------------------------------------------------------------------
+
+
+class TestHookDefinitions:
+    def test_known_hooks(self) -> None:
+        assert "tunnel_established" in HOOK_DEFINITIONS
+        assert "tunnel_dismantled" in HOOK_DEFINITIONS
+
+    def test_tunnel_established_args(self) -> None:
+        assert HOOK_DEFINITIONS["tunnel_established"] == [
+            "subdomain",
+            "public_url",
+            "tunnel_id",
+        ]
+
+    def test_tunnel_dismantled_args(self) -> None:
+        assert HOOK_DEFINITIONS["tunnel_dismantled"] == [
+            "subdomain",
+            "public_url",
+            "tunnel_id",
+        ]
+
+
+# ---------------------------------------------------------------------------
+# HookRunner.fire
+# ---------------------------------------------------------------------------
+
+
+class TestHookRunnerFire:
+    @pytest.mark.asyncio
+    async def test_no_hooks_configured(self) -> None:
+        """fire() with no hooks should be a no-op."""
+        runner = HookRunner(hooks={})
+        # Should not raise
+        await runner.fire("tunnel_established", subdomain="x", public_url="u", tunnel_id="t")
+
+    @pytest.mark.asyncio
+    async def test_hook_not_configured_for_event(self) -> None:
+        """fire() for an event with no registered script is a no-op."""
+        runner = HookRunner(hooks={"tunnel_dismantled": "/bin/true"})
+        await runner.fire("tunnel_established", subdomain="x", public_url="u", tunnel_id="t")
+
+    @pytest.mark.asyncio
+    async def test_fires_script_with_correct_args(self) -> None:
+        """The hook script receives positional args in the order defined by HOOK_DEFINITIONS."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".sh", delete=False) as f:
+            f.write('#!/bin/sh\necho "$@"\n')
+            script = f.name
+        os.chmod(script, stat.S_IRWXU)
+
+        try:
+            runner = HookRunner(hooks={"tunnel_established": script})
+            # mock create_subprocess_exec to capture arguments
+            with patch("hle_client.hooks.asyncio.create_subprocess_exec") as mock_exec:
+                mock_proc = AsyncMock()
+                mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+                mock_proc.returncode = 0
+                mock_exec.return_value = mock_proc
+
+                await runner.fire(
+                    "tunnel_established",
+                    subdomain="app-x7k",
+                    public_url="https://app-x7k.hle.world",
+                    tunnel_id="tid-123",
+                )
+
+                mock_exec.assert_called_once_with(
+                    script,
+                    "app-x7k",
+                    "https://app-x7k.hle.world",
+                    "tid-123",
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+        finally:
+            os.unlink(script)
+
+    @pytest.mark.asyncio
+    async def test_logs_warning_on_nonzero_exit(self) -> None:
+        runner = HookRunner(hooks={"tunnel_established": "/bin/false"})
+        with patch("hle_client.hooks.asyncio.create_subprocess_exec") as mock_exec:
+            mock_proc = AsyncMock()
+            mock_proc.communicate = AsyncMock(return_value=(b"", b"oops"))
+            mock_proc.returncode = 1
+            mock_exec.return_value = mock_proc
+
+            with patch("hle_client.hooks.logger") as mock_logger:
+                await runner.fire(
+                    "tunnel_established",
+                    subdomain="x",
+                    public_url="u",
+                    tunnel_id="t",
+                )
+                mock_logger.warning.assert_called_once()
+                assert "exited with code" in mock_logger.warning.call_args[0][0]
+
+    @pytest.mark.asyncio
+    async def test_handles_file_not_found(self) -> None:
+        runner = HookRunner(hooks={"tunnel_established": "/nonexistent/script.sh"})
+        with (
+            patch(
+                "hle_client.hooks.asyncio.create_subprocess_exec",
+                side_effect=FileNotFoundError,
+            ),
+            patch("hle_client.hooks.logger") as mock_logger,
+        ):
+            await runner.fire(
+                "tunnel_established",
+                subdomain="x",
+                public_url="u",
+                tunnel_id="t",
+            )
+            mock_logger.error.assert_called_once()
+            assert "not found" in mock_logger.error.call_args[0][0]
+
+    @pytest.mark.asyncio
+    async def test_handles_permission_error(self) -> None:
+        runner = HookRunner(hooks={"tunnel_established": "/etc/shadow"})
+        with (
+            patch(
+                "hle_client.hooks.asyncio.create_subprocess_exec",
+                side_effect=PermissionError,
+            ),
+            patch("hle_client.hooks.logger") as mock_logger,
+        ):
+            await runner.fire(
+                "tunnel_established",
+                subdomain="x",
+                public_url="u",
+                tunnel_id="t",
+            )
+            mock_logger.error.assert_called_once()
+            assert "permission denied" in mock_logger.error.call_args[0][0]
+
+    @pytest.mark.asyncio
+    async def test_missing_kwargs_default_to_empty_string(self) -> None:
+        """Arguments not supplied in kwargs default to empty string."""
+        runner = HookRunner(hooks={"tunnel_established": "/bin/echo"})
+        with patch("hle_client.hooks.asyncio.create_subprocess_exec") as mock_exec:
+            mock_proc = AsyncMock()
+            mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+            mock_proc.returncode = 0
+            mock_exec.return_value = mock_proc
+
+            await runner.fire("tunnel_established")  # No kwargs
+
+            mock_exec.assert_called_once_with(
+                "/bin/echo",
+                "",
+                "",
+                "",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+
+    @pytest.mark.asyncio
+    async def test_script_with_arguments_in_path(self) -> None:
+        """Script path can contain arguments (e.g. '/bin/sh -c ...')."""
+        runner = HookRunner(hooks={"tunnel_established": "/bin/sh -c echo"})
+        with patch("hle_client.hooks.asyncio.create_subprocess_exec") as mock_exec:
+            mock_proc = AsyncMock()
+            mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+            mock_proc.returncode = 0
+            mock_exec.return_value = mock_proc
+
+            await runner.fire(
+                "tunnel_established",
+                subdomain="x",
+                public_url="u",
+                tunnel_id="t",
+            )
+
+            # shlex.split('/bin/sh -c echo') + args
+            mock_exec.assert_called_once_with(
+                "/bin/sh",
+                "-c",
+                "echo",
+                "x",
+                "u",
+                "t",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )

--- a/tests/unit/test_tunnel_fatal.py
+++ b/tests/unit/test_tunnel_fatal.py
@@ -1,0 +1,135 @@
+"""Tests for TunnelFatalError handling in connect()."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import websockets.exceptions
+import websockets.frames
+
+from hle_client.tunnel import Tunnel, TunnelConfig, TunnelFatalError
+
+
+class _AsyncIter:
+    """Turn a plain list into an async iterator suitable for ``async for``."""
+
+    def __init__(self, items: list):
+        self._items = iter(items)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._items)
+        except StopIteration:
+            raise StopAsyncIteration from None
+
+
+def _tunnel(service_url: str = "http://localhost:8123", **kw) -> Tunnel:
+    """Create a Tunnel with sensible test defaults."""
+    return Tunnel(TunnelConfig(service_url=service_url, **kw))
+
+
+class TestTunnelFatalErrorCleanup:
+    """Test that TunnelFatalError (4001/4003) triggers final cleanup and dismantled hook."""
+
+    async def test_4001_sets_final_and_fires_dismantled_hook(self):
+        tunnel = _tunnel(api_key="test-key")
+        tunnel._tunnel_id = "t-4001"
+        tunnel._subdomain = "app-4001"
+        tunnel._public_url = "https://app-4001.hle.world"
+
+        cleanup_calls = []
+        original_cleanup = tunnel._cleanup
+
+        async def tracking_cleanup(final=False):
+            cleanup_calls.append(final)
+            await original_cleanup(final)
+
+        tunnel._cleanup = tracking_cleanup
+
+        hook_fired = []
+
+        async def fake_fire(event, **kwargs):
+            hook_fired.append((event, kwargs))
+
+        tunnel._hook_runner.fire = fake_fire
+
+        async def mock_connect_once():
+            # Simulate a ConnectionClosed with code 4001 that occurs during the receive loop
+            close = websockets.exceptions.ConnectionClosed(
+                websockets.frames.Close(code=4001, reason="auth failed"),
+                None
+            )
+            raise close
+
+        tunnel._proxy.start = AsyncMock()
+
+        with patch.object(tunnel, '_connect_once', mock_connect_once):
+            try:
+                await tunnel.connect()
+            except TunnelFatalError as e:
+                assert "Authentication failed" in str(e)
+            else:
+                pytest.fail("Expected TunnelFatalError to be raised")
+
+        # Verify cleanup was called with final=True at least once
+        assert True in cleanup_calls, f"Expected final=True in cleanup calls, got {cleanup_calls}"
+
+        # Verify tunnel_dismantled hook fired exactly once with correct args
+        assert len(hook_fired) == 1
+        event, kwargs = hook_fired[0]
+        assert event == "tunnel_dismantled"
+        assert kwargs["tunnel_id"] == "t-4001"
+        assert kwargs["subdomain"] == "app-4001"
+        assert kwargs["public_url"] == "https://app-4001.hle.world"
+
+    async def test_4003_sets_final_and_fires_dismantled_hook(self):
+        tunnel = _tunnel(api_key="test-key")
+        tunnel._tunnel_id = "t-4003"
+        tunnel._subdomain = "app-4003"
+        tunnel._public_url = "https://app-4003.hle.world"
+
+        cleanup_calls = []
+        original_cleanup = tunnel._cleanup
+
+        async def tracking_cleanup(final=False):
+            cleanup_calls.append(final)
+            await original_cleanup(final)
+
+        tunnel._cleanup = tracking_cleanup
+
+        hook_fired = []
+
+        async def fake_fire(event, **kwargs):
+            hook_fired.append((event, kwargs))
+
+        tunnel._hook_runner.fire = fake_fire
+
+        async def mock_connect_once():
+            close = websockets.exceptions.ConnectionClosed(
+                websockets.frames.Close(code=4003, reason="limit reached"),
+                None
+            )
+            raise close
+
+        tunnel._proxy.start = AsyncMock()
+
+        with patch.object(tunnel, '_connect_once', mock_connect_once):
+            try:
+                await tunnel.connect()
+            except TunnelFatalError as e:
+                assert "Tunnel limit reached" in str(e)
+            else:
+                pytest.fail("Expected TunnelFatalError to be raised")
+
+        assert True in cleanup_calls
+        assert len(hook_fired) == 1
+        event, kwargs = hook_fired[0]
+        assert event == "tunnel_dismantled"
+        assert kwargs["tunnel_id"] == "t-4003"
+        assert kwargs["subdomain"] == "app-4003"
+        assert kwargs["public_url"] == "https://app-4003.hle.world"


### PR DESCRIPTION
Since the tunnels are ephemeral being able to execute scripts on tunnel initiation or tear-down can help automate tasks.
For example a script can be used to register a CNAME pointing to the tunnel address on its creation. This is especially useful when hle client is called unattended via e.g. systemd


Features:
- New hooks module (src/hle_client/hooks.py) with parse, validate, execute
- --hook NAME=SCRIPT option on expose and webhook commands
- Hooks fire at tunnel_established and tunnel_dismantled events
- Sample systemd service in contrib/hle.service
- Hook reference table in README.md
- 20 new unit tests in tests/unit/test_hooks.py

Example:
```
#: cat ~/hle-client/test-hook.sh
#!/bin/bash
echo "$@" > ./arguments.received.txt

#: hle expose --service http://127.0.0.1:80 --auth none --no-websocket --forward-host --hook tunnel_established=~/hle-client/test-hook.sh
...
20:27:29  INFO      hle_client.hooks  Firing hook tunnel_established: ['/root/hle-client/test-hook.sh', 'REDACTED', 'REDACTED', 'REDACTED']

#: cat arguments.received.txt
REDACTED REDACTED REDACTED

```
