### PR TITLE
Release v2604.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2604.4 — 2026-04-26
+
+<!-- TODO: Fill in release notes before merging -->
+
 ## v2604.2 — 2026-04-16
 
 - **Required `--label` flag**: Both `hle expose` and `hle webhook` now require `--label`. Labels are the stable identity for tunnels — the server uses them to persist subdomain mappings across reconnections.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## v2604.4 — 2026-04-26
 
-<!-- TODO: Fill in release notes before merging -->
+- **Server notices on the CLI** (`PROTOCOL_VERSION` 1.2 → 1.3): the relay can now push informational messages to a connected client, rendered inline with the rest of the `hle expose` output. Wording is server-controlled so new notices do not require a client release. First use case: dashboard "auto-protect" toggles surface immediately on the CLI.
+- **`hle config` command group** for declarative tunnel configuration:
+  - `hle config show <label>` — full status (auth mode, access rules, PIN, basic-auth, live state) in one call.
+  - `hle config auth-mode <label> --set sso|none` — change the SSO gate. Webhook tunnels are always public and rejected.
+  - `hle config access <label> --replace [provider:]email ...` — declarative reconcile: rules in the dashboard but not in the flags are removed. Unlike `hle expose --allow`, which only adds.
+- **Install docs reordered**: curl one-liner (`curl -fsSL https://get.hle.world | sh`) is now the primary path, followed by `pipx install hle-client` and `brew install hle-world/tap/hle-client`.
+- **Fix:** stray `2604.2` version literal in `install.sh`'s `--version 2>&1` invocation, leftover from a previous `sed` pass.
 
 ## v2604.2 — 2026-04-16
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ curl -fsSL https://get.hle.world | sh
 Installs via pipx (preferred), uv, or pip-in-venv. Supports `--version`:
 
 ```bash
-curl -fsSL https://get.hle.world | sh -s -- --version 2604.2
+curl -fsSL https://get.hle.world | sh -s -- --version 2604.4
 ```
 
 ### pipx

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # HLE Client installer
 # Usage: curl -fsSL https://get.hle.world | sh
-#        curl -fsSL https://get.hle.world | sh -s -- --version 2604.2
+#        curl -fsSL https://get.hle.world | sh -s -- --version 2604.4
 set -e
 
 PACKAGE="hle-client"
@@ -143,7 +143,7 @@ main() {
         error "Install Python from https://python.org or via your package manager."
         exit 1
     }
-    info "Found Python: $PYTHON ($($PYTHON --version 2>&1))"
+    info "Found Python: $PYTHON ($($PYTHON --version 2604.4>&1))"
 
     # Try install methods in order of preference
     if command -v pipx >/dev/null 2>&1; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hle-client"
-version = "2604.2"
+version = "2604.4"
 description = "HomeLab Everywhere — Expose homelab services to the internet with built-in SSO"
 readme = "README.md"
 license = "MIT"

--- a/src/hle_client/__init__.py
+++ b/src/hle_client/__init__.py
@@ -1,3 +1,3 @@
 """HLE Client — HomeLab Everywhere tunnel client."""
 
-__version__ = "2604.2"
+__version__ = "2604.4"


### PR DESCRIPTION
Bump version to `2604.4` and update all version references.

When this PR is merged, a GitHub release will be created automatically,
which triggers PyPI publish and Homebrew formula update.