### PR TITLE
Forward WebSocket subprotocols end-to-end (protocol 1.5)

### DIFF
--- a/src/hle_client/tunnel.py
+++ b/src/hle_client/tunnel.py
@@ -37,6 +37,7 @@ from hle_common.models import (
     SpeedTestResult,
     TunnelRegistration,
     TunnelRegistrationResponse,
+    WsStreamAccept,
     WsStreamClose,
     WsStreamFrame,
     WsStreamOpen,
@@ -212,7 +213,10 @@ _WS_HOP_BY_HOP_HEADERS = frozenset(
         "sec-websocket-version",
         "sec-websocket-extensions",
         "sec-websocket-accept",
-        "sec-websocket-protocol",
+        # NOTE: sec-websocket-protocol is end-to-end (RFC 6455 §4.1) and must
+        # be forwarded so upstreams like ttyd/mqtt that mandate subprotocol
+        # negotiation accept the connection. The negotiated value is reported
+        # back to the relay via WS_ACCEPT (protocol 1.5+).
         "transfer-encoding",
         "content-length",
         "keep-alive",
@@ -829,10 +833,23 @@ class Tunnel:
             ws_ssl.check_hostname = False
             ws_ssl.verify_mode = ssl.CERT_NONE
 
+        # Extract the browser-requested subprotocols so websockets propagates
+        # them in the upstream handshake. The header value is a comma-separated
+        # list (RFC 6455 §4.1).
+        requested_subprotocols: list[str] = []
+        for k, v in list(clean_headers.items()):
+            if k.lower() == "sec-websocket-protocol":
+                requested_subprotocols = [p.strip() for p in v.split(",") if p.strip()]
+                # Remove from headers — websockets.connect adds it back from
+                # the `subprotocols` arg and rejects the duplicate.
+                clean_headers.pop(k)
+                break
+
         try:
             local_ws = await websockets.connect(
                 local_ws_url,
                 additional_headers=clean_headers,
+                subprotocols=requested_subprotocols or None,
                 ssl=ws_ssl,
             )
         except Exception as exc:
@@ -850,6 +867,21 @@ class Tunnel:
             with contextlib.suppress(websockets.exceptions.ConnectionClosed):
                 await ws.send(close_msg.model_dump_json())
             return
+
+        # Report the negotiated subprotocol to the relay so it can complete
+        # the browser-facing 101 handshake with the matching Sec-WebSocket-
+        # Protocol header (protocol 1.5+). Older relays ignore unknown
+        # message types, so this is safe to always send.
+        accept_msg = ProtocolMessage(
+            type=MessageType.WS_ACCEPT,
+            tunnel_id=self._tunnel_id,
+            payload=WsStreamAccept(
+                stream_id=stream_id,
+                subprotocol=local_ws.subprotocol,
+            ).model_dump(),
+        )
+        with contextlib.suppress(websockets.exceptions.ConnectionClosed):
+            await ws.send(accept_msg.model_dump_json())
 
         # Drain the buffered frames into the live local WS BEFORE swapping
         # the slot, all while holding the streams lock. This is critical:

--- a/src/hle_common/models.py
+++ b/src/hle_common/models.py
@@ -163,6 +163,19 @@ class WsStreamOpen(BaseModel):
     headers: dict[str, str] = {}
 
 
+class WsStreamAccept(BaseModel):
+    """Client → server: upstream WS handshake completed, report selected subprotocol.
+
+    Sent immediately after the client successfully opens the WebSocket to the
+    local service. The relay uses ``subprotocol`` when calling ``ws.accept()``
+    on the browser-facing socket so the 101 response echoes the requested
+    Sec-WebSocket-Protocol value. ``None`` means no subprotocol was negotiated.
+    """
+
+    stream_id: str
+    subprotocol: str | None = None
+
+
 class WsStreamFrame(BaseModel):
     """A single WebSocket frame in a proxied stream."""
 

--- a/src/hle_common/protocol.py
+++ b/src/hle_common/protocol.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel
 # Protocol version — bump on wire-format changes.
 # Major bump (1.0 → 2.0): breaking change, server must support both during deprecation.
 # Minor bump (1.0 → 1.1): new optional fields/message types, old clients unaffected.
-PROTOCOL_VERSION = "1.4"
+PROTOCOL_VERSION = "1.5"
 
 
 class MessageType(StrEnum):
@@ -42,6 +42,11 @@ class MessageType(StrEnum):
     WS_OPEN = "ws_open"
     WS_CLOSE = "ws_close"
     WS_FRAME = "ws_frame"
+    # WS_ACCEPT (client → server, added in PROTOCOL_VERSION 1.5): reports
+    # the subprotocol negotiated with the upstream service so the relay can
+    # echo it in the 101 response to the browser. Required for upstreams
+    # that mandate Sec-WebSocket-Protocol negotiation (ttyd, mqtt, etc.).
+    WS_ACCEPT = "ws_accept"
 
     # Webhook
     WEBHOOK_INCOMING = "webhook_incoming"

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -15,6 +15,7 @@ from hle_common.models import (
     ProxiedHttpRequest,
     WsStreamClose,
     WsStreamFrame,
+    WsStreamOpen,
 )
 from hle_common.protocol import MessageType, ProtocolMessage
 
@@ -651,6 +652,88 @@ class TestTunnelSsrfProtection:
         assert len(sent) == 1
         close_msg = ProtocolMessage.model_validate_json(sent[0])
         assert close_msg.type == MessageType.WS_CLOSE
+
+
+class TestTunnelWsSubprotocolNegotiation:
+    """Verify Sec-WebSocket-Protocol is forwarded to upstream and reported back."""
+
+    async def test_forwards_subprotocols_and_sends_ws_accept(self):
+        tunnel = _tunnel(service_url="http://localhost:7681")
+        tunnel._tunnel_id = "t-subproto"
+
+        mock_relay_ws = AsyncMock()
+        sent: list[str] = []
+        mock_relay_ws.send = AsyncMock(side_effect=lambda m: sent.append(m))
+
+        mock_local_ws = AsyncMock()
+        mock_local_ws.subprotocol = "tty"
+
+        open_payload = WsStreamOpen(
+            stream_id="s-tty",
+            path="/ws",
+            headers={"Sec-WebSocket-Protocol": "tty, fallback"},
+        )
+        msg = ProtocolMessage(type=MessageType.WS_OPEN, payload=open_payload.model_dump())
+
+        captured: dict = {}
+
+        async def fake_connect(url, **kwargs):
+            captured["url"] = url
+            captured["subprotocols"] = kwargs.get("subprotocols")
+            captured["headers"] = dict(kwargs.get("additional_headers") or {})
+            return mock_local_ws
+
+        with patch("hle_client.tunnel.websockets.connect", side_effect=fake_connect):
+            await tunnel._handle_ws_open(mock_relay_ws, msg)
+
+        # Subprotocols extracted and passed to websockets.connect.
+        assert captured["subprotocols"] == ["tty", "fallback"]
+        # Header removed from forwarded headers (websockets adds it back).
+        assert "sec-websocket-protocol" not in {k.lower() for k in captured["headers"]}
+
+        # WS_ACCEPT sent back with negotiated subprotocol.
+        accept_msgs = [
+            ProtocolMessage.model_validate_json(s)
+            for s in sent
+            if ProtocolMessage.model_validate_json(s).type == MessageType.WS_ACCEPT
+        ]
+        assert len(accept_msgs) == 1
+        assert accept_msgs[0].payload["stream_id"] == "s-tty"
+        assert accept_msgs[0].payload["subprotocol"] == "tty"
+
+    async def test_no_subprotocol_when_header_absent(self):
+        tunnel = _tunnel(service_url="http://localhost:8080")
+        tunnel._tunnel_id = "t-plain"
+
+        mock_relay_ws = AsyncMock()
+        sent: list[str] = []
+        mock_relay_ws.send = AsyncMock(side_effect=lambda m: sent.append(m))
+
+        mock_local_ws = AsyncMock()
+        mock_local_ws.subprotocol = None
+
+        open_payload = WsStreamOpen(stream_id="s-plain", path="/ws", headers={})
+        msg = ProtocolMessage(type=MessageType.WS_OPEN, payload=open_payload.model_dump())
+
+        captured: dict = {}
+
+        async def fake_connect(url, **kwargs):
+            captured["subprotocols"] = kwargs.get("subprotocols")
+            return mock_local_ws
+
+        with patch("hle_client.tunnel.websockets.connect", side_effect=fake_connect):
+            await tunnel._handle_ws_open(mock_relay_ws, msg)
+
+        # No subprotocols requested → None passed (not []).
+        assert captured["subprotocols"] is None
+
+        accept_msgs = [
+            ProtocolMessage.model_validate_json(s)
+            for s in sent
+            if ProtocolMessage.model_validate_json(s).type == MessageType.WS_ACCEPT
+        ]
+        assert len(accept_msgs) == 1
+        assert accept_msgs[0].payload["subprotocol"] is None
 
 
 class TestTunnelHandleWsFrame:

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -13,6 +13,7 @@ from hle_common.models import (
     SpeedTestResult,
     TunnelRegistration,
     TunnelRegistrationResponse,
+    WsStreamAccept,
     WsStreamClose,
     WsStreamFrame,
     WsStreamOpen,
@@ -203,6 +204,17 @@ class TestWsStreamOpen:
             headers={"Authorization": "Bearer tok123"},
         )
         assert stream.headers == {"Authorization": "Bearer tok123"}
+
+
+class TestWsStreamAccept:
+    def test_default_no_subprotocol(self):
+        accept = WsStreamAccept(stream_id="s-1")
+        assert accept.stream_id == "s-1"
+        assert accept.subprotocol is None
+
+    def test_with_subprotocol(self):
+        accept = WsStreamAccept(stream_id="s-2", subprotocol="tty")
+        assert accept.subprotocol == "tty"
 
 
 class TestWsStreamFrame:

--- a/tests/unit/test_protocol.py
+++ b/tests/unit/test_protocol.py
@@ -14,7 +14,7 @@ from hle_common.protocol import (
 
 class TestProtocolVersion:
     def test_protocol_version_exists(self):
-        assert PROTOCOL_VERSION == "1.4"
+        assert PROTOCOL_VERSION == "1.5"
 
     def test_protocol_version_is_string(self):
         assert isinstance(PROTOCOL_VERSION, str)
@@ -46,6 +46,7 @@ class TestMessageType:
             "ws_open",
             "ws_close",
             "ws_frame",
+            "ws_accept",
             "webhook_incoming",
             "webhook_response",
             "speed_test_data",


### PR DESCRIPTION
## Summary

Upstreams that require `Sec-WebSocket-Protocol` negotiation (ttyd, mqtt, graphql-ws, etc.) were rejecting tunneled WS connections because the client stripped the header before forwarding to the local service. Browsers then closed the WS with code 1006.

This adds a `WS_ACCEPT` message (client → relay, protocol 1.5) so the client can report the upstream-selected subprotocol after the handshake. The relay needs a matching change to defer `ws.accept()` until `WS_ACCEPT` arrives — server PR follows.

- Stop stripping `sec-websocket-protocol` in `tunnel.py` (it is end-to-end per RFC 6455 §4.1)
- Parse requested subprotocols from incoming headers, pass to `websockets.connect(subprotocols=…)`
- Send `WS_ACCEPT` with `local_ws.subprotocol` after upstream open
- Add `WsStreamAccept` model and `WS_ACCEPT` `MessageType`
- Bump `PROTOCOL_VERSION` 1.4 → 1.5

## Technical details

- `WS_ACCEPT` is always sent (even when no subprotocol negotiated). Old relays ignore unknown message types, so this is forward-safe.
- A new relay receiving no `WS_ACCEPT` from an old client falls back to accepting without a subprotocol — preserves existing flows where no subprotocol is requested.
- The fix is generic: no ttyd-specific code paths.

## Test plan

- [x] `WsStreamAccept` model serialization
- [x] `WS_ACCEPT` present in `MessageType`
- [x] Subprotocols extracted from header and forwarded to `websockets.connect`
- [x] `WS_ACCEPT` emitted with negotiated subprotocol
- [x] `WS_ACCEPT` emitted with `subprotocol=None` when no header present
- [x] Full suite (161 tests) green, ruff clean
- [ ] End-to-end against a ttyd instance once the matching relay PR lands