### PR TITLE
Fix install.sh stray version literal in --version invocation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -143,7 +143,7 @@ main() {
         error "Install Python from https://python.org or via your package manager."
         exit 1
     }
-    info "Found Python: $PYTHON ($($PYTHON --version 2604.2>&1))"
+    info "Found Python: $PYTHON ($($PYTHON --version 2>&1))"
 
     # Try install methods in order of preference
     if command -v pipx >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
Fix a stray version literal in `install.sh`: `$PYTHON --version 2604.2>&1` → `$PYTHON --version 2>&1`.

## Why
A previous run of `scripts/release.sh` did a too-broad `sed` replacement and accidentally injected `2604.2` between `--version` and `2>&1`, turning the stderr-merge redirection into a redirection to a file named `2604.2`. The shell still parsed the line (the file isn't actually opened in a path that surfaces) but the resulting log line was malformed.

## Test plan
- [x] Restore the original `2>&1` form
- [ ] Pre-commit hook passes
