### PR TITLE
feat: client debug telemetry — service check, upstream HTTP error, log lines

### DIFF
--- a/src/hle_client/proxy.py
+++ b/src/hle_client/proxy.py
@@ -23,6 +23,16 @@ _STRIP_RESPONSE_HEADERS = frozenset(
     {"content-encoding", "content-length", "transfer-encoding", "connection"}
 )
 
+# Marker header attached to synthetic upstream-error responses (502/504) so the
+# tunnel layer can emit a diagnostic and strip it before the response reaches
+# the browser. The value is the httpx exception class name.
+UPSTREAM_ERROR_HEADER = "x-hle-upstream-error"
+
+
+def _upstream_error_headers(exc: BaseException) -> dict[str, str | list[str]]:
+    """Build the header dict for a synthetic upstream-error response."""
+    return {"content-type": "text/plain", UPSTREAM_ERROR_HEADER: type(exc).__name__}
+
 
 def _collect_response_headers(
     raw_headers: list[tuple[bytes, bytes]],
@@ -242,21 +252,21 @@ class LocalProxy:
                 )
                 return (
                     502,
-                    {"content-type": "text/plain"},
+                    _upstream_error_headers(exc),
                     b"Bad Gateway: SSL certificate verification failed "
                     b"(use --no-verify-ssl for self-signed certificates)",
                 )
             logger.error("Connection refused forwarding %s %s to local service", method, url)
             return (
                 502,
-                {"content-type": "text/plain"},
+                _upstream_error_headers(exc),
                 b"Bad Gateway: local service connection refused",
             )
-        except httpx.TimeoutException:
+        except httpx.TimeoutException as exc:
             logger.error("Timeout forwarding %s %s to local service", method, url)
             return (
                 504,
-                {"content-type": "text/plain"},
+                _upstream_error_headers(exc),
                 b"Gateway Timeout: local service did not respond",
             )
         except httpx.HTTPError as exc:
@@ -265,7 +275,7 @@ class LocalProxy:
             # from the relay side (e.g. via tunnel debug capture) without
             # leaking error details.
             reason = f"Bad Gateway: unexpected error ({exc.__class__.__name__})"
-            return 502, {"content-type": "text/plain"}, reason.encode()
+            return 502, _upstream_error_headers(exc), reason.encode()
 
     async def stream_http(
         self,
@@ -322,7 +332,7 @@ class LocalProxy:
                     method,
                     url,
                 )
-                yield (502, {"content-type": "text/plain"}, None)
+                yield (502, _upstream_error_headers(exc), None)
                 yield (
                     None,
                     None,
@@ -331,13 +341,13 @@ class LocalProxy:
                 )
                 return
             logger.error("Connection refused forwarding %s %s to local service", method, url)
-            yield (502, {"content-type": "text/plain"}, None)
+            yield (502, _upstream_error_headers(exc), None)
             yield (None, None, b"Bad Gateway: local service connection refused")
-        except httpx.TimeoutException:
+        except httpx.TimeoutException as exc:
             logger.error("Timeout forwarding %s %s to local service", method, url)
-            yield (504, {"content-type": "text/plain"}, None)
+            yield (504, _upstream_error_headers(exc), None)
             yield (None, None, b"Gateway Timeout: local service did not respond")
         except httpx.HTTPError as exc:
             logger.error("HTTP error forwarding %s %s: %s", method, url, exc)
-            yield (502, {"content-type": "text/plain"}, None)
+            yield (502, _upstream_error_headers(exc), None)
             yield (None, None, b"Bad Gateway: unexpected error")

--- a/src/hle_client/tunnel.py
+++ b/src/hle_client/tunnel.py
@@ -9,6 +9,7 @@ import logging
 import os
 import re
 import time
+from collections import deque
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -17,13 +18,14 @@ from urllib.parse import urlparse
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Coroutine
 
+import httpx
 import websockets
 import websockets.asyncio.client
 import websockets.exceptions
 
 from hle_client import __version__
 from hle_client.notices import render_notice
