### PR TITLE
Apex tunnels + generic options passthrough

### DIFF
--- a/src/hle_client/cli.py
+++ b/src/hle_client/cli.py
@@ -66,7 +66,23 @@ def _parse_auth_spec(spec: str) -> tuple[str, str]:
 @main.command()
 @click.option("--service", required=True, help="Local service URL (e.g. http://localhost:8080)")
 @click.option("--auth", type=click.Choice(["sso", "none"]), default="sso", help="Auth mode")
-@click.option("--label", "service_label", required=True, help="Service label (e.g. ha, jellyfin)")
+@click.option(
+    "--label",
+    "service_label",
+    default=None,
+    help="Service label (e.g. ha, jellyfin). Required unless --apex is set.",
+)
+@click.option(
+    "--zone",
+    default=None,
+    help="Custom zone to publish under (e.g. t00t.us). Required for --apex.",
+)
+@click.option(
+    "--apex",
+    is_flag=True,
+    default=False,
+    help="Serve at the bare zone root (e.g. https://t00t.us) instead of a subdomain.",
+)
 @click.option(
     "--api-key",
     default=None,
@@ -107,6 +123,8 @@ def expose(
     service: str,
     auth: str,
     service_label: str | None,
+    zone: str | None,
+    apex: bool,
     api_key: str | None,
     websocket: bool,
     verify_ssl: bool,
@@ -115,6 +133,14 @@ def expose(
     allow: tuple[str, ...],
 ) -> None:
     """Expose a local service to the internet."""
+    # Validate apex / label / zone combination up front.
+    if apex and not zone:
+        console.print("[red]Error:[/red] --apex requires --zone (e.g. --zone t00t.us).")
+        raise SystemExit(1)
+    if not apex and not service_label:
+        console.print("[red]Error:[/red] --label is required (or use --apex with --zone).")
+        raise SystemExit(1)
+
     upstream_auth_tuple: tuple[str, str] | None = None
     if upstream_basic_auth:
         if ":" not in upstream_basic_auth:
@@ -127,6 +153,8 @@ def expose(
         service_url=service,
         auth_mode=auth,
         service_label=service_label,
+        zone=zone,
+        apex=apex,
         api_key=api_key,
         websocket_enabled=websocket,
         verify_ssl=verify_ssl,

--- a/src/hle_client/cli.py
+++ b/src/hle_client/cli.py
@@ -84,6 +84,14 @@ def _parse_auth_spec(spec: str) -> tuple[str, str]:
     help="Serve at the bare zone root (e.g. https://t00t.us) instead of a subdomain.",
 )
 @click.option(
+    "--option",
+    "options",
+    multiple=True,
+    metavar="KEY=VALUE",
+    help="Generic server-interpreted parameter, passed through verbatim. "
+    "Repeatable. The server defines which keys are valid. Example: --option zone=t00t.us",
+)
+@click.option(
     "--api-key",
     default=None,
     envvar="HLE_API_KEY",
@@ -125,6 +133,7 @@ def expose(
     service_label: str | None,
     zone: str | None,
     apex: bool,
+    options: tuple[str, ...],
     api_key: str | None,
     websocket: bool,
     verify_ssl: bool,
@@ -133,6 +142,15 @@ def expose(
     allow: tuple[str, ...],
 ) -> None:
     """Expose a local service to the internet."""
+    # Parse --option KEY=VALUE pairs into a passthrough dict.
+    options_dict: dict[str, str] = {}
+    for opt in options:
+        key, sep, val = opt.partition("=")
+        if not sep or not key:
+            console.print(f"[red]Error:[/red] --option must be KEY=VALUE (got '{opt}').")
+            raise SystemExit(1)
+        options_dict[key.strip()] = val
+
     # Validate apex / label / zone combination up front.
     if apex and not zone:
         console.print("[red]Error:[/red] --apex requires --zone (e.g. --zone t00t.us).")
@@ -155,6 +173,7 @@ def expose(
         service_label=service_label,
         zone=zone,
         apex=apex,
+        options=options_dict,
         api_key=api_key,
         websocket_enabled=websocket,
         verify_ssl=verify_ssl,

--- a/src/hle_client/tunnel.py
+++ b/src/hle_client/tunnel.py
@@ -161,6 +161,8 @@ class TunnelConfig:
     """When set, only forward requests matching this path prefix (webhook mode)."""
     zone: str | None = None
     """Custom-zone domain to publish under (None = base domain)."""
+    apex: bool = False
+    """Serve at the bare zone root (e.g. t00t.us) instead of a subdomain. Requires `zone`."""
 
 
 # Hard limits to protect against a malicious or compromised relay server.
@@ -406,9 +408,12 @@ class Tunnel:
             self._ws = ws
 
             # --- Registration handshake ---
+            # Apex tunnels serve at the bare zone root, so the label is unused
+            # for routing — but the wire model still requires a non-empty value.
+            service_label = self.config.service_label or ("apex" if self.config.apex else None)
             registration = TunnelRegistration(
                 service_url=self.config.service_url,
-                service_label=self.config.service_label,
+                service_label=service_label,
                 api_key=api_key,
                 client_version=__version__,
                 protocol_version=PROTOCOL_VERSION,
@@ -418,6 +423,7 @@ class Tunnel:
                 managed_by=self.config.managed_by,
                 webhook_path=self.config.webhook_path,
                 zone=self.config.zone,
+                apex=self.config.apex,
             )
             register_msg = ProtocolMessage(
                 type=MessageType.TUNNEL_REGISTER,

--- a/src/hle_client/tunnel.py
+++ b/src/hle_client/tunnel.py
@@ -408,12 +408,9 @@ class Tunnel:
             self._ws = ws
 
             # --- Registration handshake ---
-            # Apex tunnels serve at the bare zone root, so the label is unused
-            # for routing — but the wire model still requires a non-empty value.
-            service_label = self.config.service_label or ("apex" if self.config.apex else None)
             registration = TunnelRegistration(
                 service_url=self.config.service_url,
-                service_label=service_label,
+                service_label=self.config.service_label,
                 api_key=api_key,
                 client_version=__version__,
                 protocol_version=PROTOCOL_VERSION,

--- a/src/hle_client/tunnel.py
+++ b/src/hle_client/tunnel.py
@@ -163,6 +163,8 @@ class TunnelConfig:
     """Custom-zone domain to publish under (None = base domain)."""
     apex: bool = False
     """Serve at the bare zone root (e.g. t00t.us) instead of a subdomain. Requires `zone`."""
+    options: dict[str, str] = field(default_factory=dict)
+    """Generic server-interpreted feature parameters, passed through verbatim."""
 
 
 # Hard limits to protect against a malicious or compromised relay server.
@@ -421,6 +423,7 @@ class Tunnel:
                 webhook_path=self.config.webhook_path,
                 zone=self.config.zone,
                 apex=self.config.apex,
+                options=self.config.options,
             )
             register_msg = ProtocolMessage(
                 type=MessageType.TUNNEL_REGISTER,

--- a/src/hle_common/models.py
+++ b/src/hle_common/models.py
@@ -21,6 +21,12 @@ CAPABILITY_CHUNKED_RESPONSE = "chunked_response"
 # Validation patterns
 _SERVICE_LABEL_RE = re.compile(r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$")
 
+# Guardrails for the generic `options` passthrough bag.
+_MAX_OPTIONS = 32
+_MAX_OPTION_KEY_LEN = 64
+_MAX_OPTION_VALUE_LEN = 1024
+_OPTION_KEY_RE = re.compile(r"^[a-z0-9][a-z0-9_]*$")
+
 
 class TunnelRegistration(BaseModel):
     """Payload the client sends when requesting a new tunnel."""
@@ -39,6 +45,12 @@ class TunnelRegistration(BaseModel):
     managed_by: str | None = None  # e.g. "hle-operator" for K8s operator tunnels
     webhook_path: str | None = None  # e.g. "/webhook/github" — restricts to this path prefix
     apex: bool = False  # serve at the bare zone root (e.g. t00t.us); requires `zone`
+    # Generic, server-interpreted feature parameters. The client transports
+    # these verbatim (e.g. from `--option key=value`) without understanding
+    # them; the server defines the vocabulary and validates. This lets the
+    # server gain features without requiring a client release. Client→server
+    # intent only — the client must never act on server-returned config.
+    options: dict[str, str] = {}
 
     @field_validator("webhook_path")
     @classmethod
@@ -78,6 +90,24 @@ class TunnelRegistration(BaseModel):
             v = v[:63].rstrip("-")
         if not _SERVICE_LABEL_RE.match(v):
             raise ValueError(f"service_label '{v}' does not match required format")
+        return v
+
+    @field_validator("options")
+    @classmethod
+    def validate_options(cls, v: dict[str, str]) -> dict[str, str]:
+        # Transport-level guardrails only — the server owns the vocabulary and
+        # rejects keys it doesn't recognize. This keeps a malicious or buggy
+        # client from flooding the bag, without the contract needing to know
+        # which keys exist.
+        if len(v) > _MAX_OPTIONS:
+            raise ValueError(f"too many options (max {_MAX_OPTIONS})")
+        for key, val in v.items():
+            if not isinstance(key, str) or not isinstance(val, str):
+                raise ValueError("option keys and values must be strings")
+            if not _OPTION_KEY_RE.match(key) or len(key) > _MAX_OPTION_KEY_LEN:
+                raise ValueError(f"invalid option key: {key!r}")
+            if len(val) > _MAX_OPTION_VALUE_LEN:
+                raise ValueError(f"option {key!r} value too long (max {_MAX_OPTION_VALUE_LEN})")
         return v
 
     @model_validator(mode="after")

--- a/src/hle_common/models.py
+++ b/src/hle_common/models.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import re
 from typing import Any, Literal
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, field_validator, model_validator
 
 # ---------------------------------------------------------------------------
 # Tunnel registration (client -> server -> client)
@@ -26,7 +26,9 @@ class TunnelRegistration(BaseModel):
     """Payload the client sends when requesting a new tunnel."""
 
     service_url: str
-    service_label: str  # required — user-chosen name, e.g. "ha", "jellyfin"
+    # User-chosen name, e.g. "ha", "jellyfin". Optional only when `apex` is set
+    # (an apex tunnel serves at the bare zone root and has no label).
+    service_label: str | None = None
     api_key: str  # required — hle_<32 hex chars>
     client_version: str | None = None
     protocol_version: str | None = None  # sent by clients >= 0.5.0
@@ -58,7 +60,11 @@ class TunnelRegistration(BaseModel):
 
     @field_validator("service_label")
     @classmethod
-    def validate_service_label(cls, v: str) -> str:
+    def validate_service_label(cls, v: str | None) -> str | None:
+        # Empty/None is allowed here; the apex-vs-label rule is enforced in the
+        # model validator below so the wire contract states the rule explicitly.
+        if v is None:
+            return None
         # Auto-sanitize: lowercase, replace common separators with
         # hyphens, strip invalid characters, collapse runs.
         v = v.lower()
@@ -67,12 +73,20 @@ class TunnelRegistration(BaseModel):
         v = re.sub(r"-{2,}", "-", v)
         v = v.strip("-")
         if not v:
-            raise ValueError("service_label is required and must contain valid characters")
+            return None
         if len(v) > 63:
             v = v[:63].rstrip("-")
         if not _SERVICE_LABEL_RE.match(v):
             raise ValueError(f"service_label '{v}' does not match required format")
         return v
+
+    @model_validator(mode="after")
+    def validate_label_or_apex(self) -> TunnelRegistration:
+        # A tunnel is addressed either by a label (a subdomain) or by the apex.
+        # Exactly the absence of a label requires apex to be set.
+        if not self.service_label and not self.apex:
+            raise ValueError("service_label is required unless apex is set")
+        return self
 
 
 class TunnelRegistrationResponse(BaseModel):

--- a/src/hle_common/models.py
+++ b/src/hle_common/models.py
@@ -36,6 +36,7 @@ class TunnelRegistration(BaseModel):
     zone: str | None = None  # custom zone domain for enterprise routing
     managed_by: str | None = None  # e.g. "hle-operator" for K8s operator tunnels
     webhook_path: str | None = None  # e.g. "/webhook/github" — restricts to this path prefix
+    apex: bool = False  # serve at the bare zone root (e.g. t00t.us); requires `zone`
 
     @field_validator("webhook_path")
     @classmethod

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -71,6 +71,47 @@ class TestTunnelRegistration:
         with pytest.raises(ValueError):
             TunnelRegistration(service_url="http://localhost:5000")
 
+    def test_label_optional_when_apex(self):
+        reg = TunnelRegistration(
+            service_url="http://localhost:5000",
+            api_key="hle_abc123",
+            apex=True,
+        )
+        assert reg.service_label is None
+        assert reg.apex is True
+
+    def test_label_required_without_apex(self):
+        with pytest.raises(ValueError, match="service_label is required"):
+            TunnelRegistration(service_url="http://localhost:5000", api_key="hle_abc123")
+
+    def test_options_passthrough(self):
+        reg = TunnelRegistration(
+            service_url="http://localhost:5000",
+            api_key="hle_abc123",
+            service_label="ha",
+            options={"zone": "t00t.us", "geo_region": "eu"},
+        )
+        assert reg.options["zone"] == "t00t.us"
+        assert reg.options["geo_region"] == "eu"
+
+    def test_options_reject_invalid_key(self):
+        with pytest.raises(ValueError, match="invalid option key"):
+            TunnelRegistration(
+                service_url="http://localhost:5000",
+                api_key="hle_abc123",
+                service_label="ha",
+                options={"Bad Key!": "x"},
+            )
+
+    def test_options_reject_too_many(self):
+        with pytest.raises(ValueError, match="too many options"):
+            TunnelRegistration(
+                service_url="http://localhost:5000",
+                api_key="hle_abc123",
+                service_label="ha",
+                options={f"k{i}": "v" for i in range(40)},
+            )
+
     def test_tunnel_registration_service_label_sanitization(self):
         """Labels are auto-sanitized instead of rejected."""
         # Underscores → hyphens


### PR DESCRIPTION
## Summary
Make the open-source client more generic: support apex (zone-root) tunnels and add a server-interpreted `options` passthrough so the client carries no feature-specific semantics beyond the endpoint.

- `apex` flag on `TunnelRegistration` — serve at the bare zone root (e.g. `t00t.us`) instead of a subdomain
- `service_label` now Optional; a model validator states the contract (label **or** apex)
- `options: dict[str, str]` — generic, server-interpreted parameter bag, transported verbatim
- CLI: `--apex`, `--zone`, and repeatable `--option KEY=VALUE` on `expose`

## Technical details
- The client hardcodes no vocabulary. The server owns which `options` keys are valid and folds them into typed fields; unknown keys are rejected server-side. New server features need no client release.
- Transport guardrails on `options` (max 32 keys, key format, value length) live in the shared model; semantics do not.
- `options` is client→server intent only — the client never acts on server-returned config.
- Minor protocol addition; old clients (no `apex`/`options`) unaffected.

## Tests
- label-optional-when-apex, label-required-without-apex
- options passthrough + invalid-key + too-many-keys validation
- All 175 client tests pass; ruff clean.