### PR TITLE
Release v2604.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2604.2 — 2026-04-16
+
+<!-- TODO: Fill in release notes before merging -->
+
 ## v2604.1 — 2026-04-09
 
 First CalVer release. Switches from SemVer to Calendar Versioning (YYMM.RELEASE).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## v2604.2 — 2026-04-16
 
-<!-- TODO: Fill in release notes before merging -->
+- **Required `--label` flag**: Both `hle expose` and `hle webhook` now require `--label`. Labels are the stable identity for tunnels — the server uses them to persist subdomain mappings across reconnections.
+- **Required `service_label` in protocol**: `TunnelRegistration.service_label` is now a required field. The validator raises on empty or all-invalid-character labels.
 
 ## v2604.1 — 2026-04-09
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ curl -fsSL https://get.hle.world | sh
 Installs via pipx (preferred), uv, or pip-in-venv. Supports `--version`:
 
 ```bash
-curl -fsSL https://get.hle.world | sh -s -- --version 2604.1
+curl -fsSL https://get.hle.world | sh -s -- --version 2604.2
 ```
 
 ### Homebrew

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # HLE Client installer
 # Usage: curl -fsSL https://get.hle.world | sh
-#        curl -fsSL https://get.hle.world | sh -s -- --version 2604.1
+#        curl -fsSL https://get.hle.world | sh -s -- --version 2604.2
 set -e
 
 PACKAGE="hle-client"
@@ -143,7 +143,7 @@ main() {
         error "Install Python from https://python.org or via your package manager."
         exit 1
     }
-    info "Found Python: $PYTHON ($($PYTHON --version 2604.1>&1))"
+    info "Found Python: $PYTHON ($($PYTHON --version 2604.2>&1))"
 
     # Try install methods in order of preference
     if command -v pipx >/dev/null 2>&1; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hle-client"
-version = "2604.1"
+version = "2604.2"
 description = "HomeLab Everywhere — Expose homelab services to the internet with built-in SSO"
 readme = "README.md"
 license = "MIT"

--- a/src/hle_client/__init__.py
+++ b/src/hle_client/__init__.py
@@ -1,3 +1,3 @@
 """HLE Client — HomeLab Everywhere tunnel client."""
 
-__version__ = "2604.1"
+__version__ = "2604.2"


### PR DESCRIPTION
Bump version to `2604.2` and update all version references.

When this PR is merged, a GitHub release will be created automatically,
which triggers PyPI publish and Homebrew formula update.