-from hle_client.proxy import LocalProxy, ProxyConfig
+from hle_client.proxy import UPSTREAM_ERROR_HEADER, LocalProxy, ProxyConfig
 from hle_common.models import (
     CAPABILITY_CHUNKED_RESPONSE,
     DiagnosticEvent,
@@ -262,6 +264,123 @@ def _build_ws_close_diagnostics(
     return out
 
 
+# --------------------------------------------------------------------------
+# Diagnostics helpers (pure, unit-tested in isolation)
+# --------------------------------------------------------------------------
+
+# Secret patterns redacted from client log lines before they leave the host.
+_REDACT_API_KEY = re.compile(r"hle_[0-9a-f]{32}")
+_REDACT_KV = re.compile(r"(?i)\b(vncticket|token)=[^\s&]+")
+_REDACT_AUTH = re.compile(r"(?i)(authorization:\s*).+")
+
+
+def _redact_secrets(text: str) -> str:
+    """Redact obvious secrets from a log message (best-effort, no raise)."""
+    text = _REDACT_API_KEY.sub("[REDACTED]", text)
+    text = _REDACT_KV.sub(lambda m: f"{m.group(1)}=[REDACTED]", text)
+    text = _REDACT_AUTH.sub(lambda m: f"{m.group(1)}[REDACTED]", text)
+    return text
+
+
+def _service_check_data(
+    service_url: str,
+    verify_ssl: bool,
+    elapsed_ms: float,
+    *,
+    response: httpx.Response | None = None,
+    error: BaseException | None = None,
+) -> dict[str, Any]:
+    """Turn a probe result (response or exception) into the diagnostic payload.
+
+    Pure and side-effect free so it can be unit-tested without a network.
+    """
+    parsed = urlparse(service_url)
+    scheme = parsed.scheme or ""
+    data: dict[str, Any] = {
+        "reachable": response is not None,
+        "status": response.status_code if response is not None else None,
+        "scheme": scheme,
+        "is_tls": scheme == "https",
+        "verify_ssl": verify_ssl,
+        "redirect_location": None,
+        "elapsed_ms": round(elapsed_ms, 1),
+        "error": None,
+    }
+    if response is not None and 300 <= response.status_code < 400:
+        location = response.headers.get("location")
+        if location:
+            # Strip any query string — it can carry tokens/tickets.
+            data["redirect_location"] = location.split("?", 1)[0]
+    if error is not None:
+        # Exception class + short message; never the full repr (no secrets).
+        data["error"] = f"{type(error).__name__}: {error}"[:200]
+    return data
+
+
+class _DiagnosticLogHandler(logging.Handler):
+    """Bounded in-memory ring that forwards WARNING+ records as diagnostics.
+
+    Installed on the ``hle_client`` logger. Keeps the last ``capacity``
+    formatted records and, while the owning tunnel has diagnostics enabled,
+    emits each WARNING-or-above record as a ``log.line`` DIAGNOSTIC event.
+
+    Best-effort throughout: secrets are redacted, a token-bucket rate limit
+    prevents floods (with a dropped count surfaced on the next line), and a
+    re-entrancy flag guards against the emit path logging back into us.
+    """
+
+    def __init__(self, tunnel: Tunnel, capacity: int = 200, rate: int = 10) -> None:
+        super().__init__(level=logging.NOTSET)
+        self._tunnel = tunnel
+        self._rate = rate
+        self.ring: deque[str] = deque(maxlen=capacity)
+        self._in_emit = False
+        self._window_start = 0.0
+        self._sent_in_window = 0
+        self._dropped = 0
+
+    def emit(self, record: logging.LogRecord) -> None:
+        # Guard against infinite recursion: anything logged while we are
+        # inside emit() (including from _emit_diagnostic) must not re-enter.
+        if self._in_emit:
+            return
+        self._in_emit = True
+        try:
+            message = record.getMessage()
+            self.ring.append(message)
+
+            if not self._tunnel._diagnostics_enabled or record.levelno < logging.WARNING:
+                return
+
+            now = time.monotonic()
+            if now - self._window_start >= 1.0:
+                self._window_start = now
+                self._sent_in_window = 0
+                dropped, self._dropped = self._dropped, 0
+            else:
+                dropped = 0
+
+            if self._sent_in_window >= self._rate:
+                self._dropped += 1
+                return
+            self._sent_in_window += 1
+
+            data: dict[str, Any] = {
+                "level": record.levelname,
+                "logger": record.name,
+                "message": _redact_secrets(message),
+                "ts": record.created,
+            }
+            if dropped:
+                data["dropped"] = dropped
+            self._tunnel._emit_diagnostic("log.line", **data)
+        except Exception:
+            # Never let diagnostics logging break real logging.
+            pass
+        finally:
+            self._in_emit = False
+
+
 MAX_SPEED_TEST_CHUNKS = 100  # ~6.4 MB at 64 KB/chunk
 MAX_SPEED_TEST_CHUNK_SIZE = 1_048_576  # 1 MB — cap server-requested chunk size
 
@@ -329,8 +448,10 @@ class Tunnel:
     _active_chunked: dict[str, asyncio.Task[None]] = field(
         default_factory=dict, init=False, repr=False
     )
+    _log_handler: _DiagnosticLogHandler | None = field(default=None, init=False, repr=False)
 
     def __post_init__(self) -> None:
+        self._install_log_handler()
         self._proxy = LocalProxy(
             ProxyConfig(
                 target_url=self.config.service_url,
@@ -393,6 +514,7 @@ class Tunnel:
         if self._ws:
             await self._ws.close()
         await self._cleanup()
+        self._remove_log_handler()
         logger.info("Tunnel disconnected")
 
     @property
@@ -584,6 +706,7 @@ class Tunnel:
         # relay through DIAGNOSTIC events.
         level_value = getattr(logging, cfg.level, logging.INFO)
         logging.getLogger("hle_client").setLevel(level_value)
+        was_enabled = self._diagnostics_enabled
         self._diagnostics_enabled = cfg.diagnostics
         logger.info(
             "LOG_CONFIG applied: level=%s diagnostics=%s tunnel=%s",
@@ -591,6 +714,34 @@ class Tunnel:
             cfg.diagnostics,
             self._tunnel_id,
         )
+        # On a False->True transition, run a one-shot upstream self-check so
+        # the operator immediately sees whether the local service is reachable.
+        if cfg.diagnostics and not was_enabled:
+            self._spawn(self._probe_service_check())
+
+    async def _probe_service_check(self) -> None:
+        """Probe the local service once and emit a ``service.check`` diagnostic.
+
+        Best-effort: honours ``verify_ssl``, does not follow redirects, uses a
+        short timeout, and never raises. Tries HEAD first, falling back to GET.
+        """
+        url = self.config.service_url
+        verify = self.config.verify_ssl
+        start = time.monotonic()
+        try:
+            async with httpx.AsyncClient(
+                verify=verify, follow_redirects=False, timeout=5.0
+            ) as client:
+                try:
+                    response = await client.head(url)
+                except httpx.HTTPError:
+                    response = await client.get(url)
+            elapsed_ms = (time.monotonic() - start) * 1000
+            data = _service_check_data(url, verify, elapsed_ms, response=response)
+        except Exception as exc:
+            elapsed_ms = (time.monotonic() - start) * 1000
+            data = _service_check_data(url, verify, elapsed_ms, error=exc)
+        self._emit_diagnostic("service.check", **data)
 
     def _emit_diagnostic(self, event: str, **data: Any) -> None:
         """Send a structured DIAGNOSTIC event back to the relay.
@@ -620,6 +771,35 @@ class Tunnel:
             return
         with contextlib.suppress(Exception):
             await self._ws.send(ws_msg.model_dump_json())
+
+    def _pop_upstream_error(self, headers: dict[str, Any]) -> str | None:
+        """Pop the synthetic upstream-error marker header (case-insensitive).
+
+        The proxy tags synthetic 502/504 responses with ``UPSTREAM_ERROR_HEADER``
+        carrying the httpx exception class name. We strip it here so it never
+        reaches the browser and return its value for the ``http.upstream_error``
+        diagnostic.
+        """
+        for key in list(headers):
+            if key.lower() == UPSTREAM_ERROR_HEADER:
+                value = headers.pop(key)
+                if isinstance(value, list):
+                    return value[0] if value else None
+                if isinstance(value, str):
+                    return value
+                return None
+        return None
+
+    def _emit_upstream_error(self, req: ProxiedHttpRequest, status_code: int, reason: str) -> None:
+        """Emit an ``http.upstream_error`` diagnostic (gated, best-effort)."""
+        self._emit_diagnostic(
+            "http.upstream_error",
+            request_id=req.request_id,
+            method=req.method,
+            path=req.path,
+            status=status_code,
+            reason=reason,
+        )
 
     # ------------------------------------------------------------------
     # HTTP request handling
@@ -684,6 +864,11 @@ class Tunnel:
             query_string=req.query_string,
         )
 
+        # Strip + report the synthetic upstream-error marker before relaying.
+        reason = self._pop_upstream_error(resp_headers)
+        if reason is not None:
+            self._emit_upstream_error(req, status_code, reason)
+
         encoded_body: str | None = None
         if resp_body is not None:
             encoded_body = base64.b64encode(resp_body).decode("ascii")
@@ -733,11 +918,16 @@ class Tunnel:
                 query_string=req.query_string,
             ):
                 if status_code is not None:
-                    # First yield: send START
+                    # First yield: send START. Strip + report any synthetic
+                    # upstream-error marker before it reaches the browser.
+                    headers_out = resp_headers or {}
+                    reason = self._pop_upstream_error(headers_out)
+                    if reason is not None:
+                        self._emit_upstream_error(req, status_code, reason)
                     start = HttpResponseStart(
                         request_id=req.request_id,
                         status_code=status_code,
-                        headers=resp_headers or {},
+                        headers=headers_out,
                     )
                     start_msg = ProtocolMessage(
                         type=MessageType.HTTP_RESPONSE_START,
@@ -1291,6 +1481,22 @@ class Tunnel:
         task = asyncio.ensure_future(coro)
         self._tasks.add(task)
         task.add_done_callback(self._tasks.discard)
+
+    def _install_log_handler(self) -> None:
+        """Attach the bounded ring log handler to the ``hle_client`` logger."""
+        if self._log_handler is not None:
+            return
+        handler = _DiagnosticLogHandler(self)
+        logging.getLogger("hle_client").addHandler(handler)
+        self._log_handler = handler
+
+    def _remove_log_handler(self) -> None:
+        """Detach the ring log handler (best-effort)."""
+        if self._log_handler is None:
+            return
+        with contextlib.suppress(Exception):
+            logging.getLogger("hle_client").removeHandler(self._log_handler)
+        self._log_handler = None
 
     async def _cleanup(self) -> None:
         """Close all local WS streams, cancel background tasks, and stop the proxy."""

--- a/tests/unit/test_diagnostics.py
+++ b/tests/unit/test_diagnostics.py
@@ -1,0 +1,313 @@
+"""Tests for the server-toggled diagnostics channel — new emit sites + log ring."""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+
+from hle_client.proxy import UPSTREAM_ERROR_HEADER, LocalProxy, ProxyConfig
+from hle_client.tunnel import (
+    Tunnel,
+    TunnelConfig,
+    _DiagnosticLogHandler,
+    _redact_secrets,
+    _service_check_data,
+)
+from hle_common.models import LogConfig, ProxiedHttpRequest
+from hle_common.protocol import MessageType, ProtocolMessage
+
+
+def _proxy(target_url: str = "http://localhost:8123", **kw) -> LocalProxy:
+    return LocalProxy(ProxyConfig(target_url=target_url, **kw))
+
+
+def _tunnel(service_url: str = "http://localhost:8123", **kw) -> Tunnel:
+    return Tunnel(TunnelConfig(service_url=service_url, **kw))
+
+
+def _mock_httpx_response(
+    status_code: int = 200, headers: dict[str, str] | None = None
+) -> httpx.Response:
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.headers = httpx.Headers(headers or {})
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Proxy: upstream-error marker header
+# ---------------------------------------------------------------------------
+
+
+class TestProxyUpstreamErrorHeader:
+    async def test_connect_error_sets_marker_header(self):
+        proxy = _proxy()
+        await proxy.start()
+        proxy._http_client.request = AsyncMock(side_effect=httpx.ConnectError("connection refused"))
+        status, headers, _ = await proxy.forward_http(method="GET", path="/down", headers={})
+        assert status == 502
+        assert headers[UPSTREAM_ERROR_HEADER] == "ConnectError"
+        await proxy.stop()
+
+    async def test_timeout_sets_marker_header(self):
+        proxy = _proxy()
+        await proxy.start()
+        proxy._http_client.request = AsyncMock(side_effect=httpx.ReadTimeout("read timed out"))
+        status, headers, _ = await proxy.forward_http(method="GET", path="/slow", headers={})
+        assert status == 504
+        assert headers[UPSTREAM_ERROR_HEADER] == "ReadTimeout"
+        await proxy.stop()
+
+    async def test_success_has_no_marker_header(self):
+        proxy = _proxy()
+        await proxy.start()
+        resp = MagicMock(spec=httpx.Response)
+        resp.status_code = 200
+        resp.headers = httpx.Headers({"content-type": "text/plain"})
+        resp.content = b"ok"
+        proxy._http_client.request = AsyncMock(return_value=resp)
+        _, headers, _ = await proxy.forward_http(method="GET", path="/ok", headers={})
+        assert UPSTREAM_ERROR_HEADER not in headers
+        await proxy.stop()
+
+    async def test_stream_connect_error_sets_marker_header(self):
+        proxy = _proxy()
+        await proxy.start()
+
+        def _boom(*a, **k):
+            raise httpx.ConnectError("connection refused")
+
+        proxy._http_client.stream = MagicMock(side_effect=_boom)
+        yields = [item async for item in proxy.stream_http(method="GET", path="/down", headers={})]
+        status, headers, _ = yields[0]
+        assert status == 502
+        assert headers[UPSTREAM_ERROR_HEADER] == "ConnectError"
+        await proxy.stop()
+
+
+# ---------------------------------------------------------------------------
+# Tunnel: strip marker + emit http.upstream_error
+# ---------------------------------------------------------------------------
+
+
+class TestTunnelUpstreamErrorDiagnostic:
+    def test_pop_upstream_error_string_value(self):
+        tunnel = _tunnel()
+        headers = {"content-type": "text/plain", UPSTREAM_ERROR_HEADER: "ConnectError"}
+        assert tunnel._pop_upstream_error(headers) == "ConnectError"
+        assert UPSTREAM_ERROR_HEADER not in headers
+
+    def test_pop_upstream_error_case_insensitive_and_list(self):
+        tunnel = _tunnel()
+        headers = {"X-Hle-Upstream-Error": ["TimeoutException", "extra"]}
+        assert tunnel._pop_upstream_error(headers) == "TimeoutException"
+        assert headers == {}
+
+    def test_pop_upstream_error_absent(self):
+        tunnel = _tunnel()
+        headers = {"content-type": "text/plain"}
+        assert tunnel._pop_upstream_error(headers) is None
+        assert headers == {"content-type": "text/plain"}
+
+    async def test_buffered_emits_and_strips(self):
+        tunnel = _tunnel()
+        tunnel._tunnel_id = "t-err"
+        tunnel._diagnostics_enabled = True
+        await tunnel._proxy.start()
+        tunnel._proxy.forward_http = AsyncMock(
+            return_value=(
+                502,
+                {"content-type": "text/plain", UPSTREAM_ERROR_HEADER: "ConnectError"},
+                b"Bad Gateway: local service connection refused",
+            )
+        )
+        emitted: list[tuple[str, dict]] = []
+        tunnel._emit_diagnostic = lambda event, **data: emitted.append((event, data))
+
+        mock_ws = AsyncMock()
+        sent: list[str] = []
+        mock_ws.send = AsyncMock(side_effect=lambda m: sent.append(m))
+
+        req = ProxiedHttpRequest(
+            request_id="req-e", method="GET", path="/down", headers={}, body=None, query_string=""
+        )
+        msg = ProtocolMessage(
+            type=MessageType.HTTP_REQUEST,
+            tunnel_id="t-err",
+            request_id="req-e",
+            payload=req.model_dump(),
+        )
+        await tunnel._handle_http_request_buffered(mock_ws, msg)
+
+        resp_msg = ProtocolMessage.model_validate_json(sent[0])
+        assert UPSTREAM_ERROR_HEADER not in resp_msg.payload["headers"]
+        assert emitted == [
+            (
+                "http.upstream_error",
+                {
+                    "request_id": "req-e",
+                    "method": "GET",
+                    "path": "/down",
+                    "status": 502,
+                    "reason": "ConnectError",
+                },
+            )
+        ]
+        await tunnel._proxy.stop()
+
+
+# ---------------------------------------------------------------------------
+# Tunnel: service.check payload helper + transition trigger
+# ---------------------------------------------------------------------------
+
+
+class TestServiceCheckData:
+    def test_reachable_response(self):
+        resp = _mock_httpx_response(status_code=200)
+        data = _service_check_data("https://localhost:8006", True, 12.34, response=resp)
+        assert data == {
+            "reachable": True,
+            "status": 200,
+            "scheme": "https",
+            "is_tls": True,
+            "verify_ssl": True,
+            "redirect_location": None,
+            "elapsed_ms": 12.3,
+            "error": None,
+        }
+
+    def test_redirect_strips_query(self):
+        resp = _mock_httpx_response(
+            status_code=302, headers={"location": "http://x/login?token=abc&next=/"}
+        )
+        data = _service_check_data("http://localhost:80", False, 1.0, response=resp)
+        assert data["redirect_location"] == "http://x/login"
+        assert data["is_tls"] is False
+
+    def test_error_records_class_and_message(self):
+        exc = httpx.ConnectError("connection refused")
+        data = _service_check_data("http://localhost:9", False, 5.0, error=exc)
+        assert data["reachable"] is False
+        assert data["status"] is None
+        assert data["error"].startswith("ConnectError:")
+
+    def test_transition_false_to_true_spawns_probe(self):
+        tunnel = _tunnel()
+        tunnel._tunnel_id = "t-p"
+        spawned: list = []
+        tunnel._spawn = lambda coro: (spawned.append(coro), coro.close())
+        msg = ProtocolMessage(
+            type=MessageType.LOG_CONFIG,
+            payload=LogConfig(level="DEBUG", diagnostics=True).model_dump(),
+        )
+        tunnel._handle_log_config(msg)
+        assert len(spawned) == 1
+
+    def test_no_probe_when_already_enabled(self):
+        tunnel = _tunnel()
+        tunnel._diagnostics_enabled = True
+        spawned: list = []
+        tunnel._spawn = lambda coro: (spawned.append(coro), coro.close())
+        msg = ProtocolMessage(
+            type=MessageType.LOG_CONFIG,
+            payload=LogConfig(level="DEBUG", diagnostics=True).model_dump(),
+        )
+        tunnel._handle_log_config(msg)
+        assert spawned == []
+
+
+# ---------------------------------------------------------------------------
+# Log ring: redaction + bound + rate limit + recursion guard
+# ---------------------------------------------------------------------------
+
+
+class TestRedactSecrets:
+    def test_api_key(self):
+        s = _redact_secrets("using key hle_" + "0" * 32 + " now")
+        assert "hle_" not in s
+        assert "[REDACTED]" in s
+
+    def test_vncticket_and_token(self):
+        assert _redact_secrets("url?vncticket=SECRET&x=1") == "url?vncticket=[REDACTED]&x=1"
+        assert _redact_secrets("token=abc123 tail") == "token=[REDACTED] tail"
+
+    def test_authorization(self):
+        assert _redact_secrets("Authorization: Bearer xyz") == "Authorization: [REDACTED]"
+
+    def test_no_secret_unchanged(self):
+        assert _redact_secrets("plain message") == "plain message"
+
+
+class TestDiagnosticLogHandler:
+    def _record(self, level=logging.WARNING, msg="m", name="hle_client.x"):
+        return logging.LogRecord(name, level, __file__, 1, msg, None, None)
+
+    def test_ring_is_bounded(self):
+        handler = _DiagnosticLogHandler(_tunnel(), capacity=5)
+        for i in range(20):
+            handler.emit(self._record(level=logging.INFO, msg=f"line{i}"))
+        assert len(handler.ring) == 5
+        assert list(handler.ring)[-1] == "line19"
+
+    def test_emits_warning_when_enabled_and_redacts(self):
+        tunnel = _tunnel()
+        tunnel._diagnostics_enabled = True
+        emitted: list = []
+        tunnel._emit_diagnostic = lambda event, **data: emitted.append((event, data))
+        handler = _DiagnosticLogHandler(tunnel)
+        handler.emit(self._record(msg="hle_" + "a" * 32))
+        assert len(emitted) == 1
+        event, data = emitted[0]
+        assert event == "log.line"
+        assert data["level"] == "WARNING"
+        assert "[REDACTED]" in data["message"]
+
+    def test_info_not_emitted(self):
+        tunnel = _tunnel()
+        tunnel._diagnostics_enabled = True
+        emitted: list = []
+        tunnel._emit_diagnostic = lambda event, **data: emitted.append(event)
+        handler = _DiagnosticLogHandler(tunnel)
+        handler.emit(self._record(level=logging.INFO))
+        assert emitted == []
+
+    def test_disabled_does_not_emit_but_rings(self):
+        tunnel = _tunnel()
+        tunnel._diagnostics_enabled = False
+        emitted: list = []
+        tunnel._emit_diagnostic = lambda event, **data: emitted.append(event)
+        handler = _DiagnosticLogHandler(tunnel)
+        handler.emit(self._record())
+        assert emitted == []
+        assert len(handler.ring) == 1
+
+    def test_rate_limit_drops_and_reports(self):
+        tunnel = _tunnel()
+        tunnel._diagnostics_enabled = True
+        emitted: list = []
+        tunnel._emit_diagnostic = lambda event, **data: emitted.append(data)
+        handler = _DiagnosticLogHandler(tunnel, rate=3)
+        for _ in range(10):
+            handler.emit(self._record())
+        assert len(emitted) == 3
+        handler._window_start -= 2.0
+        handler.emit(self._record())
+        assert len(emitted) == 4
+        assert emitted[-1]["dropped"] == 7
+
+    def test_recursion_guard(self):
+        tunnel = _tunnel()
+        tunnel._diagnostics_enabled = True
+        handler = _DiagnosticLogHandler(tunnel)
+        record = self._record(msg="boom")
+        calls: list = []
+
+        def _reenter(event, **data):
+            calls.append(event)
+            handler.emit(record)  # simulate emit path logging back in
+
+        tunnel._emit_diagnostic = _reenter
+        handler.emit(record)
+        assert calls == ["log.line"]


### PR DESCRIPTION
## Summary
The client half of debug improvements #2, #3, #4. Adds three server-gated `DIAGNOSTIC` emit sites on the existing diagnostics channel (the relay turns it on via `LOG_CONFIG` when an admin enables debug capture — server PR jspanos/hle#293). All best-effort and gated on `_diagnostics_enabled`, so old relays never see them. **No protocol/models change.**

- **`service.check` (#2)** — on diagnostics-enable, probe the local service URL (reachable / status / scheme / TLS / redirect) and emit the result. Would have flagged the Proxmox upstream immediately.
- **`http.upstream_error` (#3)** — the proxy tags synthetic 502/504 upstream-error responses with an `x-hle-upstream-error` marker header (httpx exception class); the tunnel emits a diagnostic and **strips the header** before relaying to the browser.
- **`log.line` (#4)** — a bounded (200-entry) in-memory log ring forwards WARNING+ records as diagnostics while enabled, with **secret redaction** (`hle_` keys / `vncticket` / `token` / `Authorization`), a **~10/s token-bucket rate limit** (dropped count surfaced), and a **re-entrancy guard** so the emit path can't recurse.

`ws.open`/`ws.close` (#1) were already emitted; the server PR lights those up too.

## Safety
Every emit is fire-and-forget and never touches the data plane. Diagnostics only flow after the relay opts in via `LOG_CONFIG`, so an old relay never receives an unexpected message type. Secrets are redacted in `log.line`; the upstream-error marker header never reaches the browser.

## Test plan
- 23 new tests (`tests/unit/test_diagnostics.py`): proxy marker header on each error path + absent on success; tunnel strip/emit + header-variant handling; `service.check` payload (reachable / redirect-query-strip / error / transition trigger); redaction (api key / vncticket / token / Authorization / no-op); log ring bound, WARNING-emit+redact, INFO-skip, disabled-rings-only, rate-limit+dropped-count, recursion guard.
- Full suite: 217 passed; ruff + format clean.