### PR TITLE
Make --label required for expose and webhook

### DIFF
--- a/src/hle_client/cli.py
+++ b/src/hle_client/cli.py
@@ -75,7 +75,7 @@ def _parse_auth_spec(spec: str) -> tuple[str, str]:
 @main.command()
 @click.option("--service", required=True, help="Local service URL (e.g. http://localhost:8080)")
 @click.option("--auth", type=click.Choice(["sso", "none"]), default="sso", help="Auth mode")
-@click.option("--label", "service_label", default=None, help="Service label (e.g. ha, jellyfin)")
+@click.option("--label", "service_label", required=True, help="Service label (e.g. ha, jellyfin)")
 @click.option(
     "--api-key",
     default=None,
@@ -331,7 +331,7 @@ def zone_clear() -> None:
 @main.command()
 @click.option("--path", required=True, help="Webhook path (e.g. /webhook/github)")
 @click.option("--forward-to", required=True, help="Local URL to forward webhooks to")
-@click.option("--label", "service_label", default=None, help="Custom tunnel label (default: auto)")
+@click.option("--label", "service_label", required=True, help="Webhook label (e.g. github-hook)")
 @click.option(
     "--api-key",
     envvar="HLE_API_KEY",
@@ -342,7 +342,7 @@ def zone_clear() -> None:
 def webhook(
     path: str,
     forward_to: str,
-    service_label: str | None,
+    service_label: str,
     api_key: str | None,
     zone: str | None,
 ) -> None:
@@ -375,7 +375,7 @@ def webhook(
     config = TunnelConfig(
         service_url=forward_to,
         auth_mode="none",  # no SSO gate for webhooks
-        service_label=service_label or f"wh-{path.strip('/').replace('/', '-')[:20]}",
+        service_label=service_label,
         api_key=api_key,
         websocket_enabled=False,
         verify_ssl=False,

--- a/src/hle_client/tunnel.py
+++ b/src/hle_client/tunnel.py
@@ -202,7 +202,7 @@ class TunnelConfig:
     relay_host: str = "hle.world"
     relay_port: int = 443
     auth_mode: str = "sso"
-    service_label: str | None = None
+    service_label: str = ""  # required — set by CLI
     api_key: str | None = None
     websocket_enabled: bool = True
     verify_ssl: bool = False

--- a/src/hle_common/models.py
+++ b/src/hle_common/models.py
@@ -25,7 +25,7 @@ class TunnelRegistration(BaseModel):
     """Payload the client sends when requesting a new tunnel."""
 
     service_url: str
-    service_label: str | None = None  # user-chosen name, e.g. "ha", "jellyfin"
+    service_label: str  # required — user-chosen name, e.g. "ha", "jellyfin"
     api_key: str  # required — hle_<32 hex chars>
     client_version: str | None = None
     protocol_version: str | None = None  # sent by clients >= 0.5.0
@@ -56,21 +56,20 @@ class TunnelRegistration(BaseModel):
 
     @field_validator("service_label")
     @classmethod
-    def validate_service_label(cls, v: str | None) -> str | None:
-        if v is not None:
-            # Auto-sanitize: lowercase, replace common separators with
-            # hyphens, strip invalid characters, collapse runs.
-            v = v.lower()
-            v = re.sub(r"[_ .]+", "-", v)
-            v = re.sub(r"[^a-z0-9-]", "", v)
-            v = re.sub(r"-{2,}", "-", v)
-            v = v.strip("-")
-            if not v:
-                return None
-            if len(v) > 63:
-                v = v[:63].rstrip("-")
-            if not _SERVICE_LABEL_RE.match(v):
-                return None
+    def validate_service_label(cls, v: str) -> str:
+        # Auto-sanitize: lowercase, replace common separators with
+        # hyphens, strip invalid characters, collapse runs.
+        v = v.lower()
+        v = re.sub(r"[_ .]+", "-", v)
+        v = re.sub(r"[^a-z0-9-]", "", v)
+        v = re.sub(r"-{2,}", "-", v)
+        v = v.strip("-")
+        if not v:
+            raise ValueError("service_label is required and must contain valid characters")
+        if len(v) > 63:
+            v = v[:63].rstrip("-")
+        if not _SERVICE_LABEL_RE.match(v):
+            raise ValueError(f"service_label '{v}' does not match required format")
         return v
 
 

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -508,6 +508,8 @@ class TestExposeNoAutoSave:
                     "expose",
                     "--service",
                     "http://localhost:8080",
+                    "--label",
+                    "test",
                     "--api-key",
                     "hle_" + "f" * 32,
                 ],

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -318,7 +318,7 @@ class TestTunnelConfig:
         assert cfg.relay_host == "hle.world"
         assert cfg.relay_port == 443
         assert cfg.auth_mode == "sso"
-        assert cfg.service_label is None
+        assert cfg.service_label == ""
         assert cfg.api_key is None
         assert cfg.websocket_enabled is True
         assert cfg.reconnect_delay == 1.0
@@ -426,7 +426,7 @@ class TestTunnelRegistrationHandshake:
         assert tunnel._public_url == "https://myapp-abc.hle.world"
 
     async def test_wrong_ack_type_raises(self):
-        tunnel = _tunnel(api_key="hle_testkey_for_bad_ack")
+        tunnel = _tunnel(api_key="hle_testkey_for_bad_ack", service_label="test")
 
         mock_ws = AsyncMock()
         mock_ws.send = AsyncMock()

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+from pydantic import ValidationError
 
 from hle_common.models import (
     ProxiedHttpRequest,
@@ -23,9 +24,10 @@ class TestTunnelRegistration:
         reg = TunnelRegistration(
             service_url="http://localhost:5000",
             api_key="hle_abc123",
+            service_label="test",
         )
         assert reg.service_url == "http://localhost:5000"
-        assert reg.service_label is None
+        assert reg.service_label == "test"
         assert reg.api_key == "hle_abc123"
         assert reg.client_version is None
         assert reg.protocol_version is None
@@ -37,6 +39,7 @@ class TestTunnelRegistration:
         reg = TunnelRegistration(
             service_url="http://localhost:5000",
             api_key="hle_abc123",
+            service_label="test",
             managed_by="hle-operator",
         )
         assert reg.managed_by == "hle-operator"
@@ -45,6 +48,7 @@ class TestTunnelRegistration:
         reg = TunnelRegistration(
             service_url="http://localhost:5000",
             api_key="hle_abc123",
+            service_label="test",
             protocol_version="1.0",
         )
         assert reg.protocol_version == "1.0"
@@ -100,13 +104,13 @@ class TestTunnelRegistration:
         )
         assert reg.service_label == "my-app"
 
-        # All-invalid chars → None (server auto-generates)
-        reg = TunnelRegistration(
-            service_url="http://localhost:5000",
-            api_key="hle_key",
-            service_label="!!!",
-        )
-        assert reg.service_label is None
+        # All-invalid chars → raises ValueError (label is required)
+        with pytest.raises(ValidationError):
+            TunnelRegistration(
+                service_url="http://localhost:5000",
+                api_key="hle_key",
+                service_label="!!!",
+            )
 
 
 class TestTunnelRegistrationResponse:


### PR DESCRIPTION
## Summary

Makes `--label` a required argument for both `hle expose` and `hle webhook` commands. Labels are now the stable identity for tunnels — the server uses them to persist subdomain mappings across reconnections.

- `--label` changed from optional to `required=True` on both `expose` and `webhook` CLI commands
- Removed auto-generation fallbacks (no more `secrets.token_hex(4)` or `wh-<path>` defaults)
- `service_label` made required on `TunnelRegistration` in `hle_common/models.py` — validator raises `ValueError` if empty
- `TunnelConfig.service_label` type narrowed from `str | None` to `str`

## Changes

- `src/hle_client/cli.py`: `--label` is `required=True` on both commands
- `src/hle_client/tunnel.py`: `service_label: str = ""` (required, set by CLI)
- `src/hle_common/models.py`: `service_label: str` (required field), validator raises on empty

## Test plan

- [ ] `hle expose --service http://localhost:8123` without `--label` → CLI error
- [ ] `hle webhook --label github --path /hooks/github` → works, label sent to server
- [ ] `hle expose --label ha --service http://localhost:8123` → works normally