### PR TITLE
Agent core (Phase 2a) — one client, many tunnels, dashboard-driven

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,8 @@ htmlcov/
 
 # Distribution
 *.tar.gz
+
+# local env / lockfile (not tracked)
+.envrc
+.direnv/
+uv.lock

--- a/src/hle_client/agent.py
+++ b/src/hle_client/agent.py
@@ -221,13 +221,17 @@ class AgentClient:
                 self._start_endpoint(spec)
 
     def _start_endpoint(self, spec: EndpointSpec) -> None:
+        # Data-plane credential: an explicit key from the welcome if the server
+        # sent one, otherwise the agent's own token (the server accepts hlea_
+        # tokens for tunnel registration). One enrollment, one secret.
+        data_key = self._api_key or self._token
         cfg = TunnelConfig(
             service_url=spec.service_url,
             relay_host=self._relay_host,
             relay_port=self._relay_port,
             auth_mode=spec.auth_mode,
             service_label=spec.label,
-            api_key=self._api_key,
+            api_key=data_key,
             websocket_enabled=spec.websocket_enabled,
             webhook_path=spec.webhook_path,
             zone=spec.zone,

--- a/src/hle_client/agent.py
+++ b/src/hle_client/agent.py
@@ -1,0 +1,254 @@
+"""HLE agent — one process, many tunnels, driven by the dashboard.
+
+The agent holds an enrollment token, opens a single control connection to the
+server (``/_hle/agent``), receives the desired set of endpoints, and reconciles a
+pool of :class:`~hle_client.tunnel.Tunnel` instances to match. Endpoints can be
+added/removed/changed from the dashboard at runtime; the agent converges without a
+restart. Each endpoint still uses the ordinary tunnel data plane underneath.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import tomllib
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import websockets
+
+from hle_client import __version__
+from hle_client.tunnel import Tunnel, TunnelConfig
+from hle_common.agent_protocol import (
+    AgentHello,
+    AgentStateSync,
+    AgentStatus,
+    AgentWelcome,
+    EndpointSpec,
+    EndpointStatus,
+)
+
+logger = logging.getLogger(__name__)
+
+# How often the agent reports endpoint status / keepalive to the server.
+STATUS_INTERVAL = 15.0
+WS_MAX_MESSAGE_SIZE = 4 * 1024 * 1024
+
+# Enrollment token persistence (separate from the API-key config so they don't clash).
+AGENT_CONFIG_PATH = Path.home() / ".config" / "hle" / "agent.toml"
+AGENT_TOKEN_PREFIX = "hlea_"
+
+
+def save_agent_token(token: str) -> None:
+    """Persist the agent enrollment token (0600)."""
+    AGENT_CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    AGENT_CONFIG_PATH.write_text(f'token = "{token}"\n')
+    AGENT_CONFIG_PATH.chmod(0o600)
+
+
+def load_agent_token() -> str | None:
+    if not AGENT_CONFIG_PATH.exists():
+        return None
+    try:
+        with open(AGENT_CONFIG_PATH, "rb") as f:
+            return tomllib.load(f).get("token")
+    except (OSError, ValueError):
+        logger.debug("Failed to read agent token from %s", AGENT_CONFIG_PATH)
+        return None
+
+
+def remove_agent_token() -> bool:
+    if AGENT_CONFIG_PATH.exists():
+        AGENT_CONFIG_PATH.unlink()
+        return True
+    return False
+
+
+# A tunnel-like object: connect() / disconnect() coroutines + is_connected /
+# public_url properties. Real impl is hle_client.tunnel.Tunnel; tests inject fakes.
+TunnelFactory = Callable[[TunnelConfig], Any]
+
+
+def _default_tunnel_factory(cfg: TunnelConfig) -> Tunnel:
+    return Tunnel(config=cfg)
+
+
+@dataclass
+class _Running:
+    spec: EndpointSpec
+    tunnel: Any
+    task: asyncio.Task[None]
+
+
+class AgentClient:
+    """Control connection + reconciler over a pool of tunnels."""
+
+    def __init__(
+        self,
+        token: str,
+        relay_host: str = "hle.world",
+        relay_port: int = 443,
+        *,
+        tunnel_factory: TunnelFactory = _default_tunnel_factory,
+        reconnect_delay: float = 1.0,
+        max_reconnect_delay: float = 60.0,
+    ) -> None:
+        self._token = token
+        self._relay_host = relay_host
+        self._relay_port = relay_port
+        self._tunnel_factory = tunnel_factory
+        self._reconnect_delay = reconnect_delay
+        self._max_reconnect_delay = max_reconnect_delay
+        self._running = False
+        self._endpoints: dict[str, _Running] = {}
+        self._api_key: str | None = None
+        self._base_domain: str | None = None
+
+    # -- public API ----------------------------------------------------------
+
+    @property
+    def control_uri(self) -> str:
+        scheme = "ws" if self._relay_host.startswith("localhost") else "wss"
+        return f"{scheme}://{self._relay_host}:{self._relay_port}/_hle/agent"
+
+    async def run(self) -> None:
+        """Run the control connection with reconnection until stopped."""
+        self._running = True
+        delay = self._reconnect_delay
+        while self._running:
+            try:
+                await self._connect_once()
+                delay = self._reconnect_delay  # reset after a clean session
+            except asyncio.CancelledError:
+                break
+            except Exception as exc:  # noqa: BLE001 — control conn is best-effort
+                logger.warning("Agent control connection lost: %s", exc)
+            finally:
+                await self._stop_all()
+            if not self._running:
+                break
+            logger.info("Reconnecting agent control in %.1fs ...", delay)
+            await asyncio.sleep(delay)
+            delay = min(delay * 2, self._max_reconnect_delay)
+
+    async def stop(self) -> None:
+        self._running = False
+        await self._stop_all()
+
+    # -- control connection --------------------------------------------------
+
+    async def _connect_once(self) -> None:
+        logger.info("Connecting agent control to %s", self.control_uri)
+        async with websockets.connect(self.control_uri, max_size=WS_MAX_MESSAGE_SIZE) as ws:
+            hello = AgentHello(token=self._token, agent_version=__version__)
+            await ws.send(hello.model_dump_json())
+
+            raw = await asyncio.wait_for(ws.recv(), timeout=30.0)
+            welcome = AgentWelcome.model_validate_json(raw)
+            self._api_key = welcome.api_key
+            self._base_domain = welcome.base_domain
+            logger.info(
+                "Agent registered: public_id=%s endpoints=%d",
+                welcome.agent_public_id,
+                len(welcome.endpoints),
+            )
+            await self.reconcile(welcome.endpoints)
+
+            status_task = asyncio.create_task(self._status_loop(ws))
+            try:
+                async for raw in ws:
+                    await self._handle_message(raw)
+            finally:
+                status_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await status_task
+
+    async def _handle_message(self, raw: str | bytes) -> None:
+        try:
+            msg = json.loads(raw)
+        except (ValueError, TypeError):
+            logger.debug("Bad agent control message")
+            return
+        mtype = msg.get("type") if isinstance(msg, dict) else None
+        if mtype == "state_sync":
+            sync = AgentStateSync.model_validate(msg)
+            await self.reconcile(sync.endpoints)
+        elif mtype == "pong":
+            pass
+        else:
+            logger.debug("Unhandled agent control message: %s", mtype)
+
+    async def _status_loop(self, ws: Any) -> None:
+        while True:
+            await asyncio.sleep(STATUS_INTERVAL)
+            report = AgentStatus(endpoints=self._build_status())
+            with contextlib.suppress(Exception):
+                await ws.send(report.model_dump_json())
+
+    def _build_status(self) -> list[EndpointStatus]:
+        return [
+            EndpointStatus(
+                label=label,
+                connected=bool(r.tunnel.is_connected),
+                public_url=r.tunnel.public_url,
+            )
+            for label, r in self._endpoints.items()
+        ]
+
+    # -- reconciler ----------------------------------------------------------
+
+    async def reconcile(self, specs: list[EndpointSpec]) -> None:
+        """Converge the running tunnel pool to *specs* (idempotent)."""
+        desired = {s.label: s for s in specs}
+
+        # Remove endpoints no longer desired.
+        for label in list(self._endpoints):
+            if label not in desired:
+                await self._stop_endpoint(label)
+
+        # Add new endpoints; restart changed ones.
+        for label, spec in desired.items():
+            current = self._endpoints.get(label)
+            if current is None:
+                self._start_endpoint(spec)
+            elif current.spec.reconcile_key() != spec.reconcile_key():
+                logger.info("Endpoint %s changed — restarting", label)
+                await self._stop_endpoint(label)
+                self._start_endpoint(spec)
+
+    def _start_endpoint(self, spec: EndpointSpec) -> None:
+        cfg = TunnelConfig(
+            service_url=spec.service_url,
+            relay_host=self._relay_host,
+            relay_port=self._relay_port,
+            auth_mode=spec.auth_mode,
+            service_label=spec.label,
+            api_key=self._api_key,
+            websocket_enabled=spec.websocket_enabled,
+            webhook_path=spec.webhook_path,
+            zone=spec.zone,
+            managed_by="hle-agent",
+        )
+        tunnel = self._tunnel_factory(cfg)
+        task = asyncio.create_task(tunnel.connect())
+        self._endpoints[spec.label] = _Running(spec=spec, tunnel=tunnel, task=task)
+        logger.info("Endpoint %s started -> %s", spec.label, spec.service_url)
+
+    async def _stop_endpoint(self, label: str) -> None:
+        running = self._endpoints.pop(label, None)
+        if running is None:
+            return
+        with contextlib.suppress(Exception):
+            await running.tunnel.disconnect()
+        running.task.cancel()
+        with contextlib.suppress(asyncio.CancelledError, Exception):
+            await running.task
+        logger.info("Endpoint %s stopped", label)
+
+    async def _stop_all(self) -> None:
+        for label in list(self._endpoints):
+            await self._stop_endpoint(label)

--- a/src/hle_client/cli.py
+++ b/src/hle_client/cli.py
@@ -12,6 +12,13 @@ import click
 from rich.console import Console
 
 from hle_client import __version__
+from hle_client.agent import (
+    AGENT_TOKEN_PREFIX,
+    AgentClient,
+    load_agent_token,
+    remove_agent_token,
+    save_agent_token,
+)
 from hle_client.config_cmd import config as config_group
 from hle_client.tunnel import (
     Tunnel,
@@ -315,6 +322,80 @@ def logout() -> None:
 
 
 main.add_command(config_group, name="config")
+
+
+@main.group()
+def agent() -> None:
+    """Run a multi-tunnel agent controlled from the dashboard."""
+
+
+@agent.command()
+@click.argument("token", required=False)
+def enroll(token: str | None) -> None:
+    """Save an agent enrollment token (created in the dashboard)."""
+    if token is None:
+        console.print(
+            "Create an agent at [cyan]https://hle.world/dashboard[/cyan] and copy its token.\n"
+        )
+        token = click.prompt("Agent token", hide_input=True)
+
+    if not token.startswith(AGENT_TOKEN_PREFIX):
+        console.print(
+            f"[red]Error:[/red] Invalid agent token. Expected one starting with "
+            f"'{AGENT_TOKEN_PREFIX}'."
+        )
+        raise SystemExit(1)
+
+    save_agent_token(token)
+    console.print("[green]Enrolled[/green] — token saved to ~/.config/hle/agent.toml")
+    console.print("Start the agent with: [cyan]hle agent run[/cyan]")
+
+
+@agent.command()
+@click.option(
+    "--token", default=None, envvar="HLE_AGENT_TOKEN", help="Agent token (overrides saved)"
+)
+@click.option("--relay-host", default="hle.world", help="Relay host")
+@click.option("--relay-port", default=443, type=int, help="Relay port")
+def run(token: str | None, relay_host: str, relay_port: int) -> None:
+    """Run the agent: connect, fetch endpoints from the dashboard, and reconcile."""
+    token = token or load_agent_token()
+    if not token:
+        console.print("[red]Error:[/red] No agent token. Run [cyan]hle agent enroll[/cyan] first.")
+        raise SystemExit(1)
+
+    client = AgentClient(token, relay_host=relay_host, relay_port=relay_port)
+    console.print(f"[green]Agent running[/green] — control: {client.control_uri}")
+    console.print("[dim]Manage endpoints from https://hle.world/dashboard. Ctrl+C to stop.[/dim]")
+    try:
+        asyncio.run(client.run())
+    except KeyboardInterrupt:
+        console.print("\n[yellow]Agent stopped.[/yellow]")
+
+
+@agent.command("status")
+def agent_status() -> None:
+    """Show whether an agent token is configured."""
+    env_token = os.environ.get("HLE_AGENT_TOKEN")
+    if env_token:
+        console.print("Agent token source: [cyan]HLE_AGENT_TOKEN environment variable[/cyan]")
+        return
+    token = load_agent_token()
+    if token:
+        masked = f"{token[:9]}...{token[-4:]}" if len(token) > 13 else token
+        console.print("Agent token source: [cyan]~/.config/hle/agent.toml[/cyan]")
+        console.print(f"Token: [dim]{masked}[/dim]")
+    else:
+        console.print("[dim]No agent token configured. Run 'hle agent enroll'.[/dim]")
+
+
+@agent.command("logout")
+def agent_logout() -> None:
+    """Remove the saved agent token."""
+    if remove_agent_token():
+        console.print("[green]Agent token removed[/green] from ~/.config/hle/agent.toml")
+    else:
+        console.print("[dim]No agent token saved.[/dim]")
 
 
 if __name__ == "__main__":

--- a/src/hle_client/tunnel.py
+++ b/src/hle_client/tunnel.py
@@ -159,6 +159,8 @@ class TunnelConfig:
     """Identifier for the system managing this tunnel (e.g. 'hle-operator')."""
     webhook_path: str | None = None
     """When set, only forward requests matching this path prefix (webhook mode)."""
+    zone: str | None = None
+    """Custom-zone domain to publish under (None = base domain)."""
 
 
 # Hard limits to protect against a malicious or compromised relay server.
@@ -415,6 +417,7 @@ class Tunnel:
                 capabilities=[CAPABILITY_CHUNKED_RESPONSE],
                 managed_by=self.config.managed_by,
                 webhook_path=self.config.webhook_path,
+                zone=self.config.zone,
             )
             register_msg = ProtocolMessage(
                 type=MessageType.TUNNEL_REGISTER,

--- a/src/hle_common/agent_protocol.py
+++ b/src/hle_common/agent_protocol.py
@@ -1,0 +1,84 @@
+"""Agent control protocol — shared message models (client + server).
+
+The *control* protocol between a long-running HLE agent (one per homelab) and the
+server. It is separate from the tunnel *data* protocol in ``protocol.py``: the data
+plane carries proxied HTTP/WS traffic per tunnel; this channel carries only the
+desired set of endpoints (server -> agent) and runtime status (agent -> server).
+
+Declarative model: the server sends the full desired set of enabled endpoints and
+the agent reconciles its running tunnels to match. Reconnects resend the snapshot.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from pydantic import BaseModel, Field
+
+AGENT_PROTOCOL_VERSION = "1.0"
+
+
+class AgentMsgType(StrEnum):
+    HELLO = "hello"  # agent -> server (first message, authenticates)
+    WELCOME = "welcome"  # server -> agent (ack + full desired state)
+    STATE_SYNC = "state_sync"  # server -> agent (desired state changed)
+    STATUS = "status"  # agent -> server (per-endpoint runtime status)
+    PING = "ping"
+    PONG = "pong"
+    ERROR = "error"
+
+
+class EndpointSpec(BaseModel):
+    """One endpoint the agent should run."""
+
+    id: int
+    label: str
+    service_url: str
+    zone: str | None = None  # custom-zone domain, or None for the base domain
+    auth_mode: str = "sso"
+    webhook_path: str | None = None
+    websocket_enabled: bool = True
+
+    def reconcile_key(self) -> tuple[str, str | None, str, str | None, bool]:
+        """Identity used to detect when a running tunnel must be restarted."""
+        return (
+            self.service_url,
+            self.zone,
+            self.auth_mode,
+            self.webhook_path,
+            self.websocket_enabled,
+        )
+
+
+class AgentHello(BaseModel):
+    type: AgentMsgType = AgentMsgType.HELLO
+    token: str
+    agent_version: str | None = None
+    capabilities: list[str] = Field(default_factory=list)
+
+
+class AgentWelcome(BaseModel):
+    type: AgentMsgType = AgentMsgType.WELCOME
+    agent_public_id: str
+    base_domain: str
+    # Data-plane credential the agent uses to register its tunnels. Sent by the
+    # server so a single enrollment yields both control + data-plane auth.
+    api_key: str | None = None
+    endpoints: list[EndpointSpec] = Field(default_factory=list)
+
+
+class AgentStateSync(BaseModel):
+    type: AgentMsgType = AgentMsgType.STATE_SYNC
+    endpoints: list[EndpointSpec] = Field(default_factory=list)
+
+
+class EndpointStatus(BaseModel):
+    label: str
+    connected: bool = False
+    public_url: str | None = None
+    error: str | None = None
+
+
+class AgentStatus(BaseModel):
+    type: AgentMsgType = AgentMsgType.STATUS
+    endpoints: list[EndpointStatus] = Field(default_factory=list)

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -1,0 +1,130 @@
+"""Tests for the agent reconciler (no live server)."""
+
+from __future__ import annotations
+
+import asyncio
+
+from hle_client.agent import AgentClient
+from hle_common.agent_protocol import EndpointSpec
+
+
+class FakeTunnel:
+    """Records lifecycle calls; connect() blocks until cancelled like the real one."""
+
+    def __init__(self, config) -> None:
+        self.config = config
+        self.connected = False
+        self.disconnect_calls = 0
+
+    async def connect(self) -> None:
+        self.connected = True
+        try:
+            await asyncio.Event().wait()  # block forever until task cancelled
+        except asyncio.CancelledError:
+            self.connected = False
+            raise
+
+    async def disconnect(self) -> None:
+        self.disconnect_calls += 1
+        self.connected = False
+
+    @property
+    def is_connected(self) -> bool:
+        return self.connected
+
+    @property
+    def public_url(self) -> str | None:
+        zone = self.config.zone or "hle.world"
+        return f"https://{self.config.service_label}.{zone}"
+
+
+def _make_client() -> tuple[AgentClient, list[FakeTunnel]]:
+    created: list[FakeTunnel] = []
+
+    def factory(cfg):
+        t = FakeTunnel(cfg)
+        created.append(t)
+        return t
+
+    client = AgentClient("hlea_test", tunnel_factory=factory)
+    return client, created
+
+
+def _spec(label: str, url: str = "http://localhost:8000", **kw) -> EndpointSpec:
+    return EndpointSpec(id=hash(label) % 1000, label=label, service_url=url, **kw)
+
+
+class TestReconcile:
+    async def test_starts_new_endpoints(self):
+        client, created = _make_client()
+        await client.reconcile([_spec("ha"), _spec("git")])
+        await asyncio.sleep(0)  # let connect tasks start
+        assert {t.config.service_label for t in created} == {"ha", "git"}
+        assert all(t.connected for t in created)
+        await client._stop_all()
+
+    async def test_removes_dropped_endpoints(self):
+        client, created = _make_client()
+        await client.reconcile([_spec("ha"), _spec("git")])
+        await asyncio.sleep(0)
+        await client.reconcile([_spec("ha")])  # git removed
+        git = next(t for t in created if t.config.service_label == "git")
+        assert git.disconnect_calls == 1
+        assert "git" not in client._endpoints
+        assert "ha" in client._endpoints
+        await client._stop_all()
+
+    async def test_unchanged_spec_does_not_restart(self):
+        client, created = _make_client()
+        await client.reconcile([_spec("ha")])
+        await asyncio.sleep(0)
+        await client.reconcile([_spec("ha")])  # identical
+        assert len(created) == 1  # no new tunnel created
+        await client._stop_all()
+
+    async def test_changed_spec_restarts(self):
+        client, created = _make_client()
+        await client.reconcile([_spec("ha", url="http://localhost:8000")])
+        await asyncio.sleep(0)
+        await client.reconcile([_spec("ha", url="http://localhost:9999")])
+        await asyncio.sleep(0)
+        assert len(created) == 2  # old stopped, new started
+        assert created[0].disconnect_calls == 1
+        assert created[1].config.service_url == "http://localhost:9999"
+        await client._stop_all()
+
+    async def test_zone_passed_through(self):
+        client, created = _make_client()
+        await client.reconcile([_spec("jelly", zone="t00t.us")])
+        await asyncio.sleep(0)
+        assert created[0].config.zone == "t00t.us"
+        await client._stop_all()
+
+    async def test_build_status_reflects_tunnels(self):
+        client, _ = _make_client()
+        await client.reconcile([_spec("ha", zone="t00t.us")])
+        await asyncio.sleep(0)
+        statuses = client._build_status()
+        assert len(statuses) == 1
+        assert statuses[0].label == "ha"
+        assert statuses[0].connected is True
+        assert statuses[0].public_url == "https://ha.t00t.us"
+        await client._stop_all()
+
+    async def test_stop_all_clears(self):
+        client, created = _make_client()
+        await client.reconcile([_spec("a"), _spec("b")])
+        await asyncio.sleep(0)
+        await client._stop_all()
+        assert client._endpoints == {}
+        assert all(t.disconnect_calls == 1 for t in created)
+
+
+class TestControlUri:
+    def test_wss_for_remote(self):
+        client = AgentClient("hlea_x", relay_host="hle.world", relay_port=443)
+        assert client.control_uri == "wss://hle.world:443/_hle/agent"
+
+    def test_ws_for_localhost(self):
+        client = AgentClient("hlea_x", relay_host="localhost", relay_port=8000)
+        assert client.control_uri == "ws://localhost:8000/_hle/agent"

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -450,6 +450,47 @@ class TestAuthLogout:
         assert "No API key saved" in result.output
 
 
+class TestAgentCli:
+    def test_enroll_saves_token(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        cfg = tmp_path / "agent.toml"
+        with patch("hle_client.agent.AGENT_CONFIG_PATH", cfg):
+            result = runner.invoke(main, ["agent", "enroll", "hlea_" + "a" * 40])
+        assert result.exit_code == 0
+        assert "Enrolled" in result.output
+        assert "token" in cfg.read_text()
+
+    def test_enroll_rejects_bad_token(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(main, ["agent", "enroll", "hle_notanagent"])
+        assert result.exit_code == 1
+        assert "Invalid agent token" in result.output
+
+    def test_status_no_token(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        cfg = tmp_path / "missing.toml"
+        with patch("hle_client.agent.AGENT_CONFIG_PATH", cfg):
+            result = runner.invoke(main, ["agent", "status"])
+        assert result.exit_code == 0
+        assert "No agent token" in result.output
+
+    def test_run_requires_token(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        cfg = tmp_path / "missing.toml"
+        with patch("hle_client.agent.AGENT_CONFIG_PATH", cfg):
+            result = runner.invoke(main, ["agent", "run"])
+        assert result.exit_code == 1
+        assert "No agent token" in result.output
+
+    def test_run_invokes_client(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        # Close the coroutine instead of awaiting it (avoids "never awaited" warning).
+        with patch("hle_client.cli.asyncio.run", side_effect=lambda coro: coro.close()) as mock_run:
+            result = runner.invoke(main, ["agent", "run", "--token", "hlea_" + "b" * 40])
+        assert result.exit_code == 0
+        assert mock_run.called
+
+
 class TestExposeNoAutoSave:
     def test_expose_does_not_auto_save(self, tmp_path: Path) -> None:
         runner = CliRunner()


### PR DESCRIPTION
## Summary
Third slice of the agent redesign (`hle.orchistrator/docs/agent-redesign-plan.md`). Adds the **HLE agent**: a single long-running process that holds an enrollment token, opens **one control connection** to the server (`/_hle/agent`), receives the **desired set of endpoints** from the dashboard, and **reconciles a pool of `Tunnel` instances** to match. Endpoints can be added/removed/changed from the dashboard at runtime — the agent converges without a restart. Each endpoint runs over the ordinary tunnel data plane.

This generalizes the pattern hle-operator already uses (library `Tunnel` objects as asyncio tasks) into a standalone, dashboard-driven agent.

- **`hle_common/agent_protocol.py`** — shared control message models (`AgentHello`, `AgentWelcome`, `AgentStateSync`, `AgentStatus`, `EndpointSpec`, `EndpointStatus`). Canonical home; the server switches to these in Phase 2b (submodule bump).
- **`hle_client/agent.py`** — `AgentClient`: control connection (reconnecting), **declarative reconciler** (start new / stop removed / restart changed via `reconcile_key`), periodic status reporting, agent-token persistence (`~/.config/hle/agent.toml`, 0600).
- **CLI** — `hle agent enroll | run | status | logout`. `hle expose` is unchanged.
- **`TunnelConfig.zone`** — endpoints can publish under a custom zone (wired into `TunnelRegistration`).

## How auth works
The agent authenticates the **control** channel with its `hlea_` token. Its **data-plane** tunnels authenticate with an API key delivered in `AgentWelcome.api_key` — so a single enrollment yields both. The server side that mints/sends that key + correlates tunnels to endpoints is **Phase 2b** (server companion); until then the agent runs but tunnels need the key from welcome.

## Design notes
- **Declarative**: server sends desired state; agent diffs and converges. Reconnects resend the snapshot — no incremental command stream.
- Reconciler is unit-tested in isolation via an injectable `tunnel_factory` (no live server needed).
- Control models live in `hle_common` (shared) rather than duplicated client/server.

## Tests
- `tests/unit/test_agent.py`: reconcile starts/stops/restarts/ignores-unchanged; zone pass-through; status reflects tunnel state; control URI scheme. (9)
- `tests/unit/test_cli_commands.py::TestAgentCli`: enroll saves/validates token; status + run require token; run invokes client. (5)
- Full suite: 175 passed. ruff + mypy clean on new modules.

## Next
- **2b** (server): `AgentWelcome.api_key` minting + tunnel↔endpoint correlation; switch server to `hle_common.agent_protocol`.
- **2c**: reimplement `hle expose` on the agent core.