### PR TITLE
Release v2607.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v2607.1 — 2026-07-16
+
+### Fixed
+- **Scheme-less service URLs** (`hle expose --service localhost:9998`) registered the
+  tunnel successfully but failed every forwarded request with
+  `UnsupportedProtocol` — visitors saw "Bad Gateway: unexpected error" while the
+  tunnel looked healthy. Service URLs without a scheme are now normalized to
+  `http://` across all entry points (expose, forward, agent endpoints).
+- The catch-all 502 response now names the exception class
+  (`Bad Gateway: unexpected error (UnsupportedProtocol)`) so unknown failure
+  modes are diagnosable from the relay side.
+- `install.sh`: repaired a `2>&1` redirect clobbered by an earlier version bump.
+
 ## v2606.1 — 2026-06-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ curl -fsSL https://get.hle.world | sh
 Installs via pipx (preferred), uv, or pip-in-venv. Supports `--version`:
 
 ```bash
-curl -fsSL https://get.hle.world | sh -s -- --version 2606.1
+curl -fsSL https://get.hle.world | sh -s -- --version 2607.1
 ```
 
 ### pipx

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # HLE Client installer
 # Usage: curl -fsSL https://get.hle.world | sh
-#        curl -fsSL https://get.hle.world | sh -s -- --version 2606.1
+#        curl -fsSL https://get.hle.world | sh -s -- --version 2607.1
 set -e
 
 PACKAGE="hle-client"
@@ -143,7 +143,7 @@ main() {
         error "Install Python from https://python.org or via your package manager."
         exit 1
     }
-    info "Found Python: $PYTHON ($($PYTHON --version 2606.1>&1))"
+    info "Found Python: $PYTHON ($($PYTHON --version 2>&1))"
 
     # Try install methods in order of preference
     if command -v pipx >/dev/null 2>&1; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hle-client"
-version = "2606.1"
+version = "2607.1"
 description = "HomeLab Everywhere — Expose homelab services to the internet with built-in SSO"
 readme = "README.md"
 license = "MIT"

--- a/src/hle_client/__init__.py
+++ b/src/hle_client/__init__.py
@@ -1,3 +1,3 @@
 """HLE Client — HomeLab Everywhere tunnel client."""
 
-__version__ = "2606.1"
+__version__ = "2607.1"


### PR DESCRIPTION
## Summary
Release v2607.1 — service-URL scheme normalization fix.

- Bump version to 2607.1 (pyproject.toml, __init__.py, README.md, install.sh)
- CHANGELOG entry for v2607.1
- Repair `install.sh` `2>&1` redirect clobbered by an earlier version bump

See CHANGELOG.md for details.