### PR TITLE
Lift local-upstream WS max_size to 4 MB (was library default 1 MB)

### DIFF
--- a/src/hle_client/tunnel.py
+++ b/src/hle_client/tunnel.py
@@ -851,6 +851,14 @@ class Tunnel:
                 additional_headers=clean_headers,
                 subprotocols=requested_subprotocols or None,
                 ssl=ws_ssl,
+                # Match the control-plane limit. The library default is 1 MB,
+                # which breaks upstreams that send single frames bigger than
+                # that — e.g. Home Assistant's config/entity_registry/list
+                # response easily exceeds 1 MB on a populated install. The
+                # relay-side WS accepts up to WS_MAX_MESSAGE_SIZE; mirroring
+                # it here means an oversized frame fails predictably instead
+                # of silently 1006-closing the browser's WebSocket.
+                max_size=WS_MAX_MESSAGE_SIZE,
             )
         except Exception as exc:
             logger.exception("Failed to open local WS connection to %s", local_ws_url)


### PR DESCRIPTION
## Root cause (browser-observable test)
Reproduced with raw WebSocket through the tunnel:

```
[+134ms] msg auth_required             bytes=48
[+199ms] msg auth_ok                   bytes=42
[+254ms] result id=1 subscribe_events  bytes=53
[+314ms] result id=2 get_config        bytes=5,080
[+396ms] result id=3 get_services      bytes=84,216
[+610ms] result id=4 get_states        bytes=583,824
[+670ms] CLOSE code=1006 clean=false   ← after issuing config/entity_registry/list
```

Same sequence over direct (non-tunneled) HA: every query succeeds, including `config/entity_registry/list` at **1,162,131 bytes**.

## Bug
`tunnel.py:849` opens the local upstream WS without `max_size`. The `websockets` library defaults to **1 MB**, so any single upstream frame larger than that raises `PayloadTooBig` and 1006-closes. HA's `entity_registry/list` on a populated install easily exceeds 1 MB.

The control-plane WS to the relay (line 403) correctly passes `max_size=WS_MAX_MESSAGE_SIZE` (4 MB). The local-WS path was the missed spot.

## Fix
Pass the same `WS_MAX_MESSAGE_SIZE` to the local `websockets.connect()`. Mirrors the relay-side limit so an oversized upstream frame fails predictably (and is still safely below what we can forward) instead of silently breaking the browser's WebSocket.

## Test plan
- [x] `uv run pytest tests/unit` — 161 passed
- [ ] After release + addon update: HA addon panel loads /config/apps/installed correctly through the tunnel