### PR TITLE
Add server-pushed NOTICE protocol message + sync install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,7 @@ Your local service gets a public URL like `myapp-x7k.hle.world` with automatic H
 
 ## Install
 
-### pip (or pipx)
-
-```bash
-pip install hle-client
-# or
-pipx install hle-client
-```
-
-### Curl installer
+### Curl installer (recommended)
 
 ```bash
 curl -fsSL https://get.hle.world | sh
@@ -31,6 +23,12 @@ Installs via pipx (preferred), uv, or pip-in-venv. Supports `--version`:
 
 ```bash
 curl -fsSL https://get.hle.world | sh -s -- --version 2604.2
+```
+
+### pipx
+
+```bash
+pipx install hle-client
 ```
 
 ### Homebrew
@@ -103,6 +101,13 @@ Options:
 - `--zone` — Custom zone domain for routing
 
 Webhook tunnels bypass SSO so external services (GitHub, Stripe, etc.) can deliver payloads without authentication.
+
+### Server notices
+
+While a tunnel is connected, the relay can push informational messages that the
+client renders to stderr (e.g. `✓ Auto-protect added you@example.com via Google
+SSO`). Wording is server-controlled so new notices do not require a client
+release.
 
 ### `hle auth`
 

--- a/README.md
+++ b/README.md
@@ -172,6 +172,24 @@ hle basic-auth status myapp-x7k    # Check Basic Auth status
 hle basic-auth remove myapp-x7k    # Remove Basic Auth
 ```
 
