### PR TITLE
fix: normalize scheme-less service URLs (silent 502s on every request)

### DIFF
--- a/src/hle_client/proxy.py
+++ b/src/hle_client/proxy.py
@@ -261,7 +261,11 @@ class LocalProxy:
             )
         except httpx.HTTPError as exc:
             logger.error("HTTP error forwarding %s %s: %s", method, url, exc)
-            return 502, {"content-type": "text/plain"}, b"Bad Gateway: unexpected error"
+            # Include the exception class so the failure mode is identifiable
+            # from the relay side (e.g. via tunnel debug capture) without
+            # leaking error details.
+            reason = f"Bad Gateway: unexpected error ({exc.__class__.__name__})"
+            return 502, {"content-type": "text/plain"}, reason.encode()
 
     async def stream_http(
         self,

--- a/src/hle_client/tunnel.py
+++ b/src/hle_client/tunnel.py
@@ -166,6 +166,15 @@ class TunnelConfig:
     options: dict[str, str] = field(default_factory=dict)
     """Generic server-interpreted feature parameters, passed through verbatim."""
 
+    def __post_init__(self) -> None:
+        # A scheme-less service URL ("localhost:9998") makes httpx treat
+        # "localhost" as the protocol and fail every forwarded request with
+        # UnsupportedProtocol ("Bad Gateway: unexpected error" for visitors,
+        # while the tunnel itself registers fine) — normalize to http:// here
+        # so every entry point (expose, forward, agent endpoints) is covered.
+        if self.service_url and "://" not in self.service_url:
+            self.service_url = f"http://{self.service_url}"
+
 
 # Hard limits to protect against a malicious or compromised relay server.
 WS_MAX_MESSAGE_SIZE = 4 * 1024 * 1024  # 4 MB — control-plane WebSocket message limit

--- a/tests/unit/test_service_url_normalization.py
+++ b/tests/unit/test_service_url_normalization.py
@@ -1,0 +1,30 @@
+"""Tests for service URL scheme normalization in TunnelConfig."""
+
+from __future__ import annotations
+
+from hle_client.tunnel import TunnelConfig
+
+
+class TestServiceUrlNormalization:
+    def test_schemeless_host_port_gets_http(self):
+        # Regression: "localhost:9998" made httpx treat "localhost" as the
+        # protocol — the tunnel registered fine but every forwarded request
+        # failed with UnsupportedProtocol / "Bad Gateway: unexpected error".
+        cfg = TunnelConfig(service_url="localhost:9998", service_label="tv")
+        assert cfg.service_url == "http://localhost:9998"
+
+    def test_schemeless_ip_port_gets_http(self):
+        cfg = TunnelConfig(service_url="192.168.1.10:8123", service_label="ha")
+        assert cfg.service_url == "http://192.168.1.10:8123"
+
+    def test_http_url_unchanged(self):
+        cfg = TunnelConfig(service_url="http://localhost:7681", service_label="ssh")
+        assert cfg.service_url == "http://localhost:7681"
+
+    def test_https_url_unchanged(self):
+        cfg = TunnelConfig(service_url="https://192.168.2.200:8006/", service_label="prox")
+        assert cfg.service_url == "https://192.168.2.200:8006/"
+
+    def test_empty_url_unchanged(self):
+        cfg = TunnelConfig(service_url="", service_label="x")
+        assert cfg.service_url == ""


### PR DESCRIPTION
## Summary
`hle expose --service localhost:9998` (no scheme) registers the tunnel fine, but httpx then parses `localhost:` as the request protocol and every forwarded request dies with `UnsupportedProtocol` — visitors get `Bad Gateway: unexpected error` while the tunnel looks healthy. Found in production via the new relay-side tunnel debug capture (jspanos/hle#290).

- `TunnelConfig.__post_init__` normalizes scheme-less service URLs to `http://…`, covering expose/forward/agent endpoints in one place
- Catch-all 502 body now names the exception class (`Bad Gateway: unexpected error (UnsupportedProtocol)`) so future unknowns are diagnosable from the relay side

## Test plan
- New `tests/unit/test_service_url_normalization.py` (5 cases: host:port, ip:port, http/https unchanged, empty unchanged)
- Full suite: 185 passed; ruff + format clean