### PR TITLE
Release v2606.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2606.1 — 2026-06-04
+
+<!-- TODO: Fill in release notes before merging -->
+
 ## v2605.5 — 2026-05-14
 
 - **WebSocket subprotocol negotiation** (`PROTOCOL_VERSION` 1.4 → 1.5): forward `Sec-WebSocket-Protocol` end-to-end so upstreams that require subprotocol negotiation (ttyd, mqtt, graphql-ws, etc.) work through a tunnel. Previously the client stripped the header as if it were hop-by-hop, causing browsers to close the WS with code 1006. New `WS_ACCEPT` message carries the upstream-selected subprotocol back to the relay so it can echo it in the 101 response.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,16 @@
 
 ## v2606.1 — 2026-06-04
 
-<!-- TODO: Fill in release notes before merging -->
+### Added
+- **`hle agent`** — run one agent that hosts many tunnels, managed from the dashboard.
+  - `hle agent enroll <token>` — save an agent enrollment token (created in the dashboard).
+  - `hle agent run` — connect to the server, fetch the desired endpoints, and reconcile a
+    pool of tunnels live (add/remove/change endpoints from the dashboard with no restart).
+  - `hle agent status` / `hle agent logout`.
+  - Shared agent control protocol in `hle_common.agent_protocol`.
+- `TunnelConfig.zone` — publish a tunnel under a custom zone (not just the base domain).
+
+Requires a server with the agent control plane enabled (`HLE_AGENTS_ENABLED`).
 
 ## v2605.5 — 2026-05-14
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ curl -fsSL https://get.hle.world | sh
 Installs via pipx (preferred), uv, or pip-in-venv. Supports `--version`:
 
 ```bash
-curl -fsSL https://get.hle.world | sh -s -- --version 2605.5
+curl -fsSL https://get.hle.world | sh -s -- --version 2606.1
 ```
 
 ### pipx

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # HLE Client installer
 # Usage: curl -fsSL https://get.hle.world | sh
-#        curl -fsSL https://get.hle.world | sh -s -- --version 2605.5
+#        curl -fsSL https://get.hle.world | sh -s -- --version 2606.1
 set -e
 
 PACKAGE="hle-client"
@@ -143,7 +143,7 @@ main() {
         error "Install Python from https://python.org or via your package manager."
         exit 1
     }
-    info "Found Python: $PYTHON ($($PYTHON --version 2605.5>&1))"
+    info "Found Python: $PYTHON ($($PYTHON --version 2606.1>&1))"
 
     # Try install methods in order of preference
     if command -v pipx >/dev/null 2>&1; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hle-client"
-version = "2605.6"
+version = "2606.1"
 description = "HomeLab Everywhere — Expose homelab services to the internet with built-in SSO"
 readme = "README.md"
 license = "MIT"

--- a/src/hle_client/__init__.py
+++ b/src/hle_client/__init__.py
@@ -1,3 +1,3 @@
 """HLE Client — HomeLab Everywhere tunnel client."""
 
-__version__ = "2605.5"
+__version__ = "2606.1"


### PR DESCRIPTION
Bump version to `2606.1` and update all version references.

When this PR is merged, a GitHub release will be created automatically,
which triggers PyPI publish and Homebrew formula update.