### PR TITLE
Release v2607.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## v2607.2 — 2026-07-17
+
+### Fixed
+- **Proxmox VM/CT consoles (and other WebSocket upstreams) over a tunnel**: a
+  service URL with a trailing slash (`--service https://host:8006/`) produced a
+  doubled slash in the upstream WebSocket URL (`wss://host:8006//api2/...`),
+  which strict upstreams reject — Proxmox's vncwebsocket answers HTTP 500. The
+  WS URL is now built without the doubled slash. HTTP was unaffected.
+
+### Added — debug telemetry
+When the relay enables debug capture for a tunnel (admin panel), the client now
+pushes structured diagnostics back so failures are visible from the dashboard
+without reading the client's local log:
+- Failed upstream WebSocket connects report the sanitized upstream URL (query
+  string / tickets stripped) and upstream HTTP status.
+- `service.check` — on enable, the client probes its local service (reachable /
+  status / scheme / TLS / redirect).
+- `http.upstream_error` — synthetic upstream 502/504s (connect refused /
+  timeout / SSL) are surfaced with the exception class.
+- `log.line` — the client's own WARNING+ log lines stream to the relay,
+  redacted (API keys / tickets / tokens / Authorization) and rate-limited.
+
+All diagnostics are best-effort, gated on the relay opting in, and never touch
+the data plane. Requires a relay running v2607.4+ to surface them.
+
 ## v2607.1 — 2026-07-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ curl -fsSL https://get.hle.world | sh
 Installs via pipx (preferred), uv, or pip-in-venv. Supports `--version`:
 
 ```bash
-curl -fsSL https://get.hle.world | sh -s -- --version 2607.1
+curl -fsSL https://get.hle.world | sh -s -- --version 2607.2
 ```
 
 ### pipx

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # HLE Client installer
 # Usage: curl -fsSL https://get.hle.world | sh
-#        curl -fsSL https://get.hle.world | sh -s -- --version 2607.1
+#        curl -fsSL https://get.hle.world | sh -s -- --version 2607.2
 set -e
 
 PACKAGE="hle-client"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hle-client"
-version = "2607.1"
+version = "2607.2"
 description = "HomeLab Everywhere — Expose homelab services to the internet with built-in SSO"
 readme = "README.md"
 license = "MIT"

--- a/src/hle_client/__init__.py
+++ b/src/hle_client/__init__.py
@@ -1,3 +1,3 @@
 """HLE Client — HomeLab Everywhere tunnel client."""
 
-__version__ = "2607.1"
+__version__ = "2607.2"


### PR DESCRIPTION
## Summary
Release v2607.2 — Proxmox/WebSocket console fix + debug telemetry.

- Bump version to 2607.2 (pyproject.toml, __init__.py, README.md, install.sh)
- CHANGELOG for v2607.2

Bundles: #96 (WS double-slash fix), #97 (upstream connect diagnostics), #98 (client debug telemetry: service.check / http.upstream_error / log.line). See CHANGELOG.md.