### PR TITLE
feat: report upstream WS connect failures to the relay (debug visibility)

### DIFF
--- a/src/hle_client/tunnel.py
+++ b/src/hle_client/tunnel.py
@@ -183,6 +183,38 @@ MAX_WS_STREAMS = 100
 _WS_CLOSE_REASON_MAX = 123
 
 
+def _sanitize_ws_url(url: str) -> str:
+    """Drop the query string from a WS URL before logging/reporting it.
+
+    Proxmox vncwebsocket (and similar) carry single-use secrets in the query
+    string (``vncticket``, tokens), which must never be stored in the relay's
+    debug capture. The path is what matters for diagnosis (e.g. spotting a
+    doubled slash), so keep it and drop everything after ``?``.
+    """
+    return url.split("?", 1)[0]
+
+
+def _upstream_connect_diagnostics(url: str, exc: BaseException) -> dict[str, Any]:
+    """Structured diagnostics for a failed upstream WS connect.
+
+    Sent to the relay in the WS_CLOSE ``diagnostics`` field so the failure is
+    visible in admin debug capture without reading the client's local log —
+    e.g. it would have shown the ``//api2`` doubled slash and the upstream
+    ``HTTP 500`` for the Proxmox console bug directly.
+    """
+    diag: dict[str, Any] = {
+        "phase": "upstream_connect",
+        "upstream_url": _sanitize_ws_url(url),
+        "exc_type": type(exc).__name__,
+    }
+    # websockets' InvalidStatus carries the upstream HTTP response.
+    response = getattr(exc, "response", None)
+    status = getattr(response, "status_code", None)
+    if status is not None:
+        diag["upstream_status"] = status
+    return diag
+
+
 def _build_local_ws_url(service_url: str, path: str) -> str:
     """Join the local service URL and a WS path into a ``ws(s)://`` URL.
 
@@ -900,7 +932,10 @@ class Tunnel:
                 type=MessageType.WS_CLOSE,
                 tunnel_id=self._tunnel_id,
                 payload=WsStreamClose(
-                    stream_id=stream_id, code=1011, reason=reason or "local connect failed"
+                    stream_id=stream_id,
+                    code=1011,
+                    reason=reason or "local connect failed",
+                    diagnostics=_upstream_connect_diagnostics(local_ws_url, exc),
                 ).model_dump(),
             )
             with contextlib.suppress(websockets.exceptions.ConnectionClosed):

--- a/tests/unit/test_upstream_diagnostics.py
+++ b/tests/unit/test_upstream_diagnostics.py
@@ -1,0 +1,47 @@
+"""Tests for upstream WS connect diagnostics reported to the relay."""
+
+from __future__ import annotations
+
+from hle_client.tunnel import _sanitize_ws_url, _upstream_connect_diagnostics
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int) -> None:
+        self.status_code = status_code
+
+
+class _FakeInvalidStatusError(Exception):
+    """Mimics websockets.exceptions.InvalidStatus (carries .response)."""
+
+    def __init__(self, status_code: int) -> None:
+        super().__init__(f"server rejected WebSocket connection: HTTP {status_code}")
+        self.response = _FakeResponse(status_code)
+
+
+class TestSanitizeWsUrl:
+    def test_strips_query_with_secrets(self):
+        url = "wss://192.168.2.200:8006//api2/json/.../vncwebsocket?port=5900&vncticket=SECRET"
+        out = _sanitize_ws_url(url)
+        assert out == "wss://192.168.2.200:8006//api2/json/.../vncwebsocket"
+        assert "vncticket" not in out
+        assert "SECRET" not in out
+
+    def test_no_query_unchanged(self):
+        assert _sanitize_ws_url("ws://localhost:7681/ws") == "ws://localhost:7681/ws"
+
+
+class TestUpstreamConnectDiagnostics:
+    def test_includes_status_and_sanitized_url(self):
+        # The exact Proxmox failure: doubled slash + HTTP 500.
+        url = "wss://192.168.2.200:8006//api2/json/.../vncwebsocket?vncticket=SECRET"
+        diag = _upstream_connect_diagnostics(url, _FakeInvalidStatusError(500))
+        assert diag["phase"] == "upstream_connect"
+        assert diag["upstream_status"] == 500
+        assert diag["exc_type"] == "_FakeInvalidStatusError"
+        assert diag["upstream_url"].endswith("//api2/json/.../vncwebsocket")
+        assert "vncticket" not in diag["upstream_url"]
+
+    def test_no_status_when_not_http_error(self):
+        diag = _upstream_connect_diagnostics("wss://h/x", OSError("connection refused"))
+        assert "upstream_status" not in diag
+        assert diag["exc_type"] == "OSError"


### PR DESCRIPTION
## Summary
Motivated by the Proxmox console bug, where the client knew the full failure (`wss://host:8006//api2/...` → upstream **HTTP 500**) but only wrote it to its **local log** — the relay/debug-mode never saw it, so diagnosing it required pulling the log off the homelab box.

Now, when an upstream WebSocket connect fails, the client attaches structured diagnostics to the WS_CLOSE it already sends to the relay:
- `phase: "upstream_connect"`
- `upstream_url` — **query string stripped** (Proxmox's `vncticket` and similar single-use secrets are never stored)
- `upstream_status` — the upstream HTTP status when available (from websockets' `InvalidStatus`)
- `exc_type`

The relay surfaces this in admin debug capture via the `ws_upstream_close` event (server PR #292), so this class of failure is now diagnosable **from the dashboard** without the client log.

## Note on "console errors"
noVNC's *browser* console errors live on the end-user's machine — neither the client nor the relay can see those. This change covers the client's own upstream errors, which is what was actually missing here.

## Test plan
- New `tests/unit/test_upstream_diagnostics.py`: URL query-string redaction (vncticket stripped), status extraction from an InvalidStatus-shaped exception (the Proxmox 500), no `upstream_status` for non-HTTP errors (e.g. connection refused).
- Full suite: 194 passed; ruff + format clean.