### PR TITLE
fix: strip trailing slash in local WS URL (fixes Proxmox VM consoles over tunnels)

### DIFF
--- a/src/hle_client/tunnel.py
+++ b/src/hle_client/tunnel.py
@@ -183,6 +183,21 @@ MAX_WS_STREAMS = 100
 _WS_CLOSE_REASON_MAX = 123
 
 
+def _build_local_ws_url(service_url: str, path: str) -> str:
+    """Join the local service URL and a WS path into a ``ws(s)://`` URL.
+
+    ``path`` always starts with ``/``. The base has any trailing slash
+    stripped first, otherwise a service URL like ``https://host:8006/`` would
+    yield a doubled slash (``wss://host:8006//api2/...``). The HTTP path is
+    unaffected (httpx normalizes ``base_url`` + path), but ``websockets``
+    does not, and strict upstreams reject the ``//`` — e.g. Proxmox's
+    vncwebsocket answers HTTP 500, breaking every VM/CT console over the
+    tunnel.
+    """
+    base = service_url.replace("http://", "ws://").replace("https://", "wss://")
+    return f"{base.rstrip('/')}{path}"
+
+
 def _build_ws_close_diagnostics(
     stats: dict[str, Any] | None, exc_type: str | None
 ) -> dict[str, Any] | None:
@@ -814,11 +829,9 @@ class Tunnel:
                 return
             self._ws_streams[stream_id] = pending_queue
 
-        # Build the local WS URL.
-        local_base = self.config.service_url.replace("http://", "ws://").replace(
-            "https://", "wss://"
-        )
-        local_ws_url = f"{local_base}{open_req.path}"
+        # Build the local WS URL (see _build_local_ws_url for the trailing-
+        # slash handling that keeps strict upstreams like Proxmox happy).
+        local_ws_url = _build_local_ws_url(self.config.service_url, open_req.path)
 
         # Strip WebSocket handshake and hop-by-hop headers — these belong to
         # the browser↔relay connection, not the client↔local service connection.

--- a/tests/unit/test_ws_url.py
+++ b/tests/unit/test_ws_url.py
@@ -1,0 +1,34 @@
+"""Tests for local WebSocket URL construction (trailing-slash handling)."""
+
+from __future__ import annotations
+
+from hle_client.tunnel import _build_local_ws_url
+
+
+class TestBuildLocalWsUrl:
+    def test_trailing_slash_does_not_double(self):
+        # Regression: a service URL with a trailing slash produced
+        # "wss://host:8006//api2/..." which Proxmox's vncwebsocket rejects
+        # with HTTP 500, breaking every VM/CT console over the tunnel.
+        url = _build_local_ws_url(
+            "https://192.168.2.200:8006/",
+            "/api2/json/nodes/milkyway/qemu/107/vncwebsocket?port=5900",
+        )
+        assert url == (
+            "wss://192.168.2.200:8006/api2/json/nodes/milkyway/qemu/107/vncwebsocket?port=5900"
+        )
+        assert "//api2" not in url
+
+    def test_no_trailing_slash_unchanged(self):
+        url = _build_local_ws_url("http://localhost:7681", "/ws")
+        assert url == "ws://localhost:7681/ws"
+
+    def test_https_maps_to_wss(self):
+        assert _build_local_ws_url("https://host:8006", "/x").startswith("wss://")
+
+    def test_http_maps_to_ws(self):
+        assert _build_local_ws_url("http://host:7900", "/websockify").startswith("ws://")
+
+    def test_query_string_preserved(self):
+        url = _build_local_ws_url("https://h:8006/", "/vncwebsocket?port=5901&vncticket=AB%2FCD")
+        assert url == "wss://h:8006/vncwebsocket?port=5901&vncticket=AB%2FCD"


### PR DESCRIPTION
## Summary
A service URL with a **trailing slash** (`--service https://192.168.2.200:8006/`) produced a **doubled slash** in the upstream WebSocket URL:

```
wss://192.168.2.200:8006//api2/json/nodes/.../vncwebsocket?port=5900&vncticket=...
```

The HTTP proxy path is unaffected (httpx normalizes `base_url` + path), but `websockets.connect` does raw string concatenation, and strict upstreams reject the `//`. **Proxmox's `vncwebsocket` answers HTTP 500**, so every VM/CT console (noVNC) failed to connect over the tunnel — while the rest of the Proxmox UI worked fine.

Diagnosed from the client log, which showed *every* console attempt failing identically:
```
ERROR hle_client.tunnel  Failed to open local WS connection to wss://...:8006//api2/.../vncwebsocket?...
websockets.exceptions.InvalidStatus: server rejected WebSocket connection: HTTP 500
```

Tunnels whose service URL had **no** trailing slash (ttyd `http://localhost:7681`, plain websockify, etc.) were unaffected — which is exactly why only some WebSocket upstreams broke and it looked intermittent.

## Fix
Extract `_build_local_ws_url(service_url, path)` which `rstrip('/')`s the base before appending the always-leading-slash path, and use it in `_handle_ws_open`.

## Test plan
- New `tests/unit/test_ws_url.py`: trailing-slash no-double (the Proxmox URL), no-slash unchanged, http→ws / https→wss mapping, query-string preserved.
- Full suite: 190 passed.