### PR TITLE
Release v2605.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## v2605.5 — 2026-05-14
 
-<!-- TODO: Fill in release notes before merging -->
+- **WebSocket subprotocol negotiation** (`PROTOCOL_VERSION` 1.4 → 1.5): forward `Sec-WebSocket-Protocol` end-to-end so upstreams that require subprotocol negotiation (ttyd, mqtt, graphql-ws, etc.) work through a tunnel. Previously the client stripped the header as if it were hop-by-hop, causing browsers to close the WS with code 1006. New `WS_ACCEPT` message carries the upstream-selected subprotocol back to the relay so it can echo it in the 101 response.
+- Requires server protocol 1.5 to take effect; older relays ignore the new message and fall back to no-subprotocol acceptance (no regression for WS flows that don't negotiate one).
 
 ## v2604.4 — 2026-04-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2605.5 — 2026-05-14
+
+<!-- TODO: Fill in release notes before merging -->
+
 ## v2604.4 — 2026-04-26
 
 - **Server notices on the CLI** (`PROTOCOL_VERSION` 1.2 → 1.3): the relay can now push informational messages to a connected client, rendered inline with the rest of the `hle expose` output. Wording is server-controlled so new notices do not require a client release. First use case: dashboard "auto-protect" toggles surface immediately on the CLI.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ curl -fsSL https://get.hle.world | sh
 Installs via pipx (preferred), uv, or pip-in-venv. Supports `--version`:
 
 ```bash
-curl -fsSL https://get.hle.world | sh -s -- --version 2604.4
+curl -fsSL https://get.hle.world | sh -s -- --version 2605.5
 ```
 
 ### pipx

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # HLE Client installer
 # Usage: curl -fsSL https://get.hle.world | sh
-#        curl -fsSL https://get.hle.world | sh -s -- --version 2604.4
+#        curl -fsSL https://get.hle.world | sh -s -- --version 2605.5
 set -e
 
 PACKAGE="hle-client"
@@ -143,7 +143,7 @@ main() {
         error "Install Python from https://python.org or via your package manager."
         exit 1
     }
-    info "Found Python: $PYTHON ($($PYTHON --version 2604.4>&1))"
+    info "Found Python: $PYTHON ($($PYTHON --version 2605.5>&1))"
 
     # Try install methods in order of preference
     if command -v pipx >/dev/null 2>&1; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hle-client"
-version = "2605.4"
+version = "2605.5"
 description = "HomeLab Everywhere — Expose homelab services to the internet with built-in SSO"
 readme = "README.md"
 license = "MIT"

--- a/src/hle_client/__init__.py
+++ b/src/hle_client/__init__.py
@@ -1,3 +1,3 @@
 """HLE Client — HomeLab Everywhere tunnel client."""
 
-__version__ = "2605.4"
+__version__ = "2605.5"


### PR DESCRIPTION
Bump version to `2605.5` and update all version references.

When this PR is merged, a GitHub release will be created automatically,
which triggers PyPI publish and Homebrew formula update.