### PR TITLE
chore: release 1.19.0 — rebrand to HomeLab Everywhere

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -125,7 +125,7 @@ jobs:
           class HleClient < Formula
             include Language::Python::Virtualenv
 
-            desc "Home Lab Everywhere — Expose homelab services with built-in SSO"
+            desc "HomeLab Everywhere — Expose homelab services with built-in SSO"
             homepage "https://hle.world"
             url "{hle_sdist['url']}"
             sha256 "{hle_sdist['digests']['sha256']}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.19.0 — 2026-03-16
+
+Branding: rename "Home Lab Everywhere" to "HomeLab Everywhere" across all user-facing text.
+
+- **Branding consistency:** Standardise on "HomeLab Everywhere" (one word) in all CLI output, package metadata, README, and email templates
+
 ## v1.18.0 — 2026-03-12
 
 Enterprise custom domain support preparation.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024-2026 Home Lab Everywhere
+Copyright (c) 2024-2026 HomeLab Everywhere
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 [![CI](https://github.com/hle-world/hle-client/actions/workflows/test.yml/badge.svg?v=2)](https://github.com/hle-world/hle-client/actions/workflows/test.yml)
 
-**Home Lab Everywhere** — Expose homelab services to the internet with built-in SSO authentication and WebSocket support.
+**HomeLab Everywhere** — Expose homelab services to the internet with built-in SSO authentication and WebSocket support.
 
 One command: `hle expose --service http://localhost:8080`
 
@@ -30,7 +30,7 @@ curl -fsSL https://get.hle.world | sh
 Installs via pipx (preferred), uv, or pip-in-venv. Supports `--version`:
 
 ```bash
-curl -fsSL https://get.hle.world | sh -s -- --version 1.18.0
+curl -fsSL https://get.hle.world | sh -s -- --version 1.19.0
 ```
 
 ### Homebrew

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hle-client"
-version = "1.18.0"
-description = "Home Lab Everywhere — Expose homelab services to the internet with built-in SSO"
+version = "1.19.0"
+description = "HomeLab Everywhere — Expose homelab services to the internet with built-in SSO"
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.11"
 authors = [
-    { name = "Home Lab Everywhere" },
+    { name = "HomeLab Everywhere" },
 ]
 keywords = ["homelab", "tunnel", "sso", "reverse-proxy", "webhook"]
 classifiers = [

--- a/src/hle_client/__init__.py
+++ b/src/hle_client/__init__.py
@@ -1,3 +1,3 @@
-"""HLE Client — Home Lab Everywhere tunnel client."""
+"""HLE Client — HomeLab Everywhere tunnel client."""
 
-__version__ = "1.18.0"
+__version__ = "1.19.0"

--- a/src/hle_client/cli.py
+++ b/src/hle_client/cli.py
@@ -1,4 +1,4 @@
-"""HLE CLI — Main entry point for the Home Lab Everywhere client."""
+"""HLE CLI — Main entry point for the HomeLab Everywhere client."""
 
 from __future__ import annotations
 
@@ -51,7 +51,7 @@ def _resolve_api_key(api_key: str | None) -> str:
 @click.version_option(version=__version__, prog_name="hle")
 @click.option("--debug", is_flag=True, default=False, help="Enable debug logging")
 def main(debug: bool) -> None:
-    """Home Lab Everywhere — Expose homelab services to the internet with built-in SSO."""
+    """HomeLab Everywhere — Expose homelab services to the internet with built-in SSO."""
     level = logging.DEBUG if debug else logging.INFO
     logging.basicConfig(
         level=level,


### PR DESCRIPTION
## Summary

- Bump version `1.18.0` → `1.19.0`
- Rebrand all user-facing text from "Home Lab Everywhere" to "HomeLab Everywhere" (branding consistency)

## Files changed
- `pyproject.toml`, `src/hle_client/__init__.py` — version bump
- `README.md` — version reference + rebrand
- `CHANGELOG.md` — new v1.19.0 entry
- `src/hle_client/cli.py`, `__init__.py` — rebrand in docstrings
- `.github/workflows/homebrew.yml` — rebrand in formula desc
- `LICENSE` — rebrand in copyright