### PR TITLE
Reorganize CLI under hle config, drop zone scope (v2605.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ Options:
 - `--forward-to` — Local URL to forward webhooks to (required)
 - `--label` — Webhook label, e.g. `github-hook` (required)
 - `--api-key` — API key (also reads `HLE_API_KEY` env var, then config file)
-- `--zone` — Custom zone domain for routing
 
 Webhook tunnels bypass SSO so external services (GitHub, Stripe, etc.) can deliver payloads without authentication.
 
@@ -120,75 +119,66 @@ hle auth status                             # Show current key source
 hle auth logout                             # Remove saved key
 ```
 
-### `hle tunnels`
-
-List your active tunnels.
-
-```bash
-hle tunnels
-```
-
-### `hle access`
-
-Manage per-tunnel email allow-lists for SSO access.
-
-```bash
-hle access list myapp-x7k                            # List access rules
-hle access add myapp-x7k friend@example.com           # Allow an email
-hle access add myapp-x7k dev@co.com --provider github # Require GitHub SSO
-hle access remove myapp-x7k 42                        # Remove rule by ID
-```
-
-### `hle pin`
-
-Manage PIN-based access control for tunnels.
-
-```bash
-hle pin set myapp-x7k       # Set a PIN (prompts for 4-8 digit PIN)
-hle pin status myapp-x7k    # Check PIN status
-hle pin remove myapp-x7k    # Remove PIN
-```
-
-### `hle share`
-
-Create and manage temporary share links.
-
-```bash
-hle share create myapp-x7k                         # 24h link (default)
-hle share create myapp-x7k --duration 1h           # 1-hour link
-hle share create myapp-x7k --max-uses 5            # Limited uses
-hle share create myapp-x7k --label "demo"          # Label for reference
-hle share list myapp-x7k                           # List share links
-hle share revoke myapp-x7k 42                      # Revoke a link
-```
-
-### `hle basic-auth`
-
-Manage HTTP Basic Auth access control for tunnels.
-
-```bash
-hle basic-auth set myapp-x7k       # Set credentials (prompts for username & password)
-hle basic-auth status myapp-x7k    # Check Basic Auth status
-hle basic-auth remove myapp-x7k    # Remove Basic Auth
-```
-
 ### `hle config`
 
-Declarative tunnel configuration for IaC / CI/CD. Accepts a label (resolved
-to `<label>-<user_code>`) or a full subdomain.
+All tunnel and client configuration lives under `hle config`. Tunnel
+subcommands accept a label (resolved to `<label>-<user_code>`) or a full
+subdomain.
+
+#### `hle config show` / `list`
 
 ```bash
-hle config show ha                                              # full status in one call
-hle config auth-mode ha --set sso                               # SSO gate on
-hle config auth-mode ha --set none                              # tunnel becomes public
-hle config access ha --replace google:alice@example.com \
-                     --replace github:dev@co.com                # reconcile allow-list
+hle config list                       # List your active tunnels
+hle config show ha                    # Full status for one tunnel (auth, rules, PIN, …)
 ```
 
-`hle config access --replace` is declarative — rules in the dashboard but not
-in the flags are removed. Use this when the flags should be authoritative.
-`hle expose --allow` remains additive (idempotent, never prunes) for ad-hoc
-sessions.
+#### `hle config auth-mode`
+
+```bash
+hle config auth-mode ha --set sso     # SSO gate on
+hle config auth-mode ha --set none    # Tunnel becomes public
+```
+
+#### `hle config access` — SSO email allow-list
+
+```bash
+hle config access list ha                                # List rules
+hle config access add ha friend@example.com              # Allow an email
+hle config access add ha dev@co.com --provider github    # Require GitHub SSO
+hle config access remove ha 42                           # Remove rule by ID
+hle config access replace ha google:alice@x.com github:bob@y.com   # Declarative — adds + prunes
+hle config access replace ha --clear                     # Remove all rules
+```
+
+`replace` is declarative: rules on the server but not in the args are removed.
+`hle expose --allow` remains additive (never prunes) for ad-hoc sessions.
+
+#### `hle config pin`
+
+```bash
+hle config pin set ha          # Set a PIN (prompts for 4-8 digits)
+hle config pin status ha       # Check PIN status
+hle config pin remove ha       # Remove PIN
+```
+
+#### `hle config basic-auth`
+
+```bash
+hle config basic-auth set ha          # Prompts for username + password (min 8 chars)
+hle config basic-auth status ha       # Check Basic Auth status
+hle config basic-auth remove ha       # Remove Basic Auth
+```
+
+#### `hle config share` — temporary share links
+
+```bash
+hle config share create ha                        # 24h link (default)
+hle config share create ha --duration 1h          # 1-hour link
+hle config share create ha --max-uses 5           # Limited uses
+hle config share create ha --label "demo"         # Label for reference
+hle config share list ha                          # List share links
+hle config share revoke ha 42                     # Revoke a link
+```
 
 ### Global Options
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hle-client"
-version = "2604.4"
+version = "2605.1"
 description = "HomeLab Everywhere — Expose homelab services to the internet with built-in SSO"
 readme = "README.md"
 license = "MIT"

--- a/src/hle_client/__init__.py
+++ b/src/hle_client/__init__.py
@@ -1,3 +1,3 @@
 """HLE Client — HomeLab Everywhere tunnel client."""
 
-__version__ = "2604.4"
+__version__ = "2605.1"

--- a/src/hle_client/cli.py
+++ b/src/hle_client/cli.py
@@ -7,14 +7,9 @@ import logging
 import os
 import re
 import webbrowser
-from typing import TYPE_CHECKING
 
 import click
 from rich.console import Console
-from rich.table import Table
-
-if TYPE_CHECKING:
-    from hle_client.api import ApiClient
 
 from hle_client import __version__
 from hle_client.config_cmd import config as config_group
@@ -23,29 +18,12 @@ from hle_client.tunnel import (
     TunnelConfig,
     TunnelFatalError,
     _load_api_key,
-    _load_zone,
     _remove_api_key,
-    _remove_zone,
     _save_api_key,
-    _save_zone,
 )
 
 console = Console()
 logger = logging.getLogger(__name__)
-
-
-def _resolve_api_key(api_key: str | None) -> str:
-    """Resolve an API key from flag, env var, or config file.
-
-    Exits with an error message if no key is found.
-    """
-    resolved = api_key or _load_api_key()
-    if not resolved:
-        console.print(
-            "[red]No API key found.[/red] Run 'hle auth login', set HLE_API_KEY, or pass --api-key."
-        )
-        raise SystemExit(1)
-    return resolved
 
 
 @click.group()
@@ -71,6 +49,11 @@ def _parse_auth_spec(spec: str) -> tuple[str, str]:
         if prefix in _VALID_AUTH_PROVIDERS:
             return prefix, rest
     return "any", spec
+
+
+# ---------------------------------------------------------------------------
+# hle expose — run a tunnel
+# ---------------------------------------------------------------------------
 
 
 @main.command()
@@ -113,13 +96,6 @@ def _parse_auth_spec(spec: str) -> tuple[str, str]:
     "Format: 'email' or 'provider:email'. "
     "Providers: any (default), google, github, hle. Repeatable.",
 )
-@click.option(
-    "--zone",
-    default=None,
-    envvar="HLE_ZONE",
-    help="Custom zone domain for enterprise tunnel routing (e.g. project1.t00t.us). "
-    "Falls back to ~/.config/hle/config.toml if not set.",
-)
 def expose(
     service: str,
     auth: str,
@@ -130,13 +106,8 @@ def expose(
     upstream_basic_auth: str | None,
     forward_host: bool,
     allow: tuple[str, ...],
-    zone: str | None,
 ) -> None:
     """Expose a local service to the internet."""
-    # Resolve zone: --zone flag > HLE_ZONE env > config.toml
-    resolved_zone = zone or _load_zone()
-
-    # Parse --upstream-basic-auth USER:PASS
     upstream_auth_tuple: tuple[str, str] | None = None
     if upstream_basic_auth:
         if ":" not in upstream_basic_auth:
@@ -154,10 +125,8 @@ def expose(
         verify_ssl=verify_ssl,
         upstream_basic_auth=upstream_auth_tuple,
         forward_host=forward_host,
-        zone=resolved_zone,
     )
 
-    # Build post-registration callback for --allow rules
     auth_specs = [_parse_auth_spec(s) for s in allow]
     on_registered_cb = None
     if auth_specs:
@@ -189,7 +158,6 @@ def expose(
 
     tunnel = Tunnel(config=config, on_registered=on_registered_cb)
 
-    # Warn if the API key was passed as a CLI flag (visible in ps/proc).
     if api_key and not os.environ.get("HLE_API_KEY"):
         console.print(
             "[yellow]Warning:[/yellow] API key passed via --api-key is visible in process "
@@ -200,8 +168,6 @@ def expose(
     console.print("     Relay   [dim]hle.world[/dim]")
     if service_label:
         console.print(f"     Label   [dim]{service_label}[/dim]")
-    if resolved_zone:
-        console.print(f"     Zone    [dim]{resolved_zone}[/dim]")
     console.print(f"     WS      [dim]{'enabled' if websocket else 'disabled'}[/dim]")
     console.print()
 
@@ -215,7 +181,79 @@ def expose(
 
 
 # ---------------------------------------------------------------------------
-# hle auth — manage API key authentication
+# hle webhook — run a webhook forwarder
+# ---------------------------------------------------------------------------
+
+
+@main.command()
+@click.option("--path", required=True, help="Webhook path (e.g. /webhook/github)")
+@click.option("--forward-to", required=True, help="Local URL to forward webhooks to")
+@click.option("--label", "service_label", required=True, help="Webhook label (e.g. github-hook)")
+@click.option(
+    "--api-key",
+    envvar="HLE_API_KEY",
+    default=None,
+    help="API key. Falls back to ~/.config/hle/config.toml if not set.",
+)
+def webhook(
+    path: str,
+    forward_to: str,
+    service_label: str,
+    api_key: str | None,
+) -> None:
+    """Forward incoming webhooks to a local service.
+
+    Example:
+
+        hle webhook --path /hook/github --forward-to http://localhost:3000/webhook --label gh
+    """
+    import posixpath
+
+    if not path.startswith("/"):
+        path = f"/{path}"
+    path = posixpath.normpath(path)
+    if not path or path == "/":
+        console.print("[red]Error:[/red] --path must be a non-root path (e.g. /webhook/github)")
+        raise SystemExit(1)
+    if ".." in path.split("/"):
+        console.print("[red]Error:[/red] --path must not contain '..' segments")
+        raise SystemExit(1)
+
+    config = TunnelConfig(
+        service_url=forward_to,
+        auth_mode="none",
+        service_label=service_label,
+        api_key=api_key,
+        websocket_enabled=False,
+        verify_ssl=False,
+        webhook_path=path,
+    )
+
+    tunnel = Tunnel(config=config)
+
+    if api_key and not os.environ.get("HLE_API_KEY"):
+        console.print(
+            "[yellow]Warning:[/yellow] API key passed via --api-key is visible in process "
+            "listings.\n         Use HLE_API_KEY env var or ~/.config/hle/config.toml instead."
+        )
+
+    console.print(f"\n[bold]HLE[/bold] v{__version__}  Webhook forwarder")
+    console.print(f"     Path    [cyan]{path}[/cyan]")
+    console.print(f"     Forward [cyan]{forward_to}[/cyan]")
+    console.print("     Relay   [dim]hle.world[/dim]")
+    console.print()
+
+    try:
+        asyncio.run(tunnel.connect())
+    except KeyboardInterrupt:
+        console.print("\n[yellow]Shutting down ...[/yellow]")
+    except TunnelFatalError as exc:
+        console.print(f"\n[red]Error:[/red] {exc}")
+        raise SystemExit(1) from None
+
+
+# ---------------------------------------------------------------------------
+# hle auth — API key authentication
 # ---------------------------------------------------------------------------
 
 _API_KEY_PATTERN = re.compile(r"^hle_[0-9a-f]{32}$")
@@ -227,11 +265,7 @@ def auth() -> None:
 
 
 @auth.command()
-@click.option(
-    "--api-key",
-    default=None,
-    help="API key to save (skips browser prompt)",
-)
+@click.option("--api-key", default=None, help="API key to save (skips browser prompt)")
 def login(api_key: str | None) -> None:
     """Save an API key to ~/.config/hle/config.toml."""
     if api_key is None:
@@ -278,751 +312,6 @@ def logout() -> None:
         console.print("[green]API key removed[/green] from ~/.config/hle/config.toml")
     else:
         console.print("[dim]No API key saved in config file.[/dim]")
-
-
-# ---------------------------------------------------------------------------
-# hle zone — manage default custom zone
-# ---------------------------------------------------------------------------
-
-
-@main.group()
-def zone() -> None:
-    """Manage default custom zone for enterprise tunnel routing."""
-
-
-@zone.command("set")
-@click.argument("zone_domain")
-def zone_set(zone_domain: str) -> None:
-    """Set the default zone (saved to ~/.config/hle/config.toml).
-
-    This zone is used automatically by 'hle expose' when --zone is not passed.
-    """
-    _save_zone(zone_domain)
-    console.print(f"[green]Default zone set:[/green] {zone_domain}")
-    console.print("[dim]All tunnels will use this zone unless --zone overrides it.[/dim]")
-
-
-@zone.command("status")
-def zone_status() -> None:
-    """Show the current default zone."""
-    env_zone = os.environ.get("HLE_ZONE")
-    if env_zone:
-        console.print("Zone source: [cyan]HLE_ZONE environment variable[/cyan]")
-        console.print(f"Zone: [dim]{env_zone}[/dim]")
-        return
-
-    config_zone = _load_zone()
-    if config_zone:
-        console.print("Zone source: [cyan]config file (~/.config/hle/config.toml)[/cyan]")
-        console.print(f"Zone: [dim]{config_zone}[/dim]")
-        return
-
-    console.print("[dim]No default zone configured.[/dim]")
-
-
-@zone.command("clear")
-def zone_clear() -> None:
-    """Remove the default zone from ~/.config/hle/config.toml."""
-    if _remove_zone():
-        console.print("[green]Default zone removed[/green] from ~/.config/hle/config.toml")
-    else:
-        console.print("[dim]No default zone saved in config file.[/dim]")
-
-
-@main.command()
-@click.option("--path", required=True, help="Webhook path (e.g. /webhook/github)")
-@click.option("--forward-to", required=True, help="Local URL to forward webhooks to")
-@click.option("--label", "service_label", required=True, help="Webhook label (e.g. github-hook)")
-@click.option(
-    "--api-key",
-    envvar="HLE_API_KEY",
-    default=None,
-    help="API key. Falls back to ~/.config/hle/config.toml if not set.",
-)
-@click.option("--zone", default=None, help="Custom zone domain for routing.")
-def webhook(
-    path: str,
-    forward_to: str,
-    service_label: str,
-    api_key: str | None,
-    zone: str | None,
-) -> None:
-    """Forward incoming webhooks to a local service.
-
-    Creates a tunnel that only accepts requests matching --path and forwards
-    them to --forward-to. The tunnel's access gate (SSO/PIN) is disabled so
-    external services (GitHub, Stripe, etc.) can deliver webhooks without
-    authentication.
-
-    Example:
-
-        hle webhook --path /hook/github --forward-to http://localhost:3000/webhook
-    """
-    import posixpath
-
-    # Validate and normalize path
-    if not path.startswith("/"):
-        path = f"/{path}"
-    path = posixpath.normpath(path)
-    if not path or path == "/":
-        console.print("[red]Error:[/red] --path must be a non-root path (e.g. /webhook/github)")
-        raise SystemExit(1)
-    if ".." in path.split("/"):
-        console.print("[red]Error:[/red] --path must not contain '..' segments")
-        raise SystemExit(1)
-
-    resolved_zone = zone or _load_zone()
-
-    config = TunnelConfig(
-        service_url=forward_to,
-        auth_mode="none",  # no SSO gate for webhooks
-        service_label=service_label,
-        api_key=api_key,
-        websocket_enabled=False,
-        verify_ssl=False,
-        zone=resolved_zone,
-        webhook_path=path,
-    )
-
-    tunnel = Tunnel(config=config)
-
-    if api_key and not os.environ.get("HLE_API_KEY"):
-        console.print(
-            "[yellow]Warning:[/yellow] API key passed via --api-key is visible in process "
-            "listings.\n         Use HLE_API_KEY env var or ~/.config/hle/config.toml instead."
-        )
-
-    console.print(f"\n[bold]HLE[/bold] v{__version__}  Webhook forwarder")
-    console.print(f"     Path    [cyan]{path}[/cyan]")
-    console.print(f"     Forward [cyan]{forward_to}[/cyan]")
-    console.print("     Relay   [dim]hle.world[/dim]")
-    if resolved_zone:
-        console.print(f"     Zone    [dim]{resolved_zone}[/dim]")
-    console.print()
-
-    try:
-        asyncio.run(tunnel.connect())
-    except KeyboardInterrupt:
-        console.print("\n[yellow]Shutting down ...[/yellow]")
-    except TunnelFatalError as exc:
-        console.print(f"\n[red]Error:[/red] {exc}")
-        raise SystemExit(1) from None
-
-
-# ---------------------------------------------------------------------------
-# hle tunnels — list active tunnels
-# ---------------------------------------------------------------------------
-
-
-@main.command()
-@click.option(
-    "--api-key",
-    default=None,
-    envvar="HLE_API_KEY",
-    help="API key for authentication",
-)
-def tunnels(api_key: str | None) -> None:
-    """List active tunnels for your account."""
-    resolved_key = _resolve_api_key(api_key)
-
-    async def _run() -> None:
-        from hle_client.api import ApiClient, ApiClientConfig
-
-        client = ApiClient(ApiClientConfig(api_key=resolved_key))
-        try:
-            tunnel_list = await client.list_tunnels()
-        except Exception as exc:
-            _handle_api_error(exc)
-            return
-
-        if not tunnel_list:
-            console.print("[dim]No active tunnels.[/dim]")
-            return
-
-        table = Table(title="Active Tunnels")
-        table.add_column("Subdomain", style="cyan")
-        table.add_column("Service URL")
-        table.add_column("WebSocket")
-        table.add_column("Connected At", style="dim")
-        for t in tunnel_list:
-            table.add_row(
-                t.get("subdomain", ""),
-                t.get("service_url", ""),
-                "yes" if t.get("websocket_enabled") else "no",
-                t.get("connected_at", ""),
-            )
-        console.print(table)
-
-    asyncio.run(_run())
-
-
-# ---------------------------------------------------------------------------
-# Auth conflict helpers — warn when methods would override each other
-# ---------------------------------------------------------------------------
-
-
-async def _warn_if_basic_auth_active(client: ApiClient, subdomain: str) -> None:
-    """Warn the user if Basic Auth is active (it will override PIN/email rules)."""
-    try:
-        data = await client.get_tunnel_basic_auth_status(subdomain)
-        if data.get("enabled"):
-            console.print(
-                f"[yellow]Warning:[/yellow] Basic Auth is currently active on "
-                f"[cyan]{subdomain}[/cyan].\n"
-                "  Email rules and PIN are bypassed while it's active.\n"
-                "  Remove Basic Auth first ([dim]hle basic-auth remove "
-                f"{subdomain}[/dim]) to re-enable SSO/PIN access control."
-            )
-            if not click.confirm("  Continue anyway?", default=False):
-                raise SystemExit(0)
-    except SystemExit:
-        raise
-    except Exception:
-        pass  # If the status check fails (network error etc.), proceed without warning
-
-
-async def _warn_if_pin_or_rules_exist(client: ApiClient, subdomain: str) -> None:
-    """Warn the user if PIN or email rules exist (Basic Auth will override them)."""
-    conflicts: list[str] = []
-    try:
-        pin = await client.get_tunnel_pin_status(subdomain)
-        if pin.get("has_pin"):
-            conflicts.append("an active PIN")
-    except Exception:
-        pass
-    try:
-        rules = await client.list_access_rules(subdomain)
-        if rules:
-            n = len(rules)
-            conflicts.append(f"{n} email rule{'s' if n > 1 else ''}")
-    except Exception:
-        pass
-    if conflicts:
-        conflict_str = " and ".join(conflicts)
-        console.print(
-            f"[yellow]Warning:[/yellow] [cyan]{subdomain}[/cyan] already has "
-            f"{conflict_str}.\n"
-            "  Enabling Basic Auth will [bold]override[/bold] "
-            f"{'them' if len(conflicts) > 1 else 'it'} — visitors will only be "
-            "able to authenticate with the Basic Auth username/password."
-        )
-        if not click.confirm("  Continue?", default=False):
-            raise SystemExit(0)
-
-
-# ---------------------------------------------------------------------------
-# hle access — manage tunnel access rules
-# ---------------------------------------------------------------------------
-
-
-@main.group()
-def access() -> None:
-    """Manage tunnel access control rules."""
-
-
-@access.command("list")
-@click.argument("subdomain")
-@click.option(
-    "--api-key",
-    default=None,
-    envvar="HLE_API_KEY",
-    help="API key for authentication",
-)
-def access_list(subdomain: str, api_key: str | None) -> None:
-    """List access rules for a subdomain."""
-    resolved_key = _resolve_api_key(api_key)
-
-    async def _run() -> None:
-        from hle_client.api import ApiClient, ApiClientConfig
-
-        client = ApiClient(ApiClientConfig(api_key=resolved_key))
-        try:
-            rules = await client.list_access_rules(subdomain)
-        except Exception as exc:
-            _handle_api_error(exc)
-            return
-
-        if not rules:
-            console.print(f"[dim]No access rules for {subdomain}.[/dim]")
-            return
-
-        table = Table(title=f"Access Rules — {subdomain}")
-        table.add_column("ID", style="dim")
-        table.add_column("Email", style="cyan")
-        table.add_column("Provider")
-        table.add_column("Created At", style="dim")
-        for r in rules:
-            table.add_row(
-                str(r.get("id", "")),
-                r.get("allowed_email", ""),
-                r.get("provider", ""),
-                r.get("created_at", ""),
-            )
-        console.print(table)
-
-    asyncio.run(_run())
-
-
-@access.command("add")
-@click.argument("subdomain")
-@click.argument("email")
-@click.option(
-    "--provider",
-    type=click.Choice(["any", "google", "github", "hle"]),
-    default="any",
-    show_default=True,
-    help="Required auth provider",
-)
-@click.option(
-    "--api-key",
-    default=None,
-    envvar="HLE_API_KEY",
-    help="API key for authentication",
-)
-def access_add(
-    subdomain: str,
-    email: str,
-    provider: str,
-    api_key: str | None,
-) -> None:
-    """Add an email to a subdomain's access allow-list."""
-    resolved_key = _resolve_api_key(api_key)
-
-    async def _run() -> None:
-        from hle_client.api import ApiClient, ApiClientConfig
-
-        client = ApiClient(ApiClientConfig(api_key=resolved_key))
-        await _warn_if_basic_auth_active(client, subdomain)
-        try:
-            rule = await client.add_access_rule(subdomain, email, provider)
-        except Exception as exc:
-            _handle_api_error(exc)
-            return
-
-        console.print(
-            f"[green]Added[/green] {rule.get('allowed_email', email)} "
-            f"(provider={rule.get('provider', provider)}) to {subdomain}"
-        )
-
-    asyncio.run(_run())
-
-
-@access.command("remove")
-@click.argument("subdomain")
-@click.argument("rule_id", type=int)
-@click.option(
-    "--api-key",
-    default=None,
-    envvar="HLE_API_KEY",
-    help="API key for authentication",
-)
-def access_remove(subdomain: str, rule_id: int, api_key: str | None) -> None:
-    """Remove an access rule by ID."""
-    resolved_key = _resolve_api_key(api_key)
-
-    async def _run() -> None:
-        from hle_client.api import ApiClient, ApiClientConfig
-
-        client = ApiClient(ApiClientConfig(api_key=resolved_key))
-        try:
-            await client.delete_access_rule(subdomain, rule_id)
-        except Exception as exc:
-            _handle_api_error(exc)
-            return
-
-        console.print(f"[green]Removed[/green] rule {rule_id} from {subdomain}")
-
-    asyncio.run(_run())
-
-
-# ---------------------------------------------------------------------------
-# hle pin — manage tunnel PIN access
-# ---------------------------------------------------------------------------
-
-
-@main.group()
-def pin() -> None:
-    """Manage tunnel PIN access control."""
-
-
-@pin.command("set")
-@click.argument("subdomain")
-@click.option(
-    "--api-key",
-    default=None,
-    envvar="HLE_API_KEY",
-    help="API key for authentication",
-)
-def pin_set(subdomain: str, api_key: str | None) -> None:
-    """Set a PIN for a subdomain (prompts for 4-8 digit PIN)."""
-    resolved_key = _resolve_api_key(api_key)
-
-    pin_value = click.prompt("Enter PIN (4-8 digits)", hide_input=True)
-    if not pin_value.isdigit() or not (4 <= len(pin_value) <= 8):
-        console.print("[red]Error:[/red] PIN must be 4-8 digits.")
-        raise SystemExit(1)
-
-    pin_confirm = click.prompt("Confirm PIN", hide_input=True)
-    if pin_value != pin_confirm:
-        console.print("[red]Error:[/red] PINs do not match.")
-        raise SystemExit(1)
-
-    async def _run() -> None:
-        from hle_client.api import ApiClient, ApiClientConfig
-
-        client = ApiClient(ApiClientConfig(api_key=resolved_key))
-        await _warn_if_basic_auth_active(client, subdomain)
-        try:
-            await client.set_tunnel_pin(subdomain, pin_value)
-        except Exception as exc:
-            _handle_api_error(exc)
-            return
-
-        console.print(f"[green]PIN set[/green] for {subdomain}")
-
-    asyncio.run(_run())
-
-
-@pin.command("remove")
-@click.argument("subdomain")
-@click.option(
-    "--api-key",
-    default=None,
-    envvar="HLE_API_KEY",
-    help="API key for authentication",
-)
-def pin_remove(subdomain: str, api_key: str | None) -> None:
-    """Remove the PIN for a subdomain."""
-    resolved_key = _resolve_api_key(api_key)
-
-    async def _run() -> None:
-        from hle_client.api import ApiClient, ApiClientConfig
-
-        client = ApiClient(ApiClientConfig(api_key=resolved_key))
-        try:
-            await client.remove_tunnel_pin(subdomain)
-        except Exception as exc:
-            _handle_api_error(exc)
-            return
-
-        console.print(f"[green]PIN removed[/green] from {subdomain}")
-
-    asyncio.run(_run())
-
-
-@pin.command("status")
-@click.argument("subdomain")
-@click.option(
-    "--api-key",
-    default=None,
-    envvar="HLE_API_KEY",
-    help="API key for authentication",
-)
-def pin_status(subdomain: str, api_key: str | None) -> None:
-    """Show PIN status for a subdomain."""
-    resolved_key = _resolve_api_key(api_key)
-
-    async def _run() -> None:
-        from hle_client.api import ApiClient, ApiClientConfig
-
-        client = ApiClient(ApiClientConfig(api_key=resolved_key))
-        try:
-            data = await client.get_tunnel_pin_status(subdomain)
-        except Exception as exc:
-            _handle_api_error(exc)
-            return
-
-        if data.get("has_pin"):
-            updated = data.get("updated_at", "")
-            console.print(f"[cyan]{subdomain}[/cyan]: PIN is [green]active[/green]")
-            if updated:
-                console.print(f"  Last updated: [dim]{updated}[/dim]")
-        else:
-            console.print(f"[cyan]{subdomain}[/cyan]: [dim]No PIN set[/dim]")
-
-    asyncio.run(_run())
-
-
-# ---------------------------------------------------------------------------
-# hle share — manage temporary share links
-# ---------------------------------------------------------------------------
-
-
-@main.group()
-def share() -> None:
-    """Manage temporary share links for tunnels."""
-
-
-@share.command("create")
-@click.argument("subdomain")
-@click.option(
-    "--duration",
-    type=click.Choice(["1h", "24h", "7d"]),
-    default="24h",
-    show_default=True,
-    help="Link validity duration",
-)
-@click.option("--label", default="", help="Optional label for the link")
-@click.option("--max-uses", default=None, type=int, help="Maximum number of uses")
-@click.option(
-    "--api-key",
-    default=None,
-    envvar="HLE_API_KEY",
-    help="API key for authentication",
-)
-def share_create(
-    subdomain: str,
-    duration: str,
-    label: str,
-    max_uses: int | None,
-    api_key: str | None,
-) -> None:
-    """Create a temporary share link for a tunnel."""
-    resolved_key = _resolve_api_key(api_key)
-
-    async def _run() -> None:
-        from hle_client.api import ApiClient, ApiClientConfig
-
-        client = ApiClient(ApiClientConfig(api_key=resolved_key))
-        try:
-            result = await client.create_share_link(subdomain, duration, label, max_uses)
-        except Exception as exc:
-            _handle_api_error(exc)
-            return
-
-        console.print()
-        console.print("[green bold]Share link created![/green bold]")
-        console.print()
-        console.print(f"  [cyan]{result['share_url']}[/cyan]")
-        console.print()
-        if result.get("link", {}).get("label"):
-            console.print(f"  Label:   {result['link']['label']}")
-        console.print(f"  Expires: {result['link']['expires_at']}")
-        if result["link"].get("max_uses"):
-            console.print(f"  Max uses: {result['link']['max_uses']}")
-        console.print()
-        console.print("[dim]This URL will not be shown again.[/dim]")
-
-    asyncio.run(_run())
-
-
-@share.command("list")
-@click.argument("subdomain")
-@click.option(
-    "--api-key",
-    default=None,
-    envvar="HLE_API_KEY",
-    help="API key for authentication",
-)
-def share_list(subdomain: str, api_key: str | None) -> None:
-    """List share links for a tunnel."""
-    resolved_key = _resolve_api_key(api_key)
-
-    async def _run() -> None:
-        from hle_client.api import ApiClient, ApiClientConfig
-
-        client = ApiClient(ApiClientConfig(api_key=resolved_key))
-        try:
-            links = await client.list_share_links(subdomain)
-        except Exception as exc:
-            _handle_api_error(exc)
-            return
-
-        if not links:
-            console.print(f"[dim]No share links for {subdomain}.[/dim]")
-            return
-
-        table = Table(title=f"Share Links — {subdomain}")
-        table.add_column("ID", style="dim")
-        table.add_column("Label")
-        table.add_column("Prefix", style="cyan")
-        table.add_column("Expires", style="dim")
-        table.add_column("Uses")
-        table.add_column("Status")
-        for link in links:
-            uses = str(link.get("use_count", 0))
-            if link.get("max_uses"):
-                uses += f"/{link['max_uses']}"
-            status = "[green]Active[/green]" if link.get("is_active") else "[red]Revoked[/red]"
-            table.add_row(
-                str(link.get("id", "")),
-                link.get("label", "") or "-",
-                link.get("token_prefix", ""),
-                link.get("expires_at", ""),
-                uses,
-                status,
-            )
-        console.print(table)
-
-    asyncio.run(_run())
-
-
-@share.command("revoke")
-@click.argument("subdomain")
-@click.argument("link_id", type=int)
-@click.option(
-    "--api-key",
-    default=None,
-    envvar="HLE_API_KEY",
-    help="API key for authentication",
-)
-def share_revoke(subdomain: str, link_id: int, api_key: str | None) -> None:
-    """Revoke a share link by ID."""
-    resolved_key = _resolve_api_key(api_key)
-
-    async def _run() -> None:
-        from hle_client.api import ApiClient, ApiClientConfig
-
-        client = ApiClient(ApiClientConfig(api_key=resolved_key))
-        try:
-            await client.delete_share_link(subdomain, link_id)
-        except Exception as exc:
-            _handle_api_error(exc)
-            return
-
-        console.print(f"[green]Revoked[/green] share link {link_id} from {subdomain}")
-
-    asyncio.run(_run())
-
-
-# ---------------------------------------------------------------------------
-# hle basic-auth — manage tunnel HTTP Basic Auth
-# ---------------------------------------------------------------------------
-
-
-@main.group("basic-auth")
-def basic_auth() -> None:
-    """Manage tunnel HTTP Basic Auth access control."""
-
-
-@basic_auth.command("set")
-@click.argument("subdomain")
-@click.option(
-    "--api-key",
-    default=None,
-    envvar="HLE_API_KEY",
-    help="API key for authentication",
-)
-def basic_auth_set(subdomain: str, api_key: str | None) -> None:
-    """Set HTTP Basic Auth credentials for a subdomain."""
-    resolved_key = _resolve_api_key(api_key)
-
-    username = click.prompt("Username")
-    if not username.strip():
-        console.print("[red]Error:[/red] Username cannot be empty.")
-        raise SystemExit(1)
-    if ":" in username:
-        console.print("[red]Error:[/red] Username must not contain ':'.")
-        raise SystemExit(1)
-
-    password = click.prompt("Password (min 8 chars)", hide_input=True)
-    if len(password) < 8:
-        console.print("[red]Error:[/red] Password must be at least 8 characters.")
-        raise SystemExit(1)
-
-    password_confirm = click.prompt("Confirm password", hide_input=True)
-    if password != password_confirm:
-        console.print("[red]Error:[/red] Passwords do not match.")
-        raise SystemExit(1)
-
-    async def _run() -> None:
-        from hle_client.api import ApiClient, ApiClientConfig
-
-        client = ApiClient(ApiClientConfig(api_key=resolved_key))
-        await _warn_if_pin_or_rules_exist(client, subdomain)
-        try:
-            await client.set_tunnel_basic_auth(subdomain, username.strip(), password)
-        except Exception as exc:
-            _handle_api_error(exc)
-            return
-
-        console.print(f"[green]Basic Auth set[/green] for {subdomain} (user: {username.strip()})")
-
-    asyncio.run(_run())
-
-
-@basic_auth.command("remove")
-@click.argument("subdomain")
-@click.option(
-    "--api-key",
-    default=None,
-    envvar="HLE_API_KEY",
-    help="API key for authentication",
-)
-def basic_auth_remove(subdomain: str, api_key: str | None) -> None:
-    """Remove HTTP Basic Auth from a subdomain."""
-    resolved_key = _resolve_api_key(api_key)
-
-    async def _run() -> None:
-        from hle_client.api import ApiClient, ApiClientConfig
-
-        client = ApiClient(ApiClientConfig(api_key=resolved_key))
-        try:
-            await client.remove_tunnel_basic_auth(subdomain)
-        except Exception as exc:
-            _handle_api_error(exc)
-            return
-
-        console.print(f"[green]Basic Auth removed[/green] from {subdomain}")
-
-    asyncio.run(_run())
-
-
-@basic_auth.command("status")
-@click.argument("subdomain")
-@click.option(
-    "--api-key",
-    default=None,
-    envvar="HLE_API_KEY",
-    help="API key for authentication",
-)
-def basic_auth_status(subdomain: str, api_key: str | None) -> None:
-    """Show HTTP Basic Auth status for a subdomain."""
-    resolved_key = _resolve_api_key(api_key)
-
-    async def _run() -> None:
-        from hle_client.api import ApiClient, ApiClientConfig
-
-        client = ApiClient(ApiClientConfig(api_key=resolved_key))
-        try:
-            data = await client.get_tunnel_basic_auth_status(subdomain)
-        except Exception as exc:
-            _handle_api_error(exc)
-            return
-
-        if data.get("enabled"):
-            updated = data.get("updated_at", "")
-            console.print(
-                f"[cyan]{subdomain}[/cyan]: Basic Auth is [green]active[/green] "
-                f"(user: [bold]{data.get('username', '')}[/bold])"
-            )
-            if updated:
-                console.print(f"  Last updated: [dim]{updated}[/dim]")
-        else:
-            console.print(f"[cyan]{subdomain}[/cyan]: [dim]No Basic Auth set[/dim]")
-
-    asyncio.run(_run())
-
-
-def _handle_api_error(exc: Exception) -> None:
-    """Map HTTP errors to user-friendly messages."""
-    import httpx
-
-    if isinstance(exc, httpx.HTTPStatusError):
-        status = exc.response.status_code
-        messages = {
-            401: "Invalid or missing API key.",
-            403: "You do not own this subdomain.",
-            404: "Resource not found.",
-            409: "Email already in access list.",
-        }
-        body = exc.response.text[:200] if exc.response.text else ""
-        msg = messages.get(status, f"Server error ({status}): {body}")
-        console.print(f"[red]Error:[/red] {msg}")
-    elif isinstance(exc, httpx.ConnectError):
-        console.print("[red]Error:[/red] Could not connect to relay server.")
-    else:
-        console.print(f"[red]Error:[/red] {exc}")
 
 
 main.add_command(config_group, name="config")

--- a/src/hle_client/config_cmd.py
+++ b/src/hle_client/config_cmd.py
@@ -1,18 +1,16 @@
 """Implementation of the ``hle config`` command group.
 
-Declarative tunnel configuration: read aggregate state, set ``auth_mode``,
-or reconcile access rules to a desired set. Designed for IaC / CI/CD use
-where the dashboard would otherwise be the only source of truth.
-
+All tunnel-scoped operations live here under a single declarative namespace.
 Subdomain resolution: callers supply a label (e.g. ``ha``) and the client
-resolves it to ``<label>-<user_code>`` via ``GET /api/auth/me``. Custom
-zone tunnels must be addressed by full subdomain.
+resolves it to ``<label>-<user_code>`` via ``GET /api/auth/me``. Pre-resolved
+subdomains (containing ``-``) are passed through unchanged.
 """
 
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING
+from collections.abc import Callable
+from typing import Any, TypeVar
 
 import click
 import httpx
@@ -21,30 +19,29 @@ from rich.table import Table
 
 from hle_client.api import ApiClient, ApiClientConfig
 
-if TYPE_CHECKING:
-    from collections.abc import Iterable
-
 console = Console()
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+_VALID_AUTH_PROVIDERS = {"any", "google", "github", "hle"}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
 
 def _parse_auth_spec(spec: str) -> tuple[str, str]:
-    """Parse ``[provider:]email`` into ``(provider, email)``.
-
-    Mirrors the helper in cli.py so config-cmd does not import from cli.
-    """
+    """Parse ``[provider:]email`` into ``(provider, email)``."""
     if ":" in spec:
         prefix, _, rest = spec.partition(":")
-        if prefix in {"any", "google", "github", "hle"}:
+        if prefix in _VALID_AUTH_PROVIDERS:
             return prefix, rest
     return "any", spec
 
 
 async def _resolve_subdomain(client: ApiClient, label: str) -> str:
-    """Resolve ``label`` to ``<label>-<user_code>`` via the /me endpoint.
-
-    Pre-resolved subdomains (those containing a ``-``) are returned as-is so
-    custom zone tunnels work transparently.
-    """
+    """Resolve ``label`` → ``<label>-<user_code>``. Pass through if already resolved."""
     if "-" in label:
         return label
     me = await client.get_me()
@@ -54,8 +51,115 @@ async def _resolve_subdomain(client: ApiClient, label: str) -> str:
     return f"{label}-{user_code}"
 
 
-def _print_status(status: dict) -> None:
-    """Render the aggregated tunnel-status payload."""
+def _require_key(api_key: str | None) -> str:
+    from hle_client.tunnel import _load_api_key
+
+    resolved = api_key or _load_api_key()
+    if not resolved:
+        raise click.ClickException(
+            "No API key found. Run 'hle auth login', set HLE_API_KEY, or pass --api-key."
+        )
+    return resolved
+
+
+def _client(api_key: str | None) -> ApiClient:
+    return ApiClient(ApiClientConfig(api_key=_require_key(api_key)))
+
+
+def _die_http(exc: httpx.HTTPStatusError, subdomain: str | None = None) -> None:
+    code = exc.response.status_code
+    if code == 401:
+        raise click.ClickException("Invalid or missing API key.") from None
+    if code == 403:
+        raise click.ClickException(
+            f"You do not own {subdomain!r}." if subdomain else "Forbidden."
+        ) from None
+    if code == 404:
+        raise click.ClickException(
+            f"Tunnel {subdomain!r} not found." if subdomain else "Resource not found."
+        ) from None
+    if code == 409:
+        raise click.ClickException("Email already in access list.") from None
+    if code == 429:
+        raise click.ClickException("Rate limited — try again shortly.") from None
+    raise click.ClickException(f"Server returned {code}: {exc.response.text[:200]}") from None
+
+
+def _handle_exc(exc: Exception, subdomain: str | None = None) -> None:
+    if isinstance(exc, httpx.HTTPStatusError):
+        _die_http(exc, subdomain)
+    if isinstance(exc, httpx.ConnectError):
+        raise click.ClickException("Could not connect to relay server.") from None
+    raise click.ClickException(str(exc)) from None
+
+
+def _api_key_option(f: F) -> F:
+    return click.option(
+        "--api-key",
+        default=None,
+        envvar="HLE_API_KEY",
+        help="API key for authentication",
+    )(f)
+
+
+# ---------------------------------------------------------------------------
+# Conflict warnings (gate types are mutually exclusive)
+# ---------------------------------------------------------------------------
+
+
+async def _warn_if_basic_auth_active(client: ApiClient, subdomain: str) -> None:
+    try:
+        data = await client.get_tunnel_basic_auth_status(subdomain)
+    except Exception:
+        return
+    if not data.get("enabled"):
+        return
+    console.print(
+        f"[yellow]Warning:[/yellow] Basic Auth is currently active on "
+        f"[cyan]{subdomain}[/cyan].\n"
+        "  Email rules and PIN are bypassed while it's active.\n"
+        "  Remove Basic Auth first ([dim]hle config basic-auth remove "
+        f"{subdomain}[/dim]) to re-enable SSO/PIN access control."
+    )
+    if not click.confirm("  Continue anyway?", default=False):
+        raise SystemExit(0)
+
+
+async def _warn_if_pin_or_rules_exist(client: ApiClient, subdomain: str) -> None:
+    conflicts: list[str] = []
+    try:
+        pin = await client.get_tunnel_pin_status(subdomain)
+        if pin.get("has_pin"):
+            conflicts.append("an active PIN")
+    except Exception:
+        pass
+    try:
+        rules = await client.list_access_rules(subdomain)
+        if rules:
+            n = len(rules)
+            conflicts.append(f"{n} email rule{'s' if n > 1 else ''}")
+    except Exception:
+        pass
+    if not conflicts:
+        return
+    conflict_str = " and ".join(conflicts)
+    console.print(
+        f"[yellow]Warning:[/yellow] [cyan]{subdomain}[/cyan] already has "
+        f"{conflict_str}.\n"
+        "  Enabling Basic Auth will [bold]override[/bold] "
+        f"{'them' if len(conflicts) > 1 else 'it'} — visitors will only be "
+        "able to authenticate with the Basic Auth username/password."
+    )
+    if not click.confirm("  Continue?", default=False):
+        raise SystemExit(0)
+
+
+# ---------------------------------------------------------------------------
+# Status rendering
+# ---------------------------------------------------------------------------
+
+
+def _print_status(status: dict[str, Any]) -> None:
     table = Table(show_header=False, box=None, padding=(0, 1))
     table.add_column(style="dim")
     table.add_column()
@@ -66,8 +170,6 @@ def _print_status(status: dict) -> None:
     table.add_row("Auth mode", status["auth_mode"])
     if status.get("webhook_path"):
         table.add_row("Webhook path", status["webhook_path"])
-    if status.get("zone"):
-        table.add_row("Zone", status["zone"])
     if status.get("client_version"):
         table.add_row("Client", status["client_version"])
 
@@ -96,31 +198,70 @@ def _print_status(status: dict) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Click command group
+# Top-level config group
 # ---------------------------------------------------------------------------
 
 
 @click.group()
 def config() -> None:
-    """Declarative tunnel configuration (auth mode, access rules, etc.)."""
+    """Configure tunnels (auth mode, access, pin, basic-auth, share)."""
+
+
+# ---- show / list ----------------------------------------------------------
 
 
 @config.command("show")
 @click.argument("label")
-@click.option("--api-key", default=None, help="Override the configured API key")
-def show(label: str, api_key: str | None) -> None:
+@_api_key_option
+def show_cmd(label: str, api_key: str | None) -> None:
     """Show full configuration and live state for a tunnel."""
-    asyncio.run(_show_async(label, api_key))
+
+    async def _run() -> None:
+        api = _client(api_key)
+        subdomain = await _resolve_subdomain(api, label)
+        try:
+            status = await api.get_tunnel_status(subdomain)
+        except Exception as exc:
+            _handle_exc(exc, subdomain)
+        _print_status(status)
+
+    asyncio.run(_run())
 
 
-async def _show_async(label: str, api_key: str | None) -> None:
-    api = ApiClient(ApiClientConfig(api_key=_require_key(api_key)))
-    subdomain = await _resolve_subdomain(api, label)
-    try:
-        status = await api.get_tunnel_status(subdomain)
-    except httpx.HTTPStatusError as exc:
-        _die_http(exc, subdomain)
-    _print_status(status)
+@config.command("list")
+@_api_key_option
+def list_cmd(api_key: str | None) -> None:
+    """List active tunnels for your account."""
+
+    async def _run() -> None:
+        api = _client(api_key)
+        try:
+            tunnel_list = await api.list_tunnels()
+        except Exception as exc:
+            _handle_exc(exc)
+
+        if not tunnel_list:
+            console.print("[dim]No active tunnels.[/dim]")
+            return
+
+        table = Table(title="Active Tunnels")
+        table.add_column("Subdomain", style="cyan")
+        table.add_column("Service URL")
+        table.add_column("WebSocket")
+        table.add_column("Connected At", style="dim")
+        for t in tunnel_list:
+            table.add_row(
+                t.get("subdomain", ""),
+                t.get("service_url", ""),
+                "yes" if t.get("websocket_enabled") else "no",
+                t.get("connected_at", ""),
+            )
+        console.print(table)
+
+    asyncio.run(_run())
+
+
+# ---- auth-mode ------------------------------------------------------------
 
 
 @config.command("auth-mode")
@@ -132,133 +273,473 @@ async def _show_async(label: str, api_key: str | None) -> None:
     required=True,
     help="Auth mode to apply",
 )
-@click.option("--api-key", default=None, help="Override the configured API key")
-def auth_mode(label: str, mode: str, api_key: str | None) -> None:
-    """Set the SSO gate mode for a tunnel.
+@_api_key_option
+def auth_mode_cmd(label: str, mode: str, api_key: str | None) -> None:
+    """Set the SSO gate mode for a tunnel."""
 
-    Webhook tunnels are always public — the server rejects ``--set sso`` for
-    them. The tunnel must have been registered at least once (``hle expose``)
-    before its auth_mode can be changed.
-    """
-    asyncio.run(_auth_mode_async(label, mode, api_key))
-
-
-async def _auth_mode_async(label: str, mode: str, api_key: str | None) -> None:
-    api = ApiClient(ApiClientConfig(api_key=_require_key(api_key)))
-    subdomain = await _resolve_subdomain(api, label)
-    try:
-        await api.set_tunnel_auth_mode(subdomain, mode)
-    except httpx.HTTPStatusError as exc:
-        if exc.response.status_code == 404:
-            raise click.ClickException(
-                f"Tunnel {subdomain!r} has never been registered. "
-                "Run 'hle expose' once to create it, then re-run this command."
-            ) from None
-        if exc.response.status_code == 400 and b"Webhook" in exc.response.content:
-            raise click.ClickException(
-                "Webhook tunnels are always public — auth_mode cannot be changed."
-            ) from None
-        _die_http(exc, subdomain)
-    console.print(f"[green]✓[/green] {subdomain} auth_mode = {mode}")
-
-
-@config.command("access")
-@click.argument("label")
-@click.option(
-    "--replace",
-    "replace_specs",
-    multiple=True,
-    metavar="[PROVIDER:]EMAIL",
-    help="Reconcile rules to exactly this set (repeatable). Adds missing rules and removes extras.",
-)
-@click.option("--api-key", default=None, help="Override the configured API key")
-def access(label: str, replace_specs: tuple[str, ...], api_key: str | None) -> None:
-    """Reconcile a tunnel's access allow-list to a desired set.
-
-    Unlike ``hle expose --allow``, which only adds rules, ``--replace`` is
-    declarative: rules in the server but not in the flags are removed.
-    """
-    if not replace_specs:
-        raise click.ClickException(
-            "At least one --replace flag is required. "
-            "Pass --replace '' explicitly to clear all rules."
-        )
-    asyncio.run(_access_async(label, replace_specs, api_key))
-
-
-async def _access_async(label: str, replace_specs: tuple[str, ...], api_key: str | None) -> None:
-    api = ApiClient(ApiClientConfig(api_key=_require_key(api_key)))
-    subdomain = await _resolve_subdomain(api, label)
-
-    desired: set[tuple[str, str]] = set()
-    for spec in replace_specs:
-        if not spec:
-            continue
-        provider, email = _parse_auth_spec(spec)
-        desired.add((email.lower(), provider))
-
-    try:
-        existing = await api.list_access_rules(subdomain)
-    except httpx.HTTPStatusError as exc:
-        _die_http(exc, subdomain)
-
-    existing_by_key = {(r["allowed_email"].lower(), r["provider"]): r["id"] for r in existing}
-    existing_keys = set(existing_by_key.keys())
-
-    to_add = desired - existing_keys
-    to_remove = existing_keys - desired
-
-    for email, provider in sorted(to_add):
+    async def _run() -> None:
+        api = _client(api_key)
+        subdomain = await _resolve_subdomain(api, label)
         try:
-            await api.add_access_rule(subdomain, email, provider)
-            console.print(f"  [green]+[/green] {email} ({provider})")
+            await api.set_tunnel_auth_mode(subdomain, mode)
         except httpx.HTTPStatusError as exc:
-            console.print(f"  [yellow]! {email} failed: {exc.response.status_code}[/yellow]")
+            if exc.response.status_code == 404:
+                raise click.ClickException(
+                    f"Tunnel {subdomain!r} has never been registered. "
+                    "Run 'hle expose' once to create it, then re-run this command."
+                ) from None
+            if exc.response.status_code == 400 and b"Webhook" in exc.response.content:
+                raise click.ClickException(
+                    "Webhook tunnels are always public — auth_mode cannot be changed."
+                ) from None
+            _die_http(exc, subdomain)
+        console.print(f"[green]✓[/green] {subdomain} auth_mode = {mode}")
 
-    for key in sorted(to_remove):
-        rule_id = existing_by_key[key]
+    asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# access subgroup
+# ---------------------------------------------------------------------------
+
+
+@config.group("access")
+def access_grp() -> None:
+    """Manage tunnel access allow-list (SSO email rules)."""
+
+
+@access_grp.command("list")
+@click.argument("label")
+@_api_key_option
+def access_list(label: str, api_key: str | None) -> None:
+    """List access rules for a tunnel."""
+
+    async def _run() -> None:
+        api = _client(api_key)
+        subdomain = await _resolve_subdomain(api, label)
+        try:
+            rules = await api.list_access_rules(subdomain)
+        except Exception as exc:
+            _handle_exc(exc, subdomain)
+
+        if not rules:
+            console.print(f"[dim]No access rules for {subdomain}.[/dim]")
+            return
+
+        table = Table(title=f"Access Rules — {subdomain}")
+        table.add_column("ID", style="dim")
+        table.add_column("Email", style="cyan")
+        table.add_column("Provider")
+        table.add_column("Created At", style="dim")
+        for r in rules:
+            table.add_row(
+                str(r.get("id", "")),
+                r.get("allowed_email", ""),
+                r.get("provider", ""),
+                r.get("created_at", ""),
+            )
+        console.print(table)
+
+    asyncio.run(_run())
+
+
+@access_grp.command("add")
+@click.argument("label")
+@click.argument("email")
+@click.option(
+    "--provider",
+    type=click.Choice(["any", "google", "github", "hle"]),
+    default="any",
+    show_default=True,
+    help="Required auth provider",
+)
+@_api_key_option
+def access_add(label: str, email: str, provider: str, api_key: str | None) -> None:
+    """Add an email to a tunnel's access allow-list."""
+
+    async def _run() -> None:
+        api = _client(api_key)
+        subdomain = await _resolve_subdomain(api, label)
+        await _warn_if_basic_auth_active(api, subdomain)
+        try:
+            rule = await api.add_access_rule(subdomain, email, provider)
+        except Exception as exc:
+            _handle_exc(exc, subdomain)
+        console.print(
+            f"[green]Added[/green] {rule.get('allowed_email', email)} "
+            f"(provider={rule.get('provider', provider)}) to {subdomain}"
+        )
+
+    asyncio.run(_run())
+
+
+@access_grp.command("remove")
+@click.argument("label")
+@click.argument("rule_id", type=int)
+@_api_key_option
+def access_remove(label: str, rule_id: int, api_key: str | None) -> None:
+    """Remove an access rule by ID."""
+
+    async def _run() -> None:
+        api = _client(api_key)
+        subdomain = await _resolve_subdomain(api, label)
         try:
             await api.delete_access_rule(subdomain, rule_id)
-            console.print(f"  [red]-[/red] {key[0]} ({key[1]})")
-        except httpx.HTTPStatusError as exc:
+        except Exception as exc:
+            _handle_exc(exc, subdomain)
+        console.print(f"[green]Removed[/green] rule {rule_id} from {subdomain}")
+
+    asyncio.run(_run())
+
+
+@access_grp.command("replace")
+@click.argument("label")
+@click.argument("specs", nargs=-1)
+@click.option("--clear", "do_clear", is_flag=True, help="Remove all rules (no specs allowed)")
+@_api_key_option
+def access_replace(
+    label: str,
+    specs: tuple[str, ...],
+    do_clear: bool,
+    api_key: str | None,
+) -> None:
+    """Reconcile a tunnel's access allow-list to exactly SPECS.
+
+    Adds missing rules and removes extras. Use --clear to remove all rules.
+
+    Example:
+
+        hle config access replace ha google:alice@x.com github:bob@y.com
+    """
+    if do_clear and specs:
+        raise click.ClickException("Pass either SPECS or --clear, not both.")
+    if not specs and not do_clear:
+        raise click.ClickException(
+            "At least one spec is required, or pass --clear to remove all rules."
+        )
+
+    async def _run() -> None:
+        api = _client(api_key)
+        subdomain = await _resolve_subdomain(api, label)
+
+        desired: set[tuple[str, str]] = set()
+        for spec in specs:
+            if not spec:
+                continue
+            provider, email = _parse_auth_spec(spec)
+            desired.add((email.lower(), provider))
+
+        try:
+            existing = await api.list_access_rules(subdomain)
+        except Exception as exc:
+            _handle_exc(exc, subdomain)
+
+        existing_by_key = {(r["allowed_email"].lower(), r["provider"]): r["id"] for r in existing}
+        existing_keys = set(existing_by_key.keys())
+
+        to_add = desired - existing_keys
+        to_remove = existing_keys - desired
+
+        for email, provider in sorted(to_add):
+            try:
+                await api.add_access_rule(subdomain, email, provider)
+                console.print(f"  [green]+[/green] {email} ({provider})")
+            except httpx.HTTPStatusError as exc:
+                console.print(f"  [yellow]! {email} failed: {exc.response.status_code}[/yellow]")
+
+        for key in sorted(to_remove):
+            rule_id = existing_by_key[key]
+            try:
+                await api.delete_access_rule(subdomain, rule_id)
+                console.print(f"  [red]-[/red] {key[0]} ({key[1]})")
+            except httpx.HTTPStatusError as exc:
+                console.print(
+                    f"  [yellow]! remove {key[0]} failed: {exc.response.status_code}[/yellow]"
+                )
+
+        if not to_add and not to_remove:
             console.print(
-                f"  [yellow]! remove {key[0]} failed: {exc.response.status_code}[/yellow]"
+                f"[dim]{subdomain} access rules already in sync ({len(desired)} rule(s))[/dim]"
             )
 
-    if not to_add and not to_remove:
-        console.print(
-            f"[dim]{subdomain} access rules already in sync ({len(desired)} rule(s))[/dim]"
-        )
+    asyncio.run(_run())
 
 
 # ---------------------------------------------------------------------------
-# Helpers
+# pin subgroup
 # ---------------------------------------------------------------------------
 
 
-def _require_key(api_key: str | None) -> str:
-    """Return the resolved API key or raise a click error."""
-    from hle_client.tunnel import _load_api_key
-
-    resolved = api_key or _load_api_key()
-    if not resolved:
-        raise click.ClickException(
-            "No API key found. Run 'hle auth login', set HLE_API_KEY, or pass --api-key."
-        )
-    return resolved
+@config.group("pin")
+def pin_grp() -> None:
+    """Manage tunnel PIN access control."""
 
 
-def _die_http(exc: httpx.HTTPStatusError, subdomain: str) -> None:
-    code = exc.response.status_code
-    if code == 403:
-        raise click.ClickException(f"You do not own {subdomain!r}.") from None
-    if code == 404:
-        raise click.ClickException(f"Tunnel {subdomain!r} not found.") from None
-    if code == 429:
-        raise click.ClickException("Rate limited — try again shortly.") from None
-    raise click.ClickException(f"Server returned {code}: {exc.response.text}") from None
+@pin_grp.command("set")
+@click.argument("label")
+@_api_key_option
+def pin_set(label: str, api_key: str | None) -> None:
+    """Set a PIN for a tunnel (prompts for 4-8 digit PIN)."""
+    pin_value = click.prompt("Enter PIN (4-8 digits)", hide_input=True)
+    if not pin_value.isdigit() or not (4 <= len(pin_value) <= 8):
+        raise click.ClickException("PIN must be 4-8 digits.")
+    pin_confirm = click.prompt("Confirm PIN", hide_input=True)
+    if pin_value != pin_confirm:
+        raise click.ClickException("PINs do not match.")
+
+    async def _run() -> None:
+        api = _client(api_key)
+        subdomain = await _resolve_subdomain(api, label)
+        await _warn_if_basic_auth_active(api, subdomain)
+        try:
+            await api.set_tunnel_pin(subdomain, pin_value)
+        except Exception as exc:
+            _handle_exc(exc, subdomain)
+        console.print(f"[green]PIN set[/green] for {subdomain}")
+
+    asyncio.run(_run())
 
 
-def _all_commands() -> Iterable[click.Command]:
-    """Iterate the commands so cli.py can attach the group cleanly."""
-    return (config,)
+@pin_grp.command("remove")
+@click.argument("label")
+@_api_key_option
+def pin_remove(label: str, api_key: str | None) -> None:
+    """Remove the PIN for a tunnel."""
+
+    async def _run() -> None:
+        api = _client(api_key)
+        subdomain = await _resolve_subdomain(api, label)
+        try:
+            await api.remove_tunnel_pin(subdomain)
+        except Exception as exc:
+            _handle_exc(exc, subdomain)
+        console.print(f"[green]PIN removed[/green] from {subdomain}")
+
+    asyncio.run(_run())
+
+
+@pin_grp.command("status")
+@click.argument("label")
+@_api_key_option
+def pin_status(label: str, api_key: str | None) -> None:
+    """Show PIN status for a tunnel."""
+
+    async def _run() -> None:
+        api = _client(api_key)
+        subdomain = await _resolve_subdomain(api, label)
+        try:
+            data = await api.get_tunnel_pin_status(subdomain)
+        except Exception as exc:
+            _handle_exc(exc, subdomain)
+        if data.get("has_pin"):
+            updated = data.get("updated_at", "")
+            console.print(f"[cyan]{subdomain}[/cyan]: PIN is [green]active[/green]")
+            if updated:
+                console.print(f"  Last updated: [dim]{updated}[/dim]")
+        else:
+            console.print(f"[cyan]{subdomain}[/cyan]: [dim]No PIN set[/dim]")
+
+    asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# basic-auth subgroup
+# ---------------------------------------------------------------------------
+
+
+@config.group("basic-auth")
+def basic_auth_grp() -> None:
+    """Manage tunnel HTTP Basic Auth access control."""
+
+
+@basic_auth_grp.command("set")
+@click.argument("label")
+@_api_key_option
+def basic_auth_set(label: str, api_key: str | None) -> None:
+    """Set HTTP Basic Auth credentials for a tunnel."""
+    username = click.prompt("Username")
+    if not username.strip():
+        raise click.ClickException("Username cannot be empty.")
+    if ":" in username:
+        raise click.ClickException("Username must not contain ':'.")
+
+    password = click.prompt("Password (min 8 chars)", hide_input=True)
+    if len(password) < 8:
+        raise click.ClickException("Password must be at least 8 characters.")
+    password_confirm = click.prompt("Confirm password", hide_input=True)
+    if password != password_confirm:
+        raise click.ClickException("Passwords do not match.")
+
+    async def _run() -> None:
+        api = _client(api_key)
+        subdomain = await _resolve_subdomain(api, label)
+        await _warn_if_pin_or_rules_exist(api, subdomain)
+        try:
+            await api.set_tunnel_basic_auth(subdomain, username.strip(), password)
+        except Exception as exc:
+            _handle_exc(exc, subdomain)
+        console.print(f"[green]Basic Auth set[/green] for {subdomain} (user: {username.strip()})")
+
+    asyncio.run(_run())
+
+
+@basic_auth_grp.command("remove")
+@click.argument("label")
+@_api_key_option
+def basic_auth_remove(label: str, api_key: str | None) -> None:
+    """Remove HTTP Basic Auth from a tunnel."""
+
+    async def _run() -> None:
+        api = _client(api_key)
+        subdomain = await _resolve_subdomain(api, label)
+        try:
+            await api.remove_tunnel_basic_auth(subdomain)
+        except Exception as exc:
+            _handle_exc(exc, subdomain)
+        console.print(f"[green]Basic Auth removed[/green] from {subdomain}")
+
+    asyncio.run(_run())
+
+
+@basic_auth_grp.command("status")
+@click.argument("label")
+@_api_key_option
+def basic_auth_status(label: str, api_key: str | None) -> None:
+    """Show HTTP Basic Auth status for a tunnel."""
+
+    async def _run() -> None:
+        api = _client(api_key)
+        subdomain = await _resolve_subdomain(api, label)
+        try:
+            data = await api.get_tunnel_basic_auth_status(subdomain)
+        except Exception as exc:
+            _handle_exc(exc, subdomain)
+        if data.get("enabled"):
+            updated = data.get("updated_at", "")
+            console.print(
+                f"[cyan]{subdomain}[/cyan]: Basic Auth is [green]active[/green] "
+                f"(user: [bold]{data.get('username', '')}[/bold])"
+            )
+            if updated:
+                console.print(f"  Last updated: [dim]{updated}[/dim]")
+        else:
+            console.print(f"[cyan]{subdomain}[/cyan]: [dim]No Basic Auth set[/dim]")
+
+    asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# share subgroup
+# ---------------------------------------------------------------------------
+
+
+@config.group("share")
+def share_grp() -> None:
+    """Manage temporary share links for a tunnel."""
+
+
+@share_grp.command("create")
+@click.argument("label")
+@click.option(
+    "--duration",
+    type=click.Choice(["1h", "24h", "7d"]),
+    default="24h",
+    show_default=True,
+    help="Link validity duration",
+)
+@click.option("--label", "link_label", default="", help="Optional label for the link")
+@click.option("--max-uses", default=None, type=int, help="Maximum number of uses")
+@_api_key_option
+def share_create(
+    label: str,
+    duration: str,
+    link_label: str,
+    max_uses: int | None,
+    api_key: str | None,
+) -> None:
+    """Create a temporary share link for a tunnel."""
+
+    async def _run() -> None:
+        api = _client(api_key)
+        subdomain = await _resolve_subdomain(api, label)
+        try:
+            result = await api.create_share_link(subdomain, duration, link_label, max_uses)
+        except Exception as exc:
+            _handle_exc(exc, subdomain)
+
+        console.print()
+        console.print("[green bold]Share link created![/green bold]")
+        console.print()
+        console.print(f"  [cyan]{result['share_url']}[/cyan]")
+        console.print()
+        if result.get("link", {}).get("label"):
+            console.print(f"  Label:   {result['link']['label']}")
+        console.print(f"  Expires: {result['link']['expires_at']}")
+        if result["link"].get("max_uses"):
+            console.print(f"  Max uses: {result['link']['max_uses']}")
+        console.print()
+        console.print("[dim]This URL will not be shown again.[/dim]")
+
+    asyncio.run(_run())
+
+
+@share_grp.command("list")
+@click.argument("label")
+@_api_key_option
+def share_list(label: str, api_key: str | None) -> None:
+    """List share links for a tunnel."""
+
+    async def _run() -> None:
+        api = _client(api_key)
+        subdomain = await _resolve_subdomain(api, label)
+        try:
+            links = await api.list_share_links(subdomain)
+        except Exception as exc:
+            _handle_exc(exc, subdomain)
+
+        if not links:
+            console.print(f"[dim]No share links for {subdomain}.[/dim]")
+            return
+
+        table = Table(title=f"Share Links — {subdomain}")
+        table.add_column("ID", style="dim")
+        table.add_column("Label")
+        table.add_column("Prefix", style="cyan")
+        table.add_column("Expires", style="dim")
+        table.add_column("Uses")
+        table.add_column("Status")
+        for link in links:
+            uses = str(link.get("use_count", 0))
+            if link.get("max_uses"):
+                uses += f"/{link['max_uses']}"
+            status = "[green]Active[/green]" if link.get("is_active") else "[red]Revoked[/red]"
+            table.add_row(
+                str(link.get("id", "")),
+                link.get("label", "") or "-",
+                link.get("token_prefix", ""),
+                link.get("expires_at", ""),
+                uses,
+                status,
+            )
+        console.print(table)
+
+    asyncio.run(_run())
+
+
+@share_grp.command("revoke")
+@click.argument("label")
+@click.argument("link_id", type=int)
+@_api_key_option
+def share_revoke(label: str, link_id: int, api_key: str | None) -> None:
+    """Revoke a share link by ID."""
+
+    async def _run() -> None:
+        api = _client(api_key)
+        subdomain = await _resolve_subdomain(api, label)
+        try:
+            await api.delete_share_link(subdomain, link_id)
+        except Exception as exc:
+            _handle_exc(exc, subdomain)
+        console.print(f"[green]Revoked[/green] share link {link_id} from {subdomain}")
+
+    asyncio.run(_run())

--- a/src/hle_client/tunnel.py
+++ b/src/hle_client/tunnel.py
@@ -134,72 +134,6 @@ def _remove_api_key() -> bool:
         return False
 
 
-def _load_zone() -> str | None:
-    """Load zone from the config file, if it exists."""
-    if not _CONFIG_FILE.exists():
-        return None
-    try:
-        import tomllib
-
-        with open(_CONFIG_FILE, "rb") as f:
-            data = tomllib.load(f)
-        return data.get("zone")
-    except Exception:
-        logger.debug("Failed to load zone from %s", _CONFIG_FILE)
-        return None
-
-
-def _save_zone(zone: str) -> None:
-    """Persist zone to the config file."""
-    try:
-        _CONFIG_DIR.mkdir(parents=True, exist_ok=True, mode=0o700)
-
-        existing_lines: list[str] = []
-        found = False
-        if _CONFIG_FILE.exists():
-            with open(_CONFIG_FILE) as f:
-                for line in f:
-                    if line.startswith("zone"):
-                        existing_lines.append(f'zone = "{zone}"\n')
-                        found = True
-                    else:
-                        existing_lines.append(line)
-
-        if not found:
-            existing_lines.append(f'zone = "{zone}"\n')
-
-        fd = os.open(_CONFIG_FILE, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-        with os.fdopen(fd, "w") as f:
-            f.writelines(existing_lines)
-
-        logger.info("Zone saved to %s", _CONFIG_FILE)
-    except Exception:
-        logger.warning("Failed to save zone to %s", _CONFIG_FILE, exc_info=True)
-
-
-def _remove_zone() -> bool:
-    """Remove zone from the config file. Returns True if a zone was removed."""
-    if not _CONFIG_FILE.exists():
-        return False
-    try:
-        with open(_CONFIG_FILE) as f:
-            lines = f.readlines()
-
-        new_lines = [line for line in lines if not line.startswith("zone")]
-        if len(new_lines) == len(lines):
-            return False
-
-        fd = os.open(_CONFIG_FILE, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-        with os.fdopen(fd, "w") as f:
-            f.writelines(new_lines)
-
-        logger.info("Zone removed from %s", _CONFIG_FILE)
-        return True
-    except Exception:
-        logger.warning("Failed to remove zone from %s", _CONFIG_FILE, exc_info=True)
-        return False
-
-
 @dataclass
 class TunnelConfig:
     """Configuration for a tunnel connection."""
@@ -218,8 +152,6 @@ class TunnelConfig:
     """Optional (username, password) injected as Authorization: Basic toward the local service."""
     forward_host: bool = False
     """Forward the browser's Host header instead of using the target hostname."""
-    zone: str | None = None
-    """Custom zone domain for enterprise tunnel routing (e.g. 'project1.t00t.us')."""
     managed_by: str | None = None
     """Identifier for the system managing this tunnel (e.g. 'hle-operator')."""
     webhook_path: str | None = None
@@ -420,7 +352,6 @@ class Tunnel:
                 websocket_enabled=self.config.websocket_enabled,
                 auth_mode=self.config.auth_mode,
                 capabilities=[CAPABILITY_CHUNKED_RESPONSE],
-                zone=self.config.zone,
                 managed_by=self.config.managed_by,
                 webhook_path=self.config.webhook_path,
             )

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -58,9 +58,7 @@ class TestConfigAccessList:
         mock_client = AsyncMock()
         mock_client.list_access_rules = AsyncMock(return_value=[])
         with _patch_key(), _patch_client(mock_client):
-            result = runner.invoke(
-                main, ["config", "access", "list", "app-x7k", "--api-key", _KEY]
-            )
+            result = runner.invoke(main, ["config", "access", "list", "app-x7k", "--api-key", _KEY])
         assert result.exit_code == 0
         assert "No access rules" in result.output
 
@@ -77,9 +75,7 @@ class TestConfigAccessList:
         mock_client = AsyncMock()
         mock_client.list_access_rules = AsyncMock(return_value=rules)
         with _patch_key(), _patch_client(mock_client):
-            result = runner.invoke(
-                main, ["config", "access", "list", "app-x7k", "--api-key", _KEY]
-            )
+            result = runner.invoke(main, ["config", "access", "list", "app-x7k", "--api-key", _KEY])
         assert result.exit_code == 0
         assert "friend@example.com" in result.output
 
@@ -182,9 +178,7 @@ class TestConfigShareList:
         mock_client = AsyncMock()
         mock_client.list_share_links = AsyncMock(return_value=[])
         with _patch_key(), _patch_client(mock_client):
-            result = runner.invoke(
-                main, ["config", "share", "list", "app-x7k", "--api-key", _KEY]
-            )
+            result = runner.invoke(main, ["config", "share", "list", "app-x7k", "--api-key", _KEY])
         assert result.exit_code == 0
         assert "No share links" in result.output
 
@@ -204,9 +198,7 @@ class TestConfigShareList:
         mock_client = AsyncMock()
         mock_client.list_share_links = AsyncMock(return_value=links)
         with _patch_key(), _patch_client(mock_client):
-            result = runner.invoke(
-                main, ["config", "share", "list", "app-x7k", "--api-key", _KEY]
-            )
+            result = runner.invoke(main, ["config", "share", "list", "app-x7k", "--api-key", _KEY])
         assert result.exit_code == 0
         assert "abc12345" in result.output
         assert "for bob" in result.output
@@ -353,9 +345,7 @@ class TestErrorHandling:
             side_effect=httpx.HTTPStatusError("403", request=mock_resp.request, response=mock_resp)
         )
         with _patch_key(), _patch_client(mock_client):
-            result = runner.invoke(
-                main, ["config", "access", "list", "x-abc", "--api-key", _KEY]
-            )
+            result = runner.invoke(main, ["config", "access", "list", "x-abc", "--api-key", _KEY])
         assert result.exit_code != 0
         assert "do not own" in result.output
 

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -1,4 +1,4 @@
-"""Unit tests for hle_client.cli commands (access, tunnels)."""
+"""Unit tests for hle_client.cli commands (auth, expose) and config subcommands."""
 
 from __future__ import annotations
 
@@ -12,19 +12,29 @@ from click.testing import CliRunner
 
 from hle_client.cli import main
 
+_KEY = "hle_" + "a" * 32
 
-class TestTunnelsCommand:
-    def test_tunnels_empty(self) -> None:
+
+def _patch_client(mock_client: AsyncMock):
+    """Patch the ApiClient used inside config_cmd (where the runtime import resolves)."""
+    return patch("hle_client.config_cmd.ApiClient", return_value=mock_client)
+
+
+def _patch_key():
+    return patch("hle_client.config_cmd._require_key", return_value=_KEY)
+
+
+class TestConfigList:
+    def test_list_empty(self) -> None:
         runner = CliRunner()
-        with patch("hle_client.cli._resolve_api_key", return_value="hle_" + "a" * 32):
-            mock_client = AsyncMock()
-            mock_client.list_tunnels = AsyncMock(return_value=[])
-            with patch("hle_client.api.ApiClient", return_value=mock_client):
-                result = runner.invoke(main, ["tunnels", "--api-key", "hle_" + "a" * 32])
+        mock_client = AsyncMock()
+        mock_client.list_tunnels = AsyncMock(return_value=[])
+        with _patch_key(), _patch_client(mock_client):
+            result = runner.invoke(main, ["config", "list", "--api-key", _KEY])
         assert result.exit_code == 0
         assert "No active tunnels" in result.output
 
-    def test_tunnels_populated(self) -> None:
+    def test_list_populated(self) -> None:
         runner = CliRunner()
         tunnel_data = [
             {
@@ -34,25 +44,23 @@ class TestTunnelsCommand:
                 "connected_at": "2026-01-01T00:00:00",
             }
         ]
-        with patch("hle_client.cli._resolve_api_key", return_value="hle_" + "a" * 32):
-            mock_client = AsyncMock()
-            mock_client.list_tunnels = AsyncMock(return_value=tunnel_data)
-            with patch("hle_client.api.ApiClient", return_value=mock_client):
-                result = runner.invoke(main, ["tunnels", "--api-key", "hle_" + "a" * 32])
+        mock_client = AsyncMock()
+        mock_client.list_tunnels = AsyncMock(return_value=tunnel_data)
+        with _patch_key(), _patch_client(mock_client):
+            result = runner.invoke(main, ["config", "list", "--api-key", _KEY])
         assert result.exit_code == 0
         assert "app-x7k" in result.output
 
 
-class TestAccessListCommand:
+class TestConfigAccessList:
     def test_access_list_empty(self) -> None:
         runner = CliRunner()
-        with patch("hle_client.cli._resolve_api_key", return_value="hle_" + "a" * 32):
-            mock_client = AsyncMock()
-            mock_client.list_access_rules = AsyncMock(return_value=[])
-            with patch("hle_client.api.ApiClient", return_value=mock_client):
-                result = runner.invoke(
-                    main, ["access", "list", "app-x7k", "--api-key", "hle_" + "a" * 32]
-                )
+        mock_client = AsyncMock()
+        mock_client.list_access_rules = AsyncMock(return_value=[])
+        with _patch_key(), _patch_client(mock_client):
+            result = runner.invoke(
+                main, ["config", "access", "list", "app-x7k", "--api-key", _KEY]
+            )
         assert result.exit_code == 0
         assert "No access rules" in result.output
 
@@ -66,126 +74,117 @@ class TestAccessListCommand:
                 "created_at": "2026-01-01T00:00:00",
             }
         ]
-        with patch("hle_client.cli._resolve_api_key", return_value="hle_" + "a" * 32):
-            mock_client = AsyncMock()
-            mock_client.list_access_rules = AsyncMock(return_value=rules)
-            with patch("hle_client.api.ApiClient", return_value=mock_client):
-                result = runner.invoke(
-                    main, ["access", "list", "app-x7k", "--api-key", "hle_" + "a" * 32]
-                )
+        mock_client = AsyncMock()
+        mock_client.list_access_rules = AsyncMock(return_value=rules)
+        with _patch_key(), _patch_client(mock_client):
+            result = runner.invoke(
+                main, ["config", "access", "list", "app-x7k", "--api-key", _KEY]
+            )
         assert result.exit_code == 0
         assert "friend@example.com" in result.output
 
 
-class TestAccessAddCommand:
+class TestConfigAccessAdd:
     def test_access_add_default_provider(self) -> None:
         runner = CliRunner()
-        with patch("hle_client.cli._resolve_api_key", return_value="hle_" + "a" * 32):
-            mock_client = AsyncMock()
-            mock_client.add_access_rule = AsyncMock(
-                return_value={"allowed_email": "new@example.com", "provider": "any"}
+        mock_client = AsyncMock()
+        mock_client.add_access_rule = AsyncMock(
+            return_value={"allowed_email": "new@example.com", "provider": "any"}
+        )
+        mock_client.get_tunnel_basic_auth_status = AsyncMock(return_value={"enabled": False})
+        with _patch_key(), _patch_client(mock_client):
+            result = runner.invoke(
+                main,
+                ["config", "access", "add", "app-x7k", "new@example.com", "--api-key", _KEY],
             )
-            with patch("hle_client.api.ApiClient", return_value=mock_client):
-                result = runner.invoke(
-                    main,
-                    [
-                        "access",
-                        "add",
-                        "app-x7k",
-                        "new@example.com",
-                        "--api-key",
-                        "hle_" + "a" * 32,
-                    ],
-                )
         assert result.exit_code == 0
         assert "Added" in result.output
         assert "new@example.com" in result.output
 
     def test_access_add_custom_provider(self) -> None:
         runner = CliRunner()
-        with patch("hle_client.cli._resolve_api_key", return_value="hle_" + "a" * 32):
-            mock_client = AsyncMock()
-            mock_client.add_access_rule = AsyncMock(
-                return_value={"allowed_email": "dev@co.com", "provider": "github"}
+        mock_client = AsyncMock()
+        mock_client.add_access_rule = AsyncMock(
+            return_value={"allowed_email": "dev@co.com", "provider": "github"}
+        )
+        mock_client.get_tunnel_basic_auth_status = AsyncMock(return_value={"enabled": False})
+        with _patch_key(), _patch_client(mock_client):
+            result = runner.invoke(
+                main,
+                [
+                    "config",
+                    "access",
+                    "add",
+                    "app-x7k",
+                    "dev@co.com",
+                    "--provider",
+                    "github",
+                    "--api-key",
+                    _KEY,
+                ],
             )
-            with patch("hle_client.api.ApiClient", return_value=mock_client):
-                result = runner.invoke(
-                    main,
-                    [
-                        "access",
-                        "add",
-                        "app-x7k",
-                        "dev@co.com",
-                        "--provider",
-                        "github",
-                        "--api-key",
-                        "hle_" + "a" * 32,
-                    ],
-                )
         assert result.exit_code == 0
         assert "Added" in result.output
 
 
-class TestAccessRemoveCommand:
+class TestConfigAccessRemove:
     def test_access_remove_success(self) -> None:
         runner = CliRunner()
-        with patch("hle_client.cli._resolve_api_key", return_value="hle_" + "a" * 32):
-            mock_client = AsyncMock()
-            mock_client.delete_access_rule = AsyncMock(return_value={"message": "ok"})
-            with patch("hle_client.api.ApiClient", return_value=mock_client):
-                result = runner.invoke(
-                    main,
-                    ["access", "remove", "app-x7k", "1", "--api-key", "hle_" + "a" * 32],
-                )
+        mock_client = AsyncMock()
+        mock_client.delete_access_rule = AsyncMock(return_value={"message": "ok"})
+        with _patch_key(), _patch_client(mock_client):
+            result = runner.invoke(
+                main,
+                ["config", "access", "remove", "app-x7k", "1", "--api-key", _KEY],
+            )
         assert result.exit_code == 0
         assert "Removed" in result.output
 
 
-class TestShareCreateCommand:
+class TestConfigShareCreate:
     def test_share_create(self) -> None:
         runner = CliRunner()
-        with patch("hle_client.cli._resolve_api_key", return_value="hle_" + "a" * 32):
-            mock_client = AsyncMock()
-            mock_client.create_share_link = AsyncMock(
-                return_value={
-                    "share_url": "https://app-x7k.hle.world?_hle_share=token123",
-                    "raw_token": "token123",
-                    "link": {
-                        "id": 1,
-                        "label": "for bob",
-                        "expires_at": "2026-02-15T00:00:00",
-                        "max_uses": None,
-                    },
-                }
+        mock_client = AsyncMock()
+        mock_client.create_share_link = AsyncMock(
+            return_value={
+                "share_url": "https://app-x7k.hle.world?_hle_share=token123",
+                "raw_token": "token123",
+                "link": {
+                    "id": 1,
+                    "label": "for bob",
+                    "expires_at": "2026-02-15T00:00:00",
+                    "max_uses": None,
+                },
+            }
+        )
+        with _patch_key(), _patch_client(mock_client):
+            result = runner.invoke(
+                main,
+                [
+                    "config",
+                    "share",
+                    "create",
+                    "app-x7k",
+                    "--label",
+                    "for bob",
+                    "--api-key",
+                    _KEY,
+                ],
             )
-            with patch("hle_client.api.ApiClient", return_value=mock_client):
-                result = runner.invoke(
-                    main,
-                    [
-                        "share",
-                        "create",
-                        "app-x7k",
-                        "--label",
-                        "for bob",
-                        "--api-key",
-                        "hle_" + "a" * 32,
-                    ],
-                )
         assert result.exit_code == 0
         assert "Share link created" in result.output
         assert "token123" in result.output
 
 
-class TestShareListCommand:
+class TestConfigShareList:
     def test_share_list_empty(self) -> None:
         runner = CliRunner()
-        with patch("hle_client.cli._resolve_api_key", return_value="hle_" + "a" * 32):
-            mock_client = AsyncMock()
-            mock_client.list_share_links = AsyncMock(return_value=[])
-            with patch("hle_client.api.ApiClient", return_value=mock_client):
-                result = runner.invoke(
-                    main, ["share", "list", "app-x7k", "--api-key", "hle_" + "a" * 32]
-                )
+        mock_client = AsyncMock()
+        mock_client.list_share_links = AsyncMock(return_value=[])
+        with _patch_key(), _patch_client(mock_client):
+            result = runner.invoke(
+                main, ["config", "share", "list", "app-x7k", "--api-key", _KEY]
+            )
         assert result.exit_code == 0
         assert "No share links" in result.output
 
@@ -202,139 +201,125 @@ class TestShareListCommand:
                 "is_active": True,
             }
         ]
-        with patch("hle_client.cli._resolve_api_key", return_value="hle_" + "a" * 32):
-            mock_client = AsyncMock()
-            mock_client.list_share_links = AsyncMock(return_value=links)
-            with patch("hle_client.api.ApiClient", return_value=mock_client):
-                result = runner.invoke(
-                    main, ["share", "list", "app-x7k", "--api-key", "hle_" + "a" * 32]
-                )
+        mock_client = AsyncMock()
+        mock_client.list_share_links = AsyncMock(return_value=links)
+        with _patch_key(), _patch_client(mock_client):
+            result = runner.invoke(
+                main, ["config", "share", "list", "app-x7k", "--api-key", _KEY]
+            )
         assert result.exit_code == 0
         assert "abc12345" in result.output
         assert "for bob" in result.output
 
 
-class TestShareRevokeCommand:
+class TestConfigShareRevoke:
     def test_share_revoke(self) -> None:
         runner = CliRunner()
-        with patch("hle_client.cli._resolve_api_key", return_value="hle_" + "a" * 32):
-            mock_client = AsyncMock()
-            mock_client.delete_share_link = AsyncMock(return_value={"message": "ok"})
-            with patch("hle_client.api.ApiClient", return_value=mock_client):
-                result = runner.invoke(
-                    main,
-                    ["share", "revoke", "app-x7k", "1", "--api-key", "hle_" + "a" * 32],
-                )
+        mock_client = AsyncMock()
+        mock_client.delete_share_link = AsyncMock(return_value={"message": "ok"})
+        with _patch_key(), _patch_client(mock_client):
+            result = runner.invoke(
+                main,
+                ["config", "share", "revoke", "app-x7k", "1", "--api-key", _KEY],
+            )
         assert result.exit_code == 0
         assert "Revoked" in result.output
 
 
-class TestBasicAuthSetCommand:
-    def test_basic_auth_set_success(self) -> None:
+class TestConfigBasicAuthSet:
+    def test_set_success(self) -> None:
         runner = CliRunner()
-        with patch("hle_client.cli._resolve_api_key", return_value="hle_" + "a" * 32):
-            mock_client = AsyncMock()
-            mock_client.set_tunnel_basic_auth = AsyncMock(return_value={"message": "ok"})
-            mock_client.get_tunnel_pin_status = AsyncMock(return_value={"has_pin": False})
-            mock_client.list_access_rules = AsyncMock(return_value=[])
-            with patch("hle_client.api.ApiClient", return_value=mock_client):
-                result = runner.invoke(
-                    main,
-                    ["basic-auth", "set", "app-x7k", "--api-key", "hle_" + "a" * 32],
-                    input="admin\nsecret123\nsecret123\n",
-                )
+        mock_client = AsyncMock()
+        mock_client.set_tunnel_basic_auth = AsyncMock(return_value={"message": "ok"})
+        mock_client.get_tunnel_pin_status = AsyncMock(return_value={"has_pin": False})
+        mock_client.list_access_rules = AsyncMock(return_value=[])
+        with _patch_key(), _patch_client(mock_client):
+            result = runner.invoke(
+                main,
+                ["config", "basic-auth", "set", "app-x7k", "--api-key", _KEY],
+                input="admin\nsecret123\nsecret123\n",
+            )
         assert result.exit_code == 0
         assert "Basic Auth set" in result.output
         assert "admin" in result.output
 
-    def test_basic_auth_set_password_mismatch(self) -> None:
+    def test_password_mismatch(self) -> None:
         runner = CliRunner()
-        with patch("hle_client.cli._resolve_api_key", return_value="hle_" + "a" * 32):
+        with _patch_key():
             result = runner.invoke(
                 main,
-                ["basic-auth", "set", "app-x7k", "--api-key", "hle_" + "a" * 32],
+                ["config", "basic-auth", "set", "app-x7k", "--api-key", _KEY],
                 input="admin\nsecret123\nwrongpass\n",
             )
-        assert result.exit_code == 1
+        assert result.exit_code != 0
         assert "do not match" in result.output
 
-    def test_basic_auth_set_short_password(self) -> None:
+    def test_short_password(self) -> None:
         runner = CliRunner()
-        with patch("hle_client.cli._resolve_api_key", return_value="hle_" + "a" * 32):
+        with _patch_key():
             result = runner.invoke(
                 main,
-                ["basic-auth", "set", "app-x7k", "--api-key", "hle_" + "a" * 32],
+                ["config", "basic-auth", "set", "app-x7k", "--api-key", _KEY],
                 input="admin\nshort\nshort\n",
             )
-        assert result.exit_code == 1
+        assert result.exit_code != 0
         assert "8 characters" in result.output
 
-    def test_basic_auth_set_username_with_colon(self) -> None:
+    def test_username_with_colon(self) -> None:
         runner = CliRunner()
-        with patch("hle_client.cli._resolve_api_key", return_value="hle_" + "a" * 32):
+        with _patch_key():
             result = runner.invoke(
                 main,
-                ["basic-auth", "set", "app-x7k", "--api-key", "hle_" + "a" * 32],
+                ["config", "basic-auth", "set", "app-x7k", "--api-key", _KEY],
                 input="user:name\n",
             )
-        assert result.exit_code == 1
+        assert result.exit_code != 0
         assert "':'" in result.output
 
 
-class TestBasicAuthStatusCommand:
-    def test_basic_auth_status_active(self) -> None:
+class TestConfigBasicAuthStatus:
+    def test_active(self) -> None:
         runner = CliRunner()
-        with patch("hle_client.cli._resolve_api_key", return_value="hle_" + "a" * 32):
-            mock_client = AsyncMock()
-            mock_client.get_tunnel_basic_auth_status = AsyncMock(
-                return_value={
-                    "enabled": True,
-                    "subdomain": "app-x7k",
-                    "username": "admin",
-                    "updated_at": "2026-02-28T12:00:00",
-                }
+        mock_client = AsyncMock()
+        mock_client.get_tunnel_basic_auth_status = AsyncMock(
+            return_value={
+                "enabled": True,
+                "subdomain": "app-x7k",
+                "username": "admin",
+                "updated_at": "2026-02-28T12:00:00",
+            }
+        )
+        with _patch_key(), _patch_client(mock_client):
+            result = runner.invoke(
+                main, ["config", "basic-auth", "status", "app-x7k", "--api-key", _KEY]
             )
-            with patch("hle_client.api.ApiClient", return_value=mock_client):
-                result = runner.invoke(
-                    main,
-                    ["basic-auth", "status", "app-x7k", "--api-key", "hle_" + "a" * 32],
-                )
         assert result.exit_code == 0
         assert "active" in result.output
         assert "admin" in result.output
 
-    def test_basic_auth_status_not_set(self) -> None:
+    def test_not_set(self) -> None:
         runner = CliRunner()
-        with patch("hle_client.cli._resolve_api_key", return_value="hle_" + "a" * 32):
-            mock_client = AsyncMock()
-            mock_client.get_tunnel_basic_auth_status = AsyncMock(
-                return_value={
-                    "enabled": False,
-                    "subdomain": "app-x7k",
-                    "username": None,
-                    "updated_at": None,
-                }
+        mock_client = AsyncMock()
+        mock_client.get_tunnel_basic_auth_status = AsyncMock(
+            return_value={"enabled": False, "username": None, "updated_at": None}
+        )
+        with _patch_key(), _patch_client(mock_client):
+            result = runner.invoke(
+                main, ["config", "basic-auth", "status", "app-x7k", "--api-key", _KEY]
             )
-            with patch("hle_client.api.ApiClient", return_value=mock_client):
-                result = runner.invoke(
-                    main,
-                    ["basic-auth", "status", "app-x7k", "--api-key", "hle_" + "a" * 32],
-                )
         assert result.exit_code == 0
         assert "No Basic Auth" in result.output
 
 
-class TestBasicAuthRemoveCommand:
-    def test_basic_auth_remove_success(self) -> None:
+class TestConfigBasicAuthRemove:
+    def test_remove_success(self) -> None:
         runner = CliRunner()
-        with patch("hle_client.cli._resolve_api_key", return_value="hle_" + "a" * 32):
-            mock_client = AsyncMock()
-            mock_client.remove_tunnel_basic_auth = AsyncMock(return_value={"message": "ok"})
-            with patch("hle_client.api.ApiClient", return_value=mock_client):
-                result = runner.invoke(
-                    main,
-                    ["basic-auth", "remove", "app-x7k", "--api-key", "hle_" + "a" * 32],
-                )
+        mock_client = AsyncMock()
+        mock_client.remove_tunnel_basic_auth = AsyncMock(return_value={"message": "ok"})
+        with _patch_key(), _patch_client(mock_client):
+            result = runner.invoke(
+                main, ["config", "basic-auth", "remove", "app-x7k", "--api-key", _KEY]
+            )
         assert result.exit_code == 0
         assert "removed" in result.output
 
@@ -344,59 +329,47 @@ class TestErrorHandling:
         import httpx
 
         runner = CliRunner()
-        with patch("hle_client.cli._resolve_api_key", return_value="hle_" + "a" * 32):
-            mock_client = AsyncMock()
-            mock_resp = httpx.Response(
-                401,
-                text="Not authenticated",
-                request=httpx.Request("GET", "http://test/api/tunnels"),
-            )
-            mock_client.list_tunnels = AsyncMock(
-                side_effect=httpx.HTTPStatusError(
-                    "401", request=mock_resp.request, response=mock_resp
-                )
-            )
-            with patch("hle_client.api.ApiClient", return_value=mock_client):
-                result = runner.invoke(main, ["tunnels", "--api-key", "hle_" + "a" * 32])
-        assert result.exit_code == 0  # CLI handles error gracefully
+        mock_client = AsyncMock()
+        mock_resp = httpx.Response(
+            401, text="Not authenticated", request=httpx.Request("GET", "http://t/api/tunnels")
+        )
+        mock_client.list_tunnels = AsyncMock(
+            side_effect=httpx.HTTPStatusError("401", request=mock_resp.request, response=mock_resp)
+        )
+        with _patch_key(), _patch_client(mock_client):
+            result = runner.invoke(main, ["config", "list", "--api-key", _KEY])
+        assert result.exit_code != 0
         assert "Invalid or missing API key" in result.output
 
     def test_error_403(self) -> None:
         import httpx
 
         runner = CliRunner()
-        with patch("hle_client.cli._resolve_api_key", return_value="hle_" + "a" * 32):
-            mock_client = AsyncMock()
-            mock_resp = httpx.Response(
-                403,
-                text="Forbidden",
-                request=httpx.Request("GET", "http://test/api/tunnels/x-abc/access"),
+        mock_client = AsyncMock()
+        mock_resp = httpx.Response(
+            403, text="Forbidden", request=httpx.Request("GET", "http://t/api/tunnels/x-abc/access")
+        )
+        mock_client.list_access_rules = AsyncMock(
+            side_effect=httpx.HTTPStatusError("403", request=mock_resp.request, response=mock_resp)
+        )
+        with _patch_key(), _patch_client(mock_client):
+            result = runner.invoke(
+                main, ["config", "access", "list", "x-abc", "--api-key", _KEY]
             )
-            mock_client.list_access_rules = AsyncMock(
-                side_effect=httpx.HTTPStatusError(
-                    "403", request=mock_resp.request, response=mock_resp
-                )
-            )
-            with patch("hle_client.api.ApiClient", return_value=mock_client):
-                result = runner.invoke(
-                    main, ["access", "list", "x-abc", "--api-key", "hle_" + "a" * 32]
-                )
-        assert result.exit_code == 0
+        assert result.exit_code != 0
         assert "do not own" in result.output
 
     def test_no_api_key(self) -> None:
         runner = CliRunner()
-        with patch("hle_client.cli._load_api_key", return_value=None):
-            result = runner.invoke(main, ["tunnels"], env={"HLE_API_KEY": ""})
-        assert result.exit_code == 1
+        with patch("hle_client.tunnel._load_api_key", return_value=None):
+            result = runner.invoke(main, ["config", "list"], env={"HLE_API_KEY": ""})
+        assert result.exit_code != 0
         assert "No API key found" in result.output
         assert "hle auth login" in result.output
 
 
 class TestAuthLogin:
-    """Tests for ``hle auth login``."""
-
-    def test_auth_login_with_api_key(self, tmp_path: Path) -> None:
+    def test_with_api_key(self, tmp_path: Path) -> None:
         runner = CliRunner()
         config_file = tmp_path / "config.toml"
         with (
@@ -407,10 +380,9 @@ class TestAuthLogin:
         assert result.exit_code == 0
         assert "Saved" in result.output
         assert config_file.exists()
-        content = config_file.read_text()
-        assert "hle_" + "a" * 32 in content
+        assert "hle_" + "a" * 32 in config_file.read_text()
 
-    def test_auth_login_interactive(self, tmp_path: Path) -> None:
+    def test_interactive(self, tmp_path: Path) -> None:
         runner = CliRunner()
         config_file = tmp_path / "config.toml"
         valid_key = "hle_" + "b" * 32
@@ -422,16 +394,15 @@ class TestAuthLogin:
             result = runner.invoke(main, ["auth", "login"], input=valid_key + "\n")
         assert result.exit_code == 0
         assert "Saved" in result.output
-        assert config_file.exists()
         assert valid_key in config_file.read_text()
 
-    def test_auth_login_invalid_key(self) -> None:
+    def test_invalid_key(self) -> None:
         runner = CliRunner()
         result = runner.invoke(main, ["auth", "login", "--api-key", "bad_key"])
         assert result.exit_code == 1
         assert "Invalid API key format" in result.output
 
-    def test_auth_login_invalid_key_too_short(self) -> None:
+    def test_invalid_key_too_short(self) -> None:
         runner = CliRunner()
         result = runner.invoke(main, ["auth", "login", "--api-key", "hle_abc"])
         assert result.exit_code == 1
@@ -439,27 +410,24 @@ class TestAuthLogin:
 
 
 class TestAuthStatus:
-    """Tests for ``hle auth status``."""
-
-    def test_auth_status_from_config(self, tmp_path: Path) -> None:
+    def test_from_config(self, tmp_path: Path) -> None:
         runner = CliRunner()
         valid_key = "hle_" + "c" * 32
         with patch("hle_client.cli._load_api_key", return_value=valid_key):
             result = runner.invoke(main, ["auth", "status"], env={"HLE_API_KEY": ""})
         assert result.exit_code == 0
         assert "config file" in result.output
-        assert "hle_" in result.output
         assert valid_key not in result.output  # masked
 
-    def test_auth_status_from_env(self) -> None:
+    def test_from_env(self) -> None:
         runner = CliRunner()
         valid_key = "hle_" + "d" * 32
         result = runner.invoke(main, ["auth", "status"], env={"HLE_API_KEY": valid_key})
         assert result.exit_code == 0
         assert "environment variable" in result.output
-        assert valid_key not in result.output  # masked
+        assert valid_key not in result.output
 
-    def test_auth_status_no_key(self) -> None:
+    def test_no_key(self) -> None:
         runner = CliRunner()
         with patch("hle_client.cli._load_api_key", return_value=None):
             result = runner.invoke(main, ["auth", "status"], env={"HLE_API_KEY": ""})
@@ -468,9 +436,7 @@ class TestAuthStatus:
 
 
 class TestAuthLogout:
-    """Tests for ``hle auth logout``."""
-
-    def test_auth_logout(self, tmp_path: Path) -> None:
+    def test_logout(self, tmp_path: Path) -> None:
         runner = CliRunner()
         config_file = tmp_path / "config.toml"
         config_file.write_text('api_key = "hle_' + "e" * 32 + '"\nother = "keep"\n')
@@ -483,9 +449,9 @@ class TestAuthLogout:
         assert "API key removed" in result.output
         content = config_file.read_text()
         assert "api_key" not in content
-        assert "other" in content  # other config preserved
+        assert "other" in content
 
-    def test_auth_logout_no_key(self, tmp_path: Path) -> None:
+    def test_logout_no_key(self, tmp_path: Path) -> None:
         runner = CliRunner()
         config_file = tmp_path / "nonexistent.toml"
         with patch("hle_client.tunnel._CONFIG_FILE", config_file):
@@ -495,10 +461,7 @@ class TestAuthLogout:
 
 
 class TestExposeNoAutoSave:
-    """Verify that ``hle expose`` no longer auto-saves the API key."""
-
     def test_expose_does_not_auto_save(self, tmp_path: Path) -> None:
-        """The auto-save block was removed; _save_api_key should never be called."""
         runner = CliRunner()
         with patch("hle_client.cli.asyncio.run") as mock_run:
             mock_run.return_value = None
@@ -514,6 +477,5 @@ class TestExposeNoAutoSave:
                     "hle_" + "f" * 32,
                 ],
             )
-        # expose ran (asyncio.run was called) — it should not call _save_api_key
         assert result.exit_code == 0
         assert mock_run.called

--- a/tests/unit/test_config_cmd.py
+++ b/tests/unit/test_config_cmd.py
@@ -114,10 +114,9 @@ class TestConfigAccessReplace:
                 [
                     "config",
                     "access",
+                    "replace",
                     "ha",
-                    "--replace",
                     "google:alice@example.com",
-                    "--replace",
                     "github:carol@example.com",
                     "--api-key",
                     _KEY,
@@ -151,8 +150,8 @@ class TestConfigAccessReplace:
                 [
                     "config",
                     "access",
+                    "replace",
                     "ha",
-                    "--replace",
                     "google:alice@example.com",
                     "--api-key",
                     _KEY,
@@ -164,8 +163,8 @@ class TestConfigAccessReplace:
         mock_client.delete_access_rule.assert_not_called()
         assert "in sync" in result.output
 
-    def test_access_no_replace_flag_errors(self) -> None:
+    def test_access_no_specs_errors(self) -> None:
         runner = CliRunner()
-        result = runner.invoke(main, ["config", "access", "ha", "--api-key", _KEY])
+        result = runner.invoke(main, ["config", "access", "replace", "ha", "--api-key", _KEY])
         assert result.exit_code != 0
-        assert "--replace" in result.output
+        assert "--clear" in result.output


### PR DESCRIPTION
## Summary
- Consolidate all tunnel-scoped operations (access, pin, basic-auth, share, list, auth-mode) under `hle config` for a single, label-based namespace
- Top-level surface is now `expose`, `webhook`, `auth`, `config`
- Drop `hle tunnels`, `hle zone`, and `--zone` flags entirely (zone field on the wire kept for server compat, just no longer populated)
- `config access replace` takes positional specs + `--clear` instead of repeated `--replace`
- Bump to v2605.1 (CalVer)

## Breaking
Scripts using `hle access`, `hle pin`, `hle basic-auth`, `hle share`, `hle tunnels`, `hle zone`, or `--zone` need updating to `hle config <subcommand>`.

## Test plan
- [x] 157 unit tests pass
- [x] ruff clean
- [ ] Manual smoke: `hle expose`, `hle config list`, `hle config show <label>`