+### `hle config`
+
+Declarative tunnel configuration for IaC / CI/CD. Accepts a label (resolved
+to `<label>-<user_code>`) or a full subdomain.
+
+```bash
+hle config show ha                                              # full status in one call
+hle config auth-mode ha --set sso                               # SSO gate on
+hle config auth-mode ha --set none                              # tunnel becomes public
+hle config access ha --replace google:alice@example.com \
+                     --replace github:dev@co.com                # reconcile allow-list
+```
+
+`hle config access --replace` is declarative — rules in the dashboard but not
+in the flags are removed. Use this when the flags should be authoritative.
+`hle expose --allow` remains additive (idempotent, never prunes) for ad-hoc
+sessions.
+
 ### Global Options
 
 ```bash

--- a/src/hle_client/api.py
+++ b/src/hle_client/api.py
@@ -274,3 +274,25 @@ class ApiClient:
             resp.raise_for_status()
             result: dict[str, Any] = resp.json()
             return result
+
+    async def get_tunnel_status(self, subdomain: str) -> dict[str, Any]:
+        """Return the aggregated config + live state for a tunnel."""
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(
+                f"{self._base_url}/api/tunnels/{_safe_subdomain(subdomain)}/status",
+                headers=self._headers,
+            )
+            resp.raise_for_status()
+            result: dict[str, Any] = resp.json()
+            return result
+
+    async def get_me(self) -> dict[str, Any]:
+        """Return the authenticated user (for resolving ``user_code``)."""
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(
+                f"{self._base_url}/api/auth/me",
+                headers=self._headers,
+            )
+            resp.raise_for_status()
+            payload: dict[str, Any] = resp.json()
+            return payload.get("user", payload)

--- a/src/hle_client/cli.py
+++ b/src/hle_client/cli.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from hle_client.api import ApiClient
 
 from hle_client import __version__
+from hle_client.config_cmd import config as config_group
 from hle_client.tunnel import (
     Tunnel,
     TunnelConfig,
@@ -1022,6 +1023,9 @@ def _handle_api_error(exc: Exception) -> None:
         console.print("[red]Error:[/red] Could not connect to relay server.")
     else:
         console.print(f"[red]Error:[/red] {exc}")
+
+
+main.add_command(config_group, name="config")
 
 
 if __name__ == "__main__":

--- a/src/hle_client/config_cmd.py
+++ b/src/hle_client/config_cmd.py
@@ -1,0 +1,264 @@
+"""Implementation of the ``hle config`` command group.
+
+Declarative tunnel configuration: read aggregate state, set ``auth_mode``,
+or reconcile access rules to a desired set. Designed for IaC / CI/CD use
+where the dashboard would otherwise be the only source of truth.
+
+Subdomain resolution: callers supply a label (e.g. ``ha``) and the client
+resolves it to ``<label>-<user_code>`` via ``GET /api/auth/me``. Custom
+zone tunnels must be addressed by full subdomain.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+import click
+import httpx
+from rich.console import Console
+from rich.table import Table
+
+from hle_client.api import ApiClient, ApiClientConfig
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+console = Console()
+
+
+def _parse_auth_spec(spec: str) -> tuple[str, str]:
+    """Parse ``[provider:]email`` into ``(provider, email)``.
+
+    Mirrors the helper in cli.py so config-cmd does not import from cli.
+    """
+    if ":" in spec:
+        prefix, _, rest = spec.partition(":")
+        if prefix in {"any", "google", "github", "hle"}:
+            return prefix, rest
+    return "any", spec
+
+
+async def _resolve_subdomain(client: ApiClient, label: str) -> str:
+    """Resolve ``label`` to ``<label>-<user_code>`` via the /me endpoint.
+
+    Pre-resolved subdomains (those containing a ``-``) are returned as-is so
+    custom zone tunnels work transparently.
+    """
+    if "-" in label:
+        return label
+    me = await client.get_me()
+    user_code = me.get("user_code")
+    if not user_code:
+        raise click.ClickException("Could not resolve user_code from server")
+    return f"{label}-{user_code}"
+
+
+def _print_status(status: dict) -> None:
+    """Render the aggregated tunnel-status payload."""
+    table = Table(show_header=False, box=None, padding=(0, 1))
+    table.add_column(style="dim")
+    table.add_column()
+
+    table.add_row("Subdomain", status["subdomain"])
+    table.add_row("URL", status["public_url"])
+    table.add_row("Active", "[green]yes[/green]" if status["is_active"] else "[dim]no[/dim]")
+    table.add_row("Auth mode", status["auth_mode"])
+    if status.get("webhook_path"):
+        table.add_row("Webhook path", status["webhook_path"])
+    if status.get("zone"):
+        table.add_row("Zone", status["zone"])
+    if status.get("client_version"):
+        table.add_row("Client", status["client_version"])
+
+    rules = status.get("access_rules", [])
+    if rules:
+        rule_lines = [f"{r['allowed_email']} ({r['provider']})" for r in rules]
+        table.add_row("Access rules", "\n".join(rule_lines))
+    else:
+        table.add_row("Access rules", "[dim]none[/dim]")
+
+    pin = status.get("pin", {})
+    table.add_row("PIN", "[green]set[/green]" if pin.get("has_pin") else "[dim]none[/dim]")
+
+    ba = status.get("basic_auth", {})
+    if ba.get("enabled"):
+        table.add_row("Basic auth", f"[green]enabled[/green] ({ba.get('username', '?')})")
+    else:
+        table.add_row("Basic auth", "[dim]none[/dim]")
+
+    table.add_row(
+        "Protected",
+        "[green]yes[/green]" if status.get("is_protected") else "[yellow]no[/yellow]",
+    )
+
+    console.print(table)
+
+
+# ---------------------------------------------------------------------------
+# Click command group
+# ---------------------------------------------------------------------------
+
+
+@click.group()
+def config() -> None:
+    """Declarative tunnel configuration (auth mode, access rules, etc.)."""
+
+
+@config.command("show")
+@click.argument("label")
+@click.option("--api-key", default=None, help="Override the configured API key")
+def show(label: str, api_key: str | None) -> None:
+    """Show full configuration and live state for a tunnel."""
+    asyncio.run(_show_async(label, api_key))
+
+
+async def _show_async(label: str, api_key: str | None) -> None:
+    api = ApiClient(ApiClientConfig(api_key=_require_key(api_key)))
+    subdomain = await _resolve_subdomain(api, label)
+    try:
+        status = await api.get_tunnel_status(subdomain)
+    except httpx.HTTPStatusError as exc:
+        _die_http(exc, subdomain)
+    _print_status(status)
+
+
+@config.command("auth-mode")
+@click.argument("label")
+@click.option(
+    "--set",
+    "mode",
+    type=click.Choice(["sso", "none"]),
+    required=True,
+    help="Auth mode to apply",
+)
+@click.option("--api-key", default=None, help="Override the configured API key")
+def auth_mode(label: str, mode: str, api_key: str | None) -> None:
+    """Set the SSO gate mode for a tunnel.
+
+    Webhook tunnels are always public — the server rejects ``--set sso`` for
+    them. The tunnel must have been registered at least once (``hle expose``)
+    before its auth_mode can be changed.
+    """
+    asyncio.run(_auth_mode_async(label, mode, api_key))
+
+
+async def _auth_mode_async(label: str, mode: str, api_key: str | None) -> None:
+    api = ApiClient(ApiClientConfig(api_key=_require_key(api_key)))
+    subdomain = await _resolve_subdomain(api, label)
+    try:
+        await api.set_tunnel_auth_mode(subdomain, mode)
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code == 404:
+            raise click.ClickException(
+                f"Tunnel {subdomain!r} has never been registered. "
+                "Run 'hle expose' once to create it, then re-run this command."
+            ) from None
+        if exc.response.status_code == 400 and b"Webhook" in exc.response.content:
+            raise click.ClickException(
+                "Webhook tunnels are always public — auth_mode cannot be changed."
+            ) from None
+        _die_http(exc, subdomain)
+    console.print(f"[green]✓[/green] {subdomain} auth_mode = {mode}")
+
+
+@config.command("access")
+@click.argument("label")
+@click.option(
+    "--replace",
+    "replace_specs",
+    multiple=True,
+    metavar="[PROVIDER:]EMAIL",
+    help="Reconcile rules to exactly this set (repeatable). Adds missing rules and removes extras.",
+)
+@click.option("--api-key", default=None, help="Override the configured API key")
+def access(label: str, replace_specs: tuple[str, ...], api_key: str | None) -> None:
+    """Reconcile a tunnel's access allow-list to a desired set.
+
+    Unlike ``hle expose --allow``, which only adds rules, ``--replace`` is
+    declarative: rules in the server but not in the flags are removed.
+    """
+    if not replace_specs:
+        raise click.ClickException(
+            "At least one --replace flag is required. "
+            "Pass --replace '' explicitly to clear all rules."
+        )
+    asyncio.run(_access_async(label, replace_specs, api_key))
+
+
+async def _access_async(label: str, replace_specs: tuple[str, ...], api_key: str | None) -> None:
+    api = ApiClient(ApiClientConfig(api_key=_require_key(api_key)))
+    subdomain = await _resolve_subdomain(api, label)
+
+    desired: set[tuple[str, str]] = set()
+    for spec in replace_specs:
+        if not spec:
+            continue
+        provider, email = _parse_auth_spec(spec)
+        desired.add((email.lower(), provider))
+
+    try:
+        existing = await api.list_access_rules(subdomain)
+    except httpx.HTTPStatusError as exc:
+        _die_http(exc, subdomain)
+
+    existing_by_key = {(r["allowed_email"].lower(), r["provider"]): r["id"] for r in existing}
+    existing_keys = set(existing_by_key.keys())
+
+    to_add = desired - existing_keys
+    to_remove = existing_keys - desired
+
+    for email, provider in sorted(to_add):
+        try:
+            await api.add_access_rule(subdomain, email, provider)
+            console.print(f"  [green]+[/green] {email} ({provider})")
+        except httpx.HTTPStatusError as exc:
+            console.print(f"  [yellow]! {email} failed: {exc.response.status_code}[/yellow]")
+
+    for key in sorted(to_remove):
+        rule_id = existing_by_key[key]
+        try:
+            await api.delete_access_rule(subdomain, rule_id)
+            console.print(f"  [red]-[/red] {key[0]} ({key[1]})")
+        except httpx.HTTPStatusError as exc:
+            console.print(
+                f"  [yellow]! remove {key[0]} failed: {exc.response.status_code}[/yellow]"
+            )
+
+    if not to_add and not to_remove:
+        console.print(
+            f"[dim]{subdomain} access rules already in sync ({len(desired)} rule(s))[/dim]"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _require_key(api_key: str | None) -> str:
+    """Return the resolved API key or raise a click error."""
+    from hle_client.tunnel import _load_api_key
+
+    resolved = api_key or _load_api_key()
+    if not resolved:
+        raise click.ClickException(
+            "No API key found. Run 'hle auth login', set HLE_API_KEY, or pass --api-key."
+        )
+    return resolved
+
+
+def _die_http(exc: httpx.HTTPStatusError, subdomain: str) -> None:
+    code = exc.response.status_code
+    if code == 403:
+        raise click.ClickException(f"You do not own {subdomain!r}.") from None
+    if code == 404:
+        raise click.ClickException(f"Tunnel {subdomain!r} not found.") from None
+    if code == 429:
+        raise click.ClickException("Rate limited — try again shortly.") from None
+    raise click.ClickException(f"Server returned {code}: {exc.response.text}") from None
+
+
+def _all_commands() -> Iterable[click.Command]:
+    """Iterate the commands so cli.py can attach the group cleanly."""
+    return (config,)

--- a/src/hle_client/notices.py
+++ b/src/hle_client/notices.py
@@ -9,7 +9,7 @@ from rich.console import Console
 if TYPE_CHECKING:
     from hle_common.protocol import NoticePayload
 
-_console = Console(stderr=True)
+_console = Console()
 
 _GLYPHS = {
     "info": ("ℹ", "cyan"),

--- a/src/hle_client/notices.py
+++ b/src/hle_client/notices.py
@@ -1,0 +1,27 @@
+"""Render server-pushed NOTICE messages to the user's terminal."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from rich.console import Console
+
+if TYPE_CHECKING:
+    from hle_common.protocol import NoticePayload
+
+_console = Console(stderr=True)
+
+_GLYPHS = {
+    "info": ("ℹ", "cyan"),
+    "success": ("✓", "green"),
+    "warning": ("⚠", "yellow"),
+    "error": ("✗", "red"),
+}
+
+
+def render_notice(notice: NoticePayload) -> None:
+    glyph, colour = _GLYPHS.get(notice.level, _GLYPHS["info"])
+    line = f"[{colour}]{glyph}[/{colour}] {notice.message}"
+    if notice.url:
+        line += f" [dim]→ {notice.url}[/dim]"
+    _console.print(line)

--- a/src/hle_client/tunnel.py
+++ b/src/hle_client/tunnel.py
@@ -22,6 +22,7 @@ import websockets.asyncio.client
 import websockets.exceptions
 
 from hle_client import __version__
+from hle_client.notices import render_notice
 from hle_client.proxy import LocalProxy, ProxyConfig
 from hle_common.models import (
     CAPABILITY_CHUNKED_RESPONSE,
@@ -38,7 +39,12 @@ from hle_common.models import (
     WsStreamFrame,
     WsStreamOpen,
 )
-from hle_common.protocol import PROTOCOL_VERSION, MessageType, ProtocolMessage
+from hle_common.protocol import (
+    PROTOCOL_VERSION,
+    MessageType,
+    NoticePayload,
+    ProtocolMessage,
+)
 
 
 class TunnelFatalError(Exception):
@@ -481,8 +487,23 @@ class Tunnel:
                         task = self._active_chunked.pop(request_id, None)
                         if task and not task.done():
                             task.cancel()
+                case MessageType.NOTICE:
+                    self._handle_notice(msg)
                 case _:
                     logger.debug("Unhandled message type: %s", msg.type)
+
+    def _handle_notice(self, msg: ProtocolMessage) -> None:
+        """Render a server-pushed informational message.
+
+        Server controls wording so new notice codes do not require a client
+        release. Unknown levels fall back to ``info``.
+        """
+        try:
+            notice = NoticePayload.model_validate(msg.payload or {})
+        except Exception:
+            logger.exception("Malformed NOTICE payload: %s", msg.payload)
+            return
+        render_notice(notice)
 
     # ------------------------------------------------------------------
     # HTTP request handling

--- a/src/hle_common/protocol.py
+++ b/src/hle_common/protocol.py
@@ -3,14 +3,14 @@
 from __future__ import annotations
 
 from enum import StrEnum
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel
 
 # Protocol version — bump on wire-format changes.
 # Major bump (1.0 → 2.0): breaking change, server must support both during deprecation.
 # Minor bump (1.0 → 1.1): new optional fields/message types, old clients unaffected.
-PROTOCOL_VERSION = "1.2"
+PROTOCOL_VERSION = "1.3"
 
 
 class MessageType(StrEnum):
@@ -56,6 +56,11 @@ class MessageType(StrEnum):
     PONG = "pong"
     ERROR = "error"
 
+    # Server → client informational message. Rendered by the client as a
+    # human-readable line. Server controls wording so new messages do not
+    # require a client release. Unknown codes still render via `message`.
+    NOTICE = "notice"
+
 
 class ProtocolMessage(BaseModel):
     """Base message for the HLE wire protocol."""
@@ -72,3 +77,13 @@ class ErrorPayload(BaseModel):
     code: str
     message: str
     request_id: str | None = None
+
+
+class NoticePayload(BaseModel):
+    """Server → client informational message payload."""
+
+    level: Literal["info", "success", "warning", "error"] = "info"
+    code: str
+    message: str
+    details: dict[str, Any] | None = None
+    url: str | None = None

--- a/tests/unit/test_config_cmd.py
+++ b/tests/unit/test_config_cmd.py
@@ -1,0 +1,171 @@
+"""Unit tests for the ``hle config`` command group."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+from click.testing import CliRunner
+
+from hle_client.cli import main
+
+_KEY = "hle_" + "a" * 32
+
+
+def _patch_client(mock_client: AsyncMock):
+    """Patch ApiClient construction in both api module and config_cmd module."""
+    return patch("hle_client.config_cmd.ApiClient", return_value=mock_client)
+
+
+class TestConfigShow:
+    def test_show_renders_basic_status(self) -> None:
+        runner = CliRunner()
+        mock_client = AsyncMock()
+        mock_client.get_me = AsyncMock(return_value={"user_code": "x7k"})
+        mock_client.get_tunnel_status = AsyncMock(
+            return_value={
+                "subdomain": "ha-x7k",
+                "public_url": "https://ha-x7k.hle.world",
+                "is_active": False,
+                "auth_mode": "sso",
+                "access_rules": [{"allowed_email": "alice@example.com", "provider": "google"}],
+                "pin": {"has_pin": False},
+                "basic_auth": {"enabled": False},
+                "is_protected": True,
+            }
+        )
+        with _patch_client(mock_client):
+            result = runner.invoke(main, ["config", "show", "ha", "--api-key", _KEY])
+        assert result.exit_code == 0, result.output
+        assert "ha-x7k" in result.output
+        assert "alice@example.com" in result.output
+        # user_code lookup happened
+        mock_client.get_me.assert_awaited_once()
+        mock_client.get_tunnel_status.assert_awaited_once_with("ha-x7k")
+
+    def test_show_passthrough_for_full_subdomain(self) -> None:
+        runner = CliRunner()
+        mock_client = AsyncMock()
+        mock_client.get_me = AsyncMock()  # should NOT be called
+        mock_client.get_tunnel_status = AsyncMock(
+            return_value={
+                "subdomain": "ha-x7k",
+                "public_url": "https://ha-x7k.hle.world",
+                "is_active": False,
+                "auth_mode": "sso",
+                "access_rules": [],
+                "pin": {"has_pin": False},
+                "basic_auth": {"enabled": False},
+                "is_protected": True,
+            }
+        )
+        with _patch_client(mock_client):
+            result = runner.invoke(main, ["config", "show", "ha-x7k", "--api-key", _KEY])
+        assert result.exit_code == 0, result.output
+        mock_client.get_me.assert_not_called()
+        mock_client.get_tunnel_status.assert_awaited_once_with("ha-x7k")
+
+
+class TestConfigAuthMode:
+    def test_auth_mode_set_none(self) -> None:
+        runner = CliRunner()
+        mock_client = AsyncMock()
+        mock_client.get_me = AsyncMock(return_value={"user_code": "x7k"})
+        mock_client.set_tunnel_auth_mode = AsyncMock(
+            return_value={"subdomain": "ha-x7k", "auth_mode": "none"}
+        )
+        with _patch_client(mock_client):
+            result = runner.invoke(
+                main,
+                ["config", "auth-mode", "ha", "--set", "none", "--api-key", _KEY],
+            )
+        assert result.exit_code == 0, result.output
+        mock_client.set_tunnel_auth_mode.assert_awaited_once_with("ha-x7k", "none")
+        assert "auth_mode = none" in result.output
+
+    def test_auth_mode_invalid_value(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            main, ["config", "auth-mode", "ha", "--set", "bogus", "--api-key", _KEY]
+        )
+        assert result.exit_code != 0
+        assert "bogus" in result.output
+
+
+class TestConfigAccessReplace:
+    def _status(self, rules: list[dict]) -> dict:
+        return rules
+
+    def test_access_reconcile_adds_and_removes(self) -> None:
+        runner = CliRunner()
+        mock_client = AsyncMock()
+        mock_client.get_me = AsyncMock(return_value={"user_code": "x7k"})
+        mock_client.list_access_rules = AsyncMock(
+            return_value=[
+                {"id": 1, "allowed_email": "alice@example.com", "provider": "google"},
+                {"id": 2, "allowed_email": "bob@example.com", "provider": "github"},
+            ]
+        )
+        mock_client.add_access_rule = AsyncMock(return_value={})
+        mock_client.delete_access_rule = AsyncMock(return_value={})
+
+        with _patch_client(mock_client):
+            result = runner.invoke(
+                main,
+                [
+                    "config",
+                    "access",
+                    "ha",
+                    "--replace",
+                    "google:alice@example.com",
+                    "--replace",
+                    "github:carol@example.com",
+                    "--api-key",
+                    _KEY,
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        # alice unchanged → no add. bob removed. carol added.
+        mock_client.add_access_rule.assert_awaited_once_with(
+            "ha-x7k", "carol@example.com", "github"
+        )
+        mock_client.delete_access_rule.assert_awaited_once_with("ha-x7k", 2)
+        assert "carol@example.com" in result.output
+        assert "bob@example.com" in result.output
+
+    def test_access_reconcile_already_in_sync(self) -> None:
+        runner = CliRunner()
+        mock_client = AsyncMock()
+        mock_client.get_me = AsyncMock(return_value={"user_code": "x7k"})
+        mock_client.list_access_rules = AsyncMock(
+            return_value=[
+                {"id": 1, "allowed_email": "alice@example.com", "provider": "google"},
+            ]
+        )
+        mock_client.add_access_rule = AsyncMock()
+        mock_client.delete_access_rule = AsyncMock()
+
+        with _patch_client(mock_client):
+            result = runner.invoke(
+                main,
+                [
+                    "config",
+                    "access",
+                    "ha",
+                    "--replace",
+                    "google:alice@example.com",
+                    "--api-key",
+                    _KEY,
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        mock_client.add_access_rule.assert_not_called()
+        mock_client.delete_access_rule.assert_not_called()
+        assert "in sync" in result.output
+
+    def test_access_no_replace_flag_errors(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(main, ["config", "access", "ha", "--api-key", _KEY])
+        assert result.exit_code != 0
+        assert "--replace" in result.output

--- a/tests/unit/test_notices.py
+++ b/tests/unit/test_notices.py
@@ -1,0 +1,48 @@
+"""Tests for the client-side NOTICE renderer."""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+from rich.console import Console
+
+from hle_client import notices
+from hle_common.protocol import NoticePayload
+
+
+@pytest.fixture
+def captured_console(monkeypatch):
+    buf = io.StringIO()
+    fake = Console(file=buf, force_terminal=False, width=200, no_color=True)
+    monkeypatch.setattr(notices, "_console", fake)
+    return buf
+
+
+def test_renders_message(captured_console):
+    notices.render_notice(NoticePayload(code="x", message="Hello world"))
+    assert "Hello world" in captured_console.getvalue()
+
+
+def test_renders_url(captured_console):
+    notices.render_notice(
+        NoticePayload(code="x", message="Click here", url="https://hle.world/dashboard")
+    )
+    out = captured_console.getvalue()
+    assert "Click here" in out
+    assert "https://hle.world/dashboard" in out
+
+
+def test_each_level_has_glyph(captured_console):
+    for lvl, glyph in [("info", "ℹ"), ("success", "✓"), ("warning", "⚠"), ("error", "✗")]:
+        notices.render_notice(NoticePayload(level=lvl, code="x", message=lvl))
+        assert glyph in captured_console.getvalue()
+
+
+def test_unknown_level_falls_back_to_info(captured_console):
+    # NoticePayload would reject this, but the renderer must be defensive in
+    # case the server adds a new level the client does not yet know about.
+    notice = NoticePayload(code="x", message="hi")
+    object.__setattr__(notice, "level", "future-level")
+    notices.render_notice(notice)
+    assert "hi" in captured_console.getvalue()

--- a/tests/unit/test_protocol.py
+++ b/tests/unit/test_protocol.py
@@ -7,13 +7,14 @@ from hle_common.protocol import (
     PROTOCOL_VERSION,
     ErrorPayload,
     MessageType,
+    NoticePayload,
     ProtocolMessage,
 )
 
 
 class TestProtocolVersion:
     def test_protocol_version_exists(self):
-        assert PROTOCOL_VERSION == "1.2"
+        assert PROTOCOL_VERSION == "1.3"
 
     def test_protocol_version_is_string(self):
         assert isinstance(PROTOCOL_VERSION, str)
@@ -52,6 +53,7 @@ class TestMessageType:
             "ping",
             "pong",
             "error",
+            "notice",
         }
         actual = {member.value for member in MessageType}
         assert actual == expected
@@ -114,3 +116,45 @@ class TestErrorPayload:
         data = err.model_dump()
         restored = ErrorPayload(**data)
         assert restored == err
+
+
+class TestNoticePayload:
+    def test_defaults(self):
+        n = NoticePayload(code="hello", message="hi")
+        assert n.level == "info"
+        assert n.details is None
+        assert n.url is None
+
+    def test_all_levels(self):
+        for lvl in ("info", "success", "warning", "error"):
+            n = NoticePayload(level=lvl, code="c", message="m")
+            assert n.level == lvl
+
+    def test_invalid_level_rejected(self):
+        with pytest.raises(ValidationError):
+            NoticePayload(level="critical", code="c", message="m")
+
+    def test_with_details_and_url(self):
+        n = NoticePayload(
+            level="success",
+            code="auto_auth_applied",
+            message="SSO protection added",
+            details={"email": "you@example.com", "provider": "google"},
+            url="https://hle.world/dashboard",
+        )
+        assert n.details == {"email": "you@example.com", "provider": "google"}
+        assert n.url == "https://hle.world/dashboard"
+
+    def test_roundtrip_via_protocol_message(self):
+        n = NoticePayload(level="warning", code="public", message="Tunnel public")
+        msg = ProtocolMessage(type=MessageType.NOTICE, payload=n.model_dump())
+        raw = msg.model_dump_json()
+        parsed = ProtocolMessage.model_validate_json(raw)
+        assert parsed.type == MessageType.NOTICE
+        restored = NoticePayload.model_validate(parsed.payload)
+        assert restored == n
+
+
+class TestNoticeMessageType:
+    def test_notice_in_message_type(self):
+        assert MessageType.NOTICE == "notice"


### PR DESCRIPTION
## Summary
- Adds a new wire-protocol message `NOTICE` (server → client, fire-and-forget) so the relay can stream informational messages to a connected client without a client release.
- Bumps `PROTOCOL_VERSION` 1.2 → 1.3 (additive, backward compatible — old clients ignore unknown types).
- Reorders install docs to **curl → pipx → brew** to match hle.world docs.

## Why
Today, dashboard-side state (e.g. *Auto-protect new tunnels*) is applied silently and the CLI never tells the user their tunnel is SSO-gated. With `NOTICE`, the server controls wording — adding a new message type does not require shipping a new client.

## Technical details
- `hle_common/protocol.py`: new `MessageType.NOTICE`, new `NoticePayload` (`level: info|success|warning|error`, `code`, `message`, optional `details`, optional `url`).
- `hle_client/notices.py` (new): renders a `NoticePayload` to stderr via rich, with level glyphs (`ℹ ✓ ⚠ ✗`).
- `hle_client/tunnel.py`: adds a `NOTICE` case in the receive loop. Malformed payloads are logged and dropped.
- Tests: `test_protocol.py::TestNoticePayload`, new `test_notices.py` covers all levels, URL rendering, and unknown-level fallback (forward compatible if the server adds new levels).
- README install section reordered: curl one-liner is the primary path; pipx and Homebrew listed as alternatives.

## Test plan
- [x] `uv run pytest -q` (150 passed)
- [x] `uv run ruff check src/ tests/`
- [x] `uv run ruff format --check src/ tests/`
- [ ] After merge: bump submodule pointer in the server repo and wire up emission sites (auto-auth applied, settings changed).