### PR TITLE
Bump version to 2605.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hle-client"
-version = "2605.1"
+version = "2605.3"
 description = "HomeLab Everywhere — Expose homelab services to the internet with built-in SSO"
 readme = "README.md"
 license = "MIT"

--- a/src/hle_client/__init__.py
+++ b/src/hle_client/__init__.py
@@ -1,3 +1,3 @@
 """HLE Client — HomeLab Everywhere tunnel client."""
 
-__version__ = "2605.1"
+__version__ = "2605.3"


### PR DESCRIPTION
## Summary
Version bump for the WS frame race fix release. The v2605.2 tag was cut without a corresponding pyproject bump, so PyPI publish 400'd on the duplicate 2605.1 wheel and Homebrew waited on a PyPI artifact that never appeared. Skipping straight to 2605.3 to keep history clean.