### PR TITLE
feat: hle update + hle service (systemd/launchd), WS keepalive + reconnect fixes (v2607.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## v2607.3 — 2026-07-17
+
+### Added
+- **`hle update`** — self-upgrade regardless of install method. Detects pipx /
+  uv tool / installer venv / pip and runs the right upgrade. `--check` reports
+  current vs. latest without changing anything; `--version X` pins a version.
+- **`hle service`** — install and manage a background service for a tunnel so
+  it survives reboots and restarts on failure, without hand-writing unit files.
+  - **Linux** → systemd unit (system or `--user`).
+  - **macOS** → launchd plist (LaunchDaemons or `--user` LaunchAgents).
+  - Windows is unsupported (use Task Scheduler / NSSM); the command exits with
+    a clear message and no side effects.
+  - The API key is read at runtime from config/`HLE_API_KEY` — never written
+    into the service file.
+
+### Fixed
+- **Tunnel flapping under load / streaming** (`1011 keepalive ping timeout`):
+  relaxed the control-WebSocket keepalive (`ping_interval=30`, `ping_timeout=120`)
+  so a large or continuous tunnel body (e.g. a live video stream) no longer
+  starves the ping/pong and severs the tunnel. Pairs with a matching relay-side
+  change (needs a relay running the corresponding server release).
+- **Reconnect handshake**: a keepalive `PING` arriving before `TUNNEL_ACK`
+  (common right after a reconnect) no longer aborts registration — the client
+  now responds `PONG` and keeps waiting for the ACK.
+
 ## v2607.2 — 2026-07-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@
 - **Reconnect handshake**: a keepalive `PING` arriving before `TUNNEL_ACK`
   (common right after a reconnect) no longer aborts registration — the client
   now responds `PONG` and keeps waiting for the ACK.
+- **Log noise**: a `WS_FRAME` arriving just after a local WebSocket failed to
+  open or was closed (the browser's queued frames racing teardown) now logs at
+  debug instead of `WARNING: WS_FRAME for unknown stream_id=...`.
 
 ## v2607.2 — 2026-07-17
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,43 @@ Options:
 - `--forward-host` — Forward the browser's Host header to the local service
 - `--api-key` — API key (also reads `HLE_API_KEY` env var, then config file)
 
+### `hle update`
+
+Update the client to the latest version, regardless of how it was installed
+(pipx, uv tool, the installer's venv, or pip). It detects the install method
+and runs the right upgrade.
+
+```bash
+hle update            # upgrade to the latest release
+hle update --check    # just report current vs. latest, don't change anything
+hle update --version 2607.2   # pin an exact version
+```
+
+After updating, restart any running tunnels (e.g. `systemctl restart hle-<label>`)
+so they pick up the new version.
+
+### `hle service`
+
+Install and manage a systemd service for a tunnel, so it survives reboots and
+restarts on failure. Linux/systemd only. The API key is read at runtime from
+`~/.config/hle/config.toml` (or `HLE_API_KEY`) and is never written into the
+unit file.
+
+```bash
+# Install + start a system service (writes /etc/systemd/system/hle-tv.service)
+sudo hle service install --service http://localhost:9998 --label tv
+
+# Custom zone / extra expose options are supported
+sudo hle service install --service https://192.168.2.200:8006 --label prox --zone pr.t00t.us
+
+# Per-user service (no sudo; writes ~/.config/systemd/user/hle-tv.service)
+hle service install --user --service http://localhost:9998 --label tv
+
+hle service status --label tv       # systemctl status
+hle service list                    # list all hle-* services
+hle service uninstall --label tv    # stop, disable, remove the unit
+```
+
 ### `hle webhook`
 
 Forward incoming webhooks to a local service.

--- a/README.md
+++ b/README.md
@@ -101,24 +101,29 @@ so they pick up the new version.
 
 ### `hle service`
 
-Install and manage a systemd service for a tunnel, so it survives reboots and
-restarts on failure. Linux/systemd only. The API key is read at runtime from
-`~/.config/hle/config.toml` (or `HLE_API_KEY`) and is never written into the
-unit file.
+Install and manage a background service for a tunnel, so it survives reboots
+and restarts on failure. Uses **systemd on Linux** and **launchd on macOS**
+(Windows is unsupported — use Task Scheduler or NSSM). The API key is read at
+runtime from `~/.config/hle/config.toml` (or `HLE_API_KEY`) and is never
+written into the service file.
 
 ```bash
-# Install + start a system service (writes /etc/systemd/system/hle-tv.service)
+# Install + start a system service
+#   Linux → /etc/systemd/system/hle-tv.service
+#   macOS → /Library/LaunchDaemons/world.hle.tv.plist
 sudo hle service install --service http://localhost:9998 --label tv
 
 # Custom zone / extra expose options are supported
 sudo hle service install --service https://192.168.2.200:8006 --label prox --zone pr.t00t.us
 
-# Per-user service (no sudo; writes ~/.config/systemd/user/hle-tv.service)
+# Per-user service (no sudo)
+#   Linux → ~/.config/systemd/user/hle-tv.service
+#   macOS → ~/Library/LaunchAgents/world.hle.tv.plist
 hle service install --user --service http://localhost:9998 --label tv
 
-hle service status --label tv       # systemctl status
-hle service list                    # list all hle-* services
-hle service uninstall --label tv    # stop, disable, remove the unit
+hle service status --label tv       # service status
+hle service list                    # list all hle services
+hle service uninstall --label tv    # stop, disable, remove the service
 ```
 
 ### `hle webhook`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hle-client"
-version = "2607.2"
+version = "2607.3"
 description = "HomeLab Everywhere — Expose homelab services to the internet with built-in SSO"
 readme = "README.md"
 license = "MIT"

--- a/src/hle_client/__init__.py
+++ b/src/hle_client/__init__.py
@@ -1,3 +1,3 @@
 """HLE Client — HomeLab Everywhere tunnel client."""
 
-__version__ = "2607.2"
+__version__ = "2607.3"

--- a/src/hle_client/cli.py
+++ b/src/hle_client/cli.py
@@ -20,6 +20,7 @@ from hle_client.agent import (
     save_agent_token,
 )
 from hle_client.config_cmd import config as config_group
+from hle_client.service_cmd import service as service_group
 from hle_client.tunnel import (
     Tunnel,
     TunnelConfig,
@@ -28,6 +29,7 @@ from hle_client.tunnel import (
     _remove_api_key,
     _save_api_key,
 )
+from hle_client.update_cmd import update as update_command
 
 console = Console()
 logger = logging.getLogger(__name__)
@@ -369,6 +371,8 @@ def logout() -> None:
 
 
 main.add_command(config_group, name="config")
+main.add_command(update_command, name="update")
+main.add_command(service_group, name="service")
 
 
 @main.group()

--- a/src/hle_client/service_cmd.py
+++ b/src/hle_client/service_cmd.py
@@ -1,8 +1,14 @@
-"""``hle service`` — install and manage a systemd service for a tunnel.
+"""``hle service`` — install and manage a background service for a tunnel.
 
-Generates a systemd unit that runs ``hle expose ...`` with the given options,
-so a homelab tunnel survives reboots and restarts on failure without the user
-hand-writing unit files. Linux/systemd only.
+Generates a service definition that runs ``hle expose ...`` with the given
+options, so a homelab tunnel survives reboots and restarts on failure without
+the user hand-writing service files.
+
+Backends:
+  * Linux  → systemd unit (``systemctl`` / ``/etc/systemd/system`` or ``--user``)
+  * macOS  → launchd plist (``launchctl`` / LaunchDaemons or LaunchAgents)
+
+Windows is not supported (use Task Scheduler / NSSM manually).
 """
 
 from __future__ import annotations
@@ -12,6 +18,7 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
+from xml.sax.saxutils import escape as _xml_escape
 
 import click
 from rich.console import Console
@@ -19,10 +26,14 @@ from rich.console import Console
 console = Console()
 
 _SYSTEM_UNIT_DIR = Path("/etc/systemd/system")
+_LAUNCHD_LABEL_PREFIX = "world.hle"
 
 
+# --------------------------------------------------------------------------- #
+# Shared helpers
+# --------------------------------------------------------------------------- #
 def find_hle_path() -> str:
-    """Resolve an absolute path to the ``hle`` executable for ExecStart."""
+    """Resolve an absolute path to the ``hle`` executable for the service."""
     found = shutil.which("hle")
     if found:
         return found
@@ -39,6 +50,13 @@ def unit_name(label: str, name: str | None = None) -> str:
     return base if base.endswith(".service") else f"{base}.service"
 
 
+def launchd_label(label: str, name: str | None = None) -> str:
+    """launchd Label (reverse-DNS) for a tunnel label (or an explicit name)."""
+    if name:
+        return name[: -len(".plist")] if name.endswith(".plist") else name
+    return f"{_LAUNCHD_LABEL_PREFIX}.{label}"
+
+
 def build_expose_args(
     *,
     service: str,
@@ -52,7 +70,7 @@ def build_expose_args(
     allow: tuple[str, ...] = (),
     options: tuple[str, ...] = (),
 ) -> list[str]:
-    """Build the ``expose`` argv (no secrets) for the unit's ExecStart."""
+    """Build the ``expose`` argv (no secrets) for the service definition."""
     args = ["expose", "--service", service]
     if label:
         args += ["--label", label]
@@ -75,6 +93,43 @@ def build_expose_args(
     return args
 
 
+def current_platform() -> str:
+    """Return ``"linux"``, ``"darwin"``, or the raw ``sys.platform`` value."""
+    if sys.platform.startswith("linux"):
+        return "linux"
+    if sys.platform == "darwin":
+        return "darwin"
+    return sys.platform
+
+
+def _require_supported() -> str:
+    """Ensure the running platform has a supported service backend.
+
+    Returns the platform key (``"linux"`` / ``"darwin"``) or exits with a
+    clear message on Windows / anything else.
+    """
+    plat = current_platform()
+    if plat == "linux":
+        if shutil.which("systemctl") is None:
+            console.print("[red]`hle service` needs systemd (systemctl not found).[/red]")
+            raise SystemExit(1)
+        return plat
+    if plat == "darwin":
+        if shutil.which("launchctl") is None:
+            console.print("[red]`hle service` needs launchd (launchctl not found).[/red]")
+            raise SystemExit(1)
+        return plat
+    console.print(
+        f"[red]`hle service` is not supported on this platform ({plat}).[/red]\n"
+        "Supported: Linux (systemd) and macOS (launchd). On Windows, use "
+        "Task Scheduler or NSSM to run `hle expose ...`."
+    )
+    raise SystemExit(1)
+
+
+# --------------------------------------------------------------------------- #
+# systemd backend (Linux)
+# --------------------------------------------------------------------------- #
 def _quote_exec_args(args: list[str]) -> str:
     """Quote ExecStart args that contain whitespace (systemd-safe)."""
     out = []
@@ -126,12 +181,6 @@ def _systemctl(user_mode: bool, *args: str) -> subprocess.CompletedProcess[bytes
     return subprocess.run(cmd, check=False)  # noqa: S603 — argv built internally
 
 
-def _require_systemd() -> None:
-    if sys.platform != "linux" or shutil.which("systemctl") is None:
-        console.print("[red]`hle service` requires Linux with systemd (systemctl not found).[/red]")
-        raise SystemExit(1)
-
-
 def _unit_dir(user_mode: bool) -> Path:
     if user_mode:
         d = Path.home() / ".config" / "systemd" / "user"
@@ -140,64 +189,15 @@ def _unit_dir(user_mode: bool) -> Path:
     return _SYSTEM_UNIT_DIR
 
 
-@click.group()
-def service() -> None:
-    """Install and manage a systemd service for a tunnel."""
-
-
-@service.command("install")
-@click.option("--service", "service_url", required=True, help="Local service URL")
-@click.option("--label", required=True, help="Service label (also names the unit hle-<label>)")
-@click.option("--zone", default=None, help="Custom zone to publish under")
-@click.option("--apex", is_flag=True, default=False, help="Serve at the bare zone root")
-@click.option("--auth", type=click.Choice(["sso", "none"]), default="sso", help="Auth mode")
-@click.option("--websocket/--no-websocket", default=True, help="Enable WebSocket proxying")
-@click.option("--verify-ssl", is_flag=True, default=False, help="Verify upstream TLS cert")
-@click.option("--forward-host", is_flag=True, default=False, help="Forward the browser Host header")
-@click.option("--allow", multiple=True, metavar="[PROVIDER:]EMAIL", help="SSO allow rule (repeat)")
-@click.option(
-    "--option", "options", multiple=True, metavar="KEY=VALUE", help="Passthrough (repeat)"
-)
-@click.option("--name", default=None, help="Override the unit name (default hle-<label>)")
-@click.option("--user", "user_mode", is_flag=True, default=False, help="Install a --user unit")
-@click.option("--run-as", "run_as", default=None, help="System unit User= (default: current user)")
-@click.option("--start/--no-start", default=True, help="Enable + start the service now")
-def install(
-    service_url: str,
+def _systemd_install(
+    *,
     label: str,
-    zone: str | None,
-    apex: bool,
-    auth: str,
-    websocket: bool,
-    verify_ssl: bool,
-    forward_host: bool,
-    allow: tuple[str, ...],
-    options: tuple[str, ...],
+    expose_args: list[str],
     name: str | None,
     user_mode: bool,
     run_as: str | None,
     start: bool,
 ) -> None:
-    """Install (and start) a systemd service running this tunnel.
-
-    The API key is read from the running user's ~/.config/hle/config.toml or
-    HLE_API_KEY at runtime — it is never written into the unit file. For a
-    system unit, pass --run-as <user> (defaults to the current user) so the
-    service reads that user's config.
-    """
-    _require_systemd()
-    expose_args = build_expose_args(
-        service=service_url,
-        label=label,
-        zone=zone,
-        apex=apex,
-        auth=auth,
-        websocket=websocket,
-        verify_ssl=verify_ssl,
-        forward_host=forward_host,
-        allow=allow,
-        options=options,
-    )
     run_as_user = run_as or (None if user_mode else getpass.getuser())
     unit = render_unit(
         label=label,
@@ -229,13 +229,7 @@ def install(
         console.print(f"Run: systemctl {'--user ' if user_mode else ''}enable --now {uname}")
 
 
-@service.command("uninstall")
-@click.option("--label", required=True, help="Service label")
-@click.option("--name", default=None, help="Explicit unit name")
-@click.option("--user", "user_mode", is_flag=True, default=False, help="Target a --user unit")
-def uninstall(label: str, name: str | None, user_mode: bool) -> None:
-    """Stop, disable, and remove a tunnel's systemd service."""
-    _require_systemd()
+def _systemd_uninstall(*, label: str, name: str | None, user_mode: bool) -> None:
     uname = unit_name(label, name)
     _systemctl(user_mode, "disable", "--now", uname)
     path = _unit_dir(user_mode) / uname
@@ -249,23 +243,283 @@ def uninstall(label: str, name: str | None, user_mode: bool) -> None:
     _systemctl(user_mode, "daemon-reload")
 
 
-@service.command("status")
-@click.option("--label", required=True, help="Service label")
-@click.option("--name", default=None, help="Explicit unit name")
-@click.option("--user", "user_mode", is_flag=True, default=False, help="Target a --user unit")
-def status(label: str, name: str | None, user_mode: bool) -> None:
-    """Show systemctl status for a tunnel's service."""
-    _require_systemd()
+def _systemd_status(*, label: str, name: str | None, user_mode: bool) -> None:
     _systemctl(user_mode, "status", "--no-pager", unit_name(label, name))
 
 
-@service.command("list")
-@click.option("--user", "user_mode", is_flag=True, default=False, help="List --user units")
-def list_services(user_mode: bool) -> None:
-    """List installed hle-* services."""
-    _require_systemd()
+def _systemd_list(*, user_mode: bool) -> None:
     cmd = ["systemctl"]
     if user_mode:
         cmd.append("--user")
     cmd += ["list-units", "--type=service", "--all", "hle-*"]
     subprocess.run(cmd, check=False)  # noqa: S603 — argv built internally
+
+
+# --------------------------------------------------------------------------- #
+# launchd backend (macOS)
+# --------------------------------------------------------------------------- #
+def render_launchd_plist(
+    *,
+    label: str,
+    plist_label: str,
+    hle_path: str,
+    expose_args: list[str],
+    run_as_user: str | None,
+    log_dir: str,
+) -> str:
+    """Render a launchd plist. Pure function (unit-testable).
+
+    ``run_as_user`` adds a ``UserName`` key (system daemons only); pass ``None``
+    for per-user agents that already run as the invoking user.
+    """
+    prog = [hle_path, *expose_args]
+    prog_xml = "\n".join(f"        <string>{_xml_escape(a)}</string>" for a in prog)
+    out_log = f"{log_dir.rstrip('/')}/{label}.log"
+    err_log = f"{log_dir.rstrip('/')}/{label}.err.log"
+    lines = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" '
+        '"http://www.apple.com/DTDs/PropertyList-1.0.dtd">',
+        '<plist version="1.0">',
+        "<dict>",
+        "    <key>Label</key>",
+        f"    <string>{_xml_escape(plist_label)}</string>",
+        "    <key>ProgramArguments</key>",
+        "    <array>",
+        prog_xml,
+        "    </array>",
+        "    <key>RunAtLoad</key>",
+        "    <true/>",
+        "    <key>KeepAlive</key>",
+        "    <true/>",
+    ]
+    if run_as_user:
+        lines += ["    <key>UserName</key>", f"    <string>{_xml_escape(run_as_user)}</string>"]
+    lines += [
+        "    <key>StandardOutPath</key>",
+        f"    <string>{_xml_escape(out_log)}</string>",
+        "    <key>StandardErrorPath</key>",
+        f"    <string>{_xml_escape(err_log)}</string>",
+        "</dict>",
+        "</plist>",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def _launchctl(*args: str) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(["launchctl", *args], check=False)  # noqa: S603 — argv built internally
+
+
+def _launchd_dir(user_mode: bool) -> Path:
+    if user_mode:
+        d = Path.home() / "Library" / "LaunchAgents"
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+    return Path("/Library/LaunchDaemons")
+
+
+def _launchd_log_dir(user_mode: bool) -> str:
+    if user_mode:
+        d = Path.home() / "Library" / "Logs" / "hle"
+        d.mkdir(parents=True, exist_ok=True)
+        return str(d)
+    return "/var/log"
+
+
+def _launchd_install(
+    *,
+    label: str,
+    expose_args: list[str],
+    name: str | None,
+    user_mode: bool,
+    run_as: str | None,
+    start: bool,
+) -> None:
+    # Per-user agents run as the invoking user already; only system daemons
+    # need an explicit UserName so the tunnel reads that user's config.
+    run_as_user = None if user_mode else (run_as or getpass.getuser())
+    plabel = launchd_label(label, name)
+    plist = render_launchd_plist(
+        label=label,
+        plist_label=plabel,
+        hle_path=find_hle_path(),
+        expose_args=expose_args,
+        run_as_user=run_as_user,
+        log_dir=_launchd_log_dir(user_mode),
+    )
+    path = _launchd_dir(user_mode) / f"{plabel}.plist"
+    try:
+        path.write_text(plist)
+    except PermissionError:
+        console.print(
+            f"[red]Permission denied writing {path}.[/red] "
+            "Re-run with sudo, or use --user for a per-user agent."
+        )
+        raise SystemExit(1) from None
+
+    console.print(f"[green]Wrote[/green] {path}")
+    if start:
+        # Reload cleanly: unload first (ignore errors) so re-install re-reads.
+        _launchctl("unload", str(path))
+        result = _launchctl("load", "-w", str(path))
+        if result.returncode == 0:
+            console.print(f"[green]Loaded[/green] {plabel}")
+        else:
+            console.print(f"[yellow]Wrote plist but failed to load {plabel}.[/yellow]")
+    else:
+        console.print(f"Run: launchctl load -w {path}")
+
+
+def _launchd_uninstall(*, label: str, name: str | None, user_mode: bool) -> None:
+    plabel = launchd_label(label, name)
+    path = _launchd_dir(user_mode) / f"{plabel}.plist"
+    if path.exists():
+        _launchctl("unload", "-w", str(path))
+        try:
+            path.unlink()
+            console.print(f"[green]Removed[/green] {path}")
+        except PermissionError:
+            console.print(f"[red]Permission denied removing {path}[/red] (try sudo).")
+            raise SystemExit(1) from None
+    else:
+        _launchctl("remove", plabel)
+        console.print(f"[yellow]No plist at {path}[/yellow] (attempted launchctl remove).")
+
+
+def _launchd_status(*, label: str, name: str | None, user_mode: bool) -> None:
+    plabel = launchd_label(label, name)
+    result = _launchctl("list", plabel)
+    if result.returncode != 0:
+        console.print(f"[yellow]{plabel} is not loaded.[/yellow]")
+
+
+def _launchd_list(*, user_mode: bool) -> None:
+    # launchctl list has no glob; filter its output for our label prefix.
+    result = subprocess.run(  # noqa: S603 — argv built internally
+        ["launchctl", "list"], check=False, capture_output=True, text=True
+    )
+    matched = [
+        ln
+        for ln in result.stdout.splitlines()
+        if _LAUNCHD_LABEL_PREFIX in ln or ln.startswith("PID")
+    ]
+    console.print("\n".join(matched) if matched else "No hle launchd services loaded.")
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+@click.group()
+def service() -> None:
+    """Install and manage a background service for a tunnel (systemd/launchd)."""
+
+
+@service.command("install")
+@click.option("--service", "service_url", required=True, help="Local service URL")
+@click.option("--label", required=True, help="Service label (also names the unit hle-<label>)")
+@click.option("--zone", default=None, help="Custom zone to publish under")
+@click.option("--apex", is_flag=True, default=False, help="Serve at the bare zone root")
+@click.option("--auth", type=click.Choice(["sso", "none"]), default="sso", help="Auth mode")
+@click.option("--websocket/--no-websocket", default=True, help="Enable WebSocket proxying")
+@click.option("--verify-ssl", is_flag=True, default=False, help="Verify upstream TLS cert")
+@click.option("--forward-host", is_flag=True, default=False, help="Forward the browser Host header")
+@click.option("--allow", multiple=True, metavar="[PROVIDER:]EMAIL", help="SSO allow rule (repeat)")
+@click.option(
+    "--option", "options", multiple=True, metavar="KEY=VALUE", help="Passthrough (repeat)"
+)
+@click.option("--name", default=None, help="Override the unit/plist name")
+@click.option("--user", "user_mode", is_flag=True, default=False, help="Install a per-user service")
+@click.option("--run-as", "run_as", default=None, help="System service user (default: current)")
+@click.option("--start/--no-start", default=True, help="Enable + start the service now")
+def install(
+    service_url: str,
+    label: str,
+    zone: str | None,
+    apex: bool,
+    auth: str,
+    websocket: bool,
+    verify_ssl: bool,
+    forward_host: bool,
+    allow: tuple[str, ...],
+    options: tuple[str, ...],
+    name: str | None,
+    user_mode: bool,
+    run_as: str | None,
+    start: bool,
+) -> None:
+    """Install (and start) a background service running this tunnel.
+
+    The API key is read from the running user's ~/.config/hle/config.toml or
+    HLE_API_KEY at runtime — it is never written into the service file. For a
+    system service, pass --run-as <user> (defaults to the current user) so the
+    service reads that user's config.
+    """
+    plat = _require_supported()
+    expose_args = build_expose_args(
+        service=service_url,
+        label=label,
+        zone=zone,
+        apex=apex,
+        auth=auth,
+        websocket=websocket,
+        verify_ssl=verify_ssl,
+        forward_host=forward_host,
+        allow=allow,
+        options=options,
+    )
+    if plat == "darwin":
+        _launchd_install(
+            label=label,
+            expose_args=expose_args,
+            name=name,
+            user_mode=user_mode,
+            run_as=run_as,
+            start=start,
+        )
+    else:
+        _systemd_install(
+            label=label,
+            expose_args=expose_args,
+            name=name,
+            user_mode=user_mode,
+            run_as=run_as,
+            start=start,
+        )
+
+
+@service.command("uninstall")
+@click.option("--label", required=True, help="Service label")
+@click.option("--name", default=None, help="Explicit unit/plist name")
+@click.option("--user", "user_mode", is_flag=True, default=False, help="Target a per-user service")
+def uninstall(label: str, name: str | None, user_mode: bool) -> None:
+    """Stop, disable, and remove a tunnel's background service."""
+    plat = _require_supported()
+    if plat == "darwin":
+        _launchd_uninstall(label=label, name=name, user_mode=user_mode)
+    else:
+        _systemd_uninstall(label=label, name=name, user_mode=user_mode)
+
+
+@service.command("status")
+@click.option("--label", required=True, help="Service label")
+@click.option("--name", default=None, help="Explicit unit/plist name")
+@click.option("--user", "user_mode", is_flag=True, default=False, help="Target a per-user service")
+def status(label: str, name: str | None, user_mode: bool) -> None:
+    """Show status for a tunnel's background service."""
+    plat = _require_supported()
+    if plat == "darwin":
+        _launchd_status(label=label, name=name, user_mode=user_mode)
+    else:
+        _systemd_status(label=label, name=name, user_mode=user_mode)
+
+
+@service.command("list")
+@click.option("--user", "user_mode", is_flag=True, default=False, help="List per-user services")
+def list_services(user_mode: bool) -> None:
+    """List installed hle services."""
+    plat = _require_supported()
+    if plat == "darwin":
+        _launchd_list(user_mode=user_mode)
+    else:
+        _systemd_list(user_mode=user_mode)

--- a/src/hle_client/service_cmd.py
+++ b/src/hle_client/service_cmd.py
@@ -1,0 +1,271 @@
+"""``hle service`` — install and manage a systemd service for a tunnel.
+
+Generates a systemd unit that runs ``hle expose ...`` with the given options,
+so a homelab tunnel survives reboots and restarts on failure without the user
+hand-writing unit files. Linux/systemd only.
+"""
+
+from __future__ import annotations
+
+import getpass
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import click
+from rich.console import Console
+
+console = Console()
+
+_SYSTEM_UNIT_DIR = Path("/etc/systemd/system")
+
+
+def find_hle_path() -> str:
+    """Resolve an absolute path to the ``hle`` executable for ExecStart."""
+    found = shutil.which("hle")
+    if found:
+        return found
+    # Fall back to a sibling of the running interpreter (venv/bin/hle).
+    candidate = Path(sys.executable).with_name("hle")
+    if candidate.exists():
+        return str(candidate)
+    return "hle"
+
+
+def unit_name(label: str, name: str | None = None) -> str:
+    """Systemd unit filename for a tunnel label (or an explicit name)."""
+    base = name or f"hle-{label}"
+    return base if base.endswith(".service") else f"{base}.service"
+
+
+def build_expose_args(
+    *,
+    service: str,
+    label: str | None,
+    zone: str | None = None,
+    apex: bool = False,
+    auth: str = "sso",
+    websocket: bool = True,
+    verify_ssl: bool = False,
+    forward_host: bool = False,
+    allow: tuple[str, ...] = (),
+    options: tuple[str, ...] = (),
+) -> list[str]:
+    """Build the ``expose`` argv (no secrets) for the unit's ExecStart."""
+    args = ["expose", "--service", service]
+    if label:
+        args += ["--label", label]
+    if zone:
+        args += ["--zone", zone]
+    if apex:
+        args.append("--apex")
+    if auth and auth != "sso":
+        args += ["--auth", auth]
+    if not websocket:
+        args.append("--no-websocket")
+    if verify_ssl:
+        args.append("--verify-ssl")
+    if forward_host:
+        args.append("--forward-host")
+    for email in allow:
+        args += ["--allow", email]
+    for opt in options:
+        args += ["--option", opt]
+    return args
+
+
+def _quote_exec_args(args: list[str]) -> str:
+    """Quote ExecStart args that contain whitespace (systemd-safe)."""
+    out = []
+    for a in args:
+        out.append(f'"{a}"' if (" " in a or "\t" in a) else a)
+    return " ".join(out)
+
+
+def render_unit(
+    *,
+    label: str,
+    hle_path: str,
+    expose_args: list[str],
+    user_mode: bool,
+    run_as_user: str | None,
+) -> str:
+    """Render the systemd unit file text. Pure function (unit-testable)."""
+    exec_start = f"{hle_path} {_quote_exec_args(expose_args)}"
+    lines = [
+        "[Unit]",
+        f"Description=HLE tunnel: {label}",
+        "After=network-online.target",
+        "Wants=network-online.target",
+        "",
+        "[Service]",
+        "Type=simple",
+        f"ExecStart={exec_start}",
+        "Restart=on-failure",
+        "RestartSec=5",
+    ]
+    # System units run as root by default; pin an explicit user when asked so
+    # the tunnel reads that user's ~/.config/hle/config.toml (API key).
+    if not user_mode and run_as_user:
+        lines.append(f"User={run_as_user}")
+    lines += [
+        "",
+        "[Install]",
+        f"WantedBy={'default.target' if user_mode else 'multi-user.target'}",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def _systemctl(user_mode: bool, *args: str) -> subprocess.CompletedProcess[bytes]:
+    cmd = ["systemctl"]
+    if user_mode:
+        cmd.append("--user")
+    cmd += list(args)
+    return subprocess.run(cmd, check=False)  # noqa: S603 — argv built internally
+
+
+def _require_systemd() -> None:
+    if sys.platform != "linux" or shutil.which("systemctl") is None:
+        console.print("[red]`hle service` requires Linux with systemd (systemctl not found).[/red]")
+        raise SystemExit(1)
+
+
+def _unit_dir(user_mode: bool) -> Path:
+    if user_mode:
+        d = Path.home() / ".config" / "systemd" / "user"
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+    return _SYSTEM_UNIT_DIR
+
+
+@click.group()
+def service() -> None:
+    """Install and manage a systemd service for a tunnel."""
+
+
+@service.command("install")
+@click.option("--service", "service_url", required=True, help="Local service URL")
+@click.option("--label", required=True, help="Service label (also names the unit hle-<label>)")
+@click.option("--zone", default=None, help="Custom zone to publish under")
+@click.option("--apex", is_flag=True, default=False, help="Serve at the bare zone root")
+@click.option("--auth", type=click.Choice(["sso", "none"]), default="sso", help="Auth mode")
+@click.option("--websocket/--no-websocket", default=True, help="Enable WebSocket proxying")
+@click.option("--verify-ssl", is_flag=True, default=False, help="Verify upstream TLS cert")
+@click.option("--forward-host", is_flag=True, default=False, help="Forward the browser Host header")
+@click.option("--allow", multiple=True, metavar="[PROVIDER:]EMAIL", help="SSO allow rule (repeat)")
+@click.option(
+    "--option", "options", multiple=True, metavar="KEY=VALUE", help="Passthrough (repeat)"
+)
+@click.option("--name", default=None, help="Override the unit name (default hle-<label>)")
+@click.option("--user", "user_mode", is_flag=True, default=False, help="Install a --user unit")
+@click.option("--run-as", "run_as", default=None, help="System unit User= (default: current user)")
+@click.option("--start/--no-start", default=True, help="Enable + start the service now")
+def install(
+    service_url: str,
+    label: str,
+    zone: str | None,
+    apex: bool,
+    auth: str,
+    websocket: bool,
+    verify_ssl: bool,
+    forward_host: bool,
+    allow: tuple[str, ...],
+    options: tuple[str, ...],
+    name: str | None,
+    user_mode: bool,
+    run_as: str | None,
+    start: bool,
+) -> None:
+    """Install (and start) a systemd service running this tunnel.
+
+    The API key is read from the running user's ~/.config/hle/config.toml or
+    HLE_API_KEY at runtime — it is never written into the unit file. For a
+    system unit, pass --run-as <user> (defaults to the current user) so the
+    service reads that user's config.
+    """
+    _require_systemd()
+    expose_args = build_expose_args(
+        service=service_url,
+        label=label,
+        zone=zone,
+        apex=apex,
+        auth=auth,
+        websocket=websocket,
+        verify_ssl=verify_ssl,
+        forward_host=forward_host,
+        allow=allow,
+        options=options,
+    )
+    run_as_user = run_as or (None if user_mode else getpass.getuser())
+    unit = render_unit(
+        label=label,
+        hle_path=find_hle_path(),
+        expose_args=expose_args,
+        user_mode=user_mode,
+        run_as_user=run_as_user,
+    )
+    uname = unit_name(label, name)
+    path = _unit_dir(user_mode) / uname
+    try:
+        path.write_text(unit)
+    except PermissionError:
+        console.print(
+            f"[red]Permission denied writing {path}.[/red] "
+            "Re-run with sudo, or use --user for a per-user service."
+        )
+        raise SystemExit(1) from None
+
+    console.print(f"[green]Wrote[/green] {path}")
+    _systemctl(user_mode, "daemon-reload")
+    if start:
+        result = _systemctl(user_mode, "enable", "--now", uname)
+        if result.returncode == 0:
+            console.print(f"[green]Started[/green] {uname}")
+        else:
+            console.print(f"[yellow]Installed but failed to start {uname}.[/yellow]")
+    else:
+        console.print(f"Run: systemctl {'--user ' if user_mode else ''}enable --now {uname}")
+
+
+@service.command("uninstall")
+@click.option("--label", required=True, help="Service label")
+@click.option("--name", default=None, help="Explicit unit name")
+@click.option("--user", "user_mode", is_flag=True, default=False, help="Target a --user unit")
+def uninstall(label: str, name: str | None, user_mode: bool) -> None:
+    """Stop, disable, and remove a tunnel's systemd service."""
+    _require_systemd()
+    uname = unit_name(label, name)
+    _systemctl(user_mode, "disable", "--now", uname)
+    path = _unit_dir(user_mode) / uname
+    if path.exists():
+        try:
+            path.unlink()
+            console.print(f"[green]Removed[/green] {path}")
+        except PermissionError:
+            console.print(f"[red]Permission denied removing {path}[/red] (try sudo).")
+            raise SystemExit(1) from None
+    _systemctl(user_mode, "daemon-reload")
+
+
+@service.command("status")
+@click.option("--label", required=True, help="Service label")
+@click.option("--name", default=None, help="Explicit unit name")
+@click.option("--user", "user_mode", is_flag=True, default=False, help="Target a --user unit")
+def status(label: str, name: str | None, user_mode: bool) -> None:
+    """Show systemctl status for a tunnel's service."""
+    _require_systemd()
+    _systemctl(user_mode, "status", "--no-pager", unit_name(label, name))
+
+
+@service.command("list")
+@click.option("--user", "user_mode", is_flag=True, default=False, help="List --user units")
+def list_services(user_mode: bool) -> None:
+    """List installed hle-* services."""
+    _require_systemd()
+    cmd = ["systemctl"]
+    if user_mode:
+        cmd.append("--user")
+    cmd += ["list-units", "--type=service", "--all", "hle-*"]
+    subprocess.run(cmd, check=False)  # noqa: S603 — argv built internally

--- a/src/hle_client/tunnel.py
+++ b/src/hle_client/tunnel.py
@@ -431,6 +431,12 @@ class Tunnel:
         default_factory=dict, init=False, repr=False
     )
     _ws_streams_lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False, repr=False)
+    # Recently removed/failed stream ids. A WS_FRAME can arrive from the relay
+    # just after a local WS failed to open or was closed (the browser's queued
+    # frames race the teardown); demote those to debug instead of WARNING.
+    _recent_closed_streams: deque[str] = field(
+        default_factory=lambda: deque(maxlen=512), init=False, repr=False
+    )
     # Per-stream lifecycle stats — populated for every stream regardless of
     # whether server-side diagnostics are enabled. Attached to every
     # WsStreamClose so the relay sees rich close info even with diagnostics
@@ -1138,6 +1144,7 @@ class Tunnel:
             logger.exception("Failed to open local WS connection to %s", local_ws_url)
             async with self._ws_streams_lock:
                 self._ws_streams.pop(stream_id, None)
+                self._recent_closed_streams.append(stream_id)
             reason = f"{type(exc).__name__}: {exc}"[:_WS_CLOSE_REASON_MAX]
             close_msg = ProtocolMessage(
                 type=MessageType.WS_CLOSE,
@@ -1229,6 +1236,7 @@ class Tunnel:
                 # are recognized as unknown-stream rather than enqueued
                 # into a placeholder that nothing will ever drain.
                 self._ws_streams.pop(stream_id, None)
+                self._recent_closed_streams.append(stream_id)
                 with contextlib.suppress(Exception):
                     await local_ws.close()
                 return
@@ -1327,6 +1335,7 @@ class Tunnel:
         finally:
             async with self._ws_streams_lock:
                 self._ws_streams.pop(stream_id, None)
+                self._recent_closed_streams.append(stream_id)
             stats = self._ws_stream_stats.pop(stream_id, None)
             diagnostics = _build_ws_close_diagnostics(stats, exc_type)
             # Notify the relay that this stream is closed, preserving the
@@ -1363,7 +1372,11 @@ class Tunnel:
         async with self._ws_streams_lock:
             target = self._ws_streams.get(frame.stream_id)
         if target is None:
-            logger.warning("WS_FRAME for unknown stream_id=%s", frame.stream_id)
+            if frame.stream_id in self._recent_closed_streams:
+                # Expected race: frames trailing a failed/closed local WS.
+                logger.debug("WS_FRAME for recently closed stream_id=%s", frame.stream_id)
+            else:
+                logger.warning("WS_FRAME for unknown stream_id=%s", frame.stream_id)
             return
 
         if isinstance(target, asyncio.Queue):
@@ -1388,12 +1401,14 @@ class Tunnel:
             logger.info("Local WS already closed for stream_id=%s", frame.stream_id)
             async with self._ws_streams_lock:
                 self._ws_streams.pop(frame.stream_id, None)
+                self._recent_closed_streams.append(frame.stream_id)
 
     async def _handle_ws_close(self, msg: ProtocolMessage) -> None:
         """Close a local WS connection when the relay signals stream closure."""
         close_req = WsStreamClose.model_validate(msg.payload)
         async with self._ws_streams_lock:
             target = self._ws_streams.pop(close_req.stream_id, None)
+            self._recent_closed_streams.append(close_req.stream_id)
         if target is None:
             return
 

--- a/src/hle_client/tunnel.py
+++ b/src/hle_client/tunnel.py
@@ -584,7 +584,15 @@ class Tunnel:
         relay_uri = await self._discover_relay_uri(api_key)
         logger.info("Connecting to relay at %s", relay_uri)
 
-        async with websockets.connect(relay_uri, max_size=WS_MAX_MESSAGE_SIZE) as ws:
+        # Relaxed keepalive: a large/slow tunnel body over the single control
+        # WS can delay a pong; the default 20s ping timeout would sever the
+        # tunnel (1011). App-level PING/PONG still tracks liveness.
+        async with websockets.connect(
+            relay_uri,
+            max_size=WS_MAX_MESSAGE_SIZE,
+            ping_interval=30,
+            ping_timeout=120,
+        ) as ws:
             self._ws = ws
 
             # --- Registration handshake ---
@@ -609,10 +617,23 @@ class Tunnel:
             )
             await ws.send(register_msg.model_dump_json())
 
-            # Wait for acknowledgement (30s timeout to avoid hanging on buggy relay)
-            ack_raw = await asyncio.wait_for(ws.recv(), timeout=30.0)
-            ack_msg = ProtocolMessage.model_validate_json(ack_raw)
-            if ack_msg.type != MessageType.TUNNEL_ACK:
+            # Wait for acknowledgement (30s total to avoid hanging on a buggy
+            # relay). The relay's app-level keepalive PING can arrive before
+            # TUNNEL_ACK — especially right after a reconnect — so respond with
+            # PONG and keep waiting instead of tearing down a healthy tunnel.
+            deadline = time.monotonic() + 30.0
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise ConnectionError("Timed out waiting for TUNNEL_ACK")
+                ack_raw = await asyncio.wait_for(ws.recv(), timeout=remaining)
+                ack_msg = ProtocolMessage.model_validate_json(ack_raw)
+                if ack_msg.type == MessageType.TUNNEL_ACK:
+                    break
+                if ack_msg.type == MessageType.PING:
+                    pong = ProtocolMessage(type=MessageType.PONG, tunnel_id=ack_msg.tunnel_id)
+                    await ws.send(pong.model_dump_json())
+                    continue
                 raise ConnectionError(f"Expected TUNNEL_ACK, received {ack_msg.type}")
 
             ack_data = TunnelRegistrationResponse.model_validate(ack_msg.payload)

--- a/src/hle_client/update_cmd.py
+++ b/src/hle_client/update_cmd.py
@@ -1,0 +1,149 @@
+"""``hle update`` — self-upgrade regardless of how the client was installed.
+
+Detects whether the running client lives in a pipx-managed venv, a uv-managed
+tool venv, the installer's plain venv, or a system/pip environment, and runs
+the matching upgrade. Keeps users from having to remember the install method
+(and sidesteps the installer's symlink pitfalls).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import click
+from rich.console import Console
+
+from hle_client import __version__
+
+console = Console()
+
+_PACKAGE = "hle-client"
+
+# Install-method identifiers.
+PIPX = "pipx"
+UV = "uv"
+VENV = "venv"
+PIP = "pip"
+
+
+def detect_install_method(prefix: str, executable: str) -> str:
+    """Classify the environment the running client lives in.
+
+    ``prefix`` is ``sys.prefix`` (the venv/environment root); ``executable``
+    is ``sys.executable``. Pure function so it is unit-testable.
+    """
+    p = prefix.replace("\\", "/")
+    if "/pipx/venvs/" in p or "/pipx/venvs" in p:
+        return PIPX
+    if "/uv/tools/" in p or "/uv/tools" in p:
+        return UV
+    # The website installer's plain-venv location.
+    if p.rstrip("/").endswith(".local/share/hle/venv"):
+        return VENV
+    # Any other virtualenv: upgrade in place with its own interpreter.
+    if executable and (Path(prefix) / "pyvenv.cfg").as_posix() and prefix != sys.base_prefix:
+        return VENV
+    return PIP
+
+
+def build_upgrade_command(method: str, executable: str, *, version: str | None = None) -> list[str]:
+    """Build the argv that upgrades the client for the given install method.
+
+    Pure function so it is unit-testable. ``version`` pins an exact version
+    (e.g. ``"2607.2"``); otherwise upgrades to the latest.
+    """
+    spec = f"{_PACKAGE}=={version}" if version else _PACKAGE
+    if method == PIPX:
+        if version:
+            return ["pipx", "install", "--force", spec]
+        return ["pipx", "upgrade", _PACKAGE]
+    if method == UV:
+        if version:
+            return ["uv", "tool", "install", "--force", spec]
+        return ["uv", "tool", "upgrade", _PACKAGE]
+    # venv / pip: upgrade the package inside the running interpreter.
+    return [executable, "-m", "pip", "install", "--upgrade", spec]
+
+
+def pypi_latest_version(package: str = _PACKAGE, timeout: float = 10.0) -> str | None:
+    """Return the latest version on PyPI, or ``None`` if it can't be fetched."""
+    try:
+        import httpx
+
+        resp = httpx.get(f"https://pypi.org/pypi/{package}/json", timeout=timeout)
+        resp.raise_for_status()
+        version = resp.json()["info"]["version"]
+        return str(version) if version else None
+    except Exception:
+        return None
+
+
+def _installed_version(executable: str) -> str | None:
+    """Best-effort read of the installed version after an upgrade."""
+    try:
+        out = subprocess.run(
+            [executable, "-c", "import hle_client; print(hle_client.__version__)"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+        v = out.stdout.strip()
+        return v or None
+    except Exception:
+        return None
+
+
+@click.command()
+@click.option("--check", is_flag=True, help="Only report current vs. latest; don't upgrade.")
+@click.option("--version", "target_version", default=None, help="Upgrade/downgrade to this version")
+@click.option("--yes", "-y", is_flag=True, help="Skip the confirmation prompt.")
+def update(check: bool, target_version: str | None, yes: bool) -> None:
+    """Update the HLE client to the latest version (any install method)."""
+    method = detect_install_method(sys.prefix, sys.executable)
+    console.print(f"Installed: [bold]{__version__}[/bold]  (install method: {method})")
+
+    latest = pypi_latest_version()
+    if latest:
+        console.print(f"Latest on PyPI: [bold]{latest}[/bold]")
+    elif not target_version:
+        console.print("[yellow]Could not reach PyPI to check the latest version.[/yellow]")
+
+    if check:
+        if latest and latest == __version__:
+            console.print("[green]Already up to date.[/green]")
+        elif latest:
+            console.print(f"[yellow]Update available: {__version__} -> {latest}[/yellow]")
+        return
+
+    if not target_version and latest and latest == __version__:
+        console.print("[green]Already up to date.[/green]")
+        return
+
+    target_desc = target_version or latest or "latest"
+    if not yes:
+        click.confirm(f"Upgrade {_PACKAGE} to {target_desc}?", abort=True)
+
+    cmd = build_upgrade_command(method, sys.executable, version=target_version)
+    console.print(f"[dim]$ {' '.join(cmd)}[/dim]")
+    try:
+        result = subprocess.run(cmd, check=False)  # noqa: S603 — argv built internally
+    except FileNotFoundError:
+        console.print(
+            f"[red]Could not run '{cmd[0]}'.[/red] Install it or upgrade manually with:\n"
+            f"  {sys.executable} -m pip install --upgrade {_PACKAGE}"
+        )
+        raise SystemExit(1) from None
+
+    if result.returncode != 0:
+        console.print("[red]Upgrade command failed.[/red]")
+        raise SystemExit(result.returncode)
+
+    new_version = _installed_version(sys.executable) or "unknown"
+    console.print(f"[green]Updated to {new_version}.[/green]")
+    console.print(
+        "[yellow]Restart any running tunnels[/yellow] so they pick up the new version "
+        "(e.g. restart the systemd service, or stop and re-run 'hle expose ...')."
+    )

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -824,6 +824,29 @@ class TestTunnelHandleWsFrame:
         )
         await tunnel._handle_ws_frame(msg)  # no error
 
+    async def test_recently_closed_stream_frame_is_demoted(self, caplog):
+        # A frame trailing a failed/closed local WS should log at debug, not
+        # WARNING (expected race), while a truly unknown id still warns.
+        import logging
+
+        tunnel = _tunnel()
+        tunnel._recent_closed_streams.append("recent")
+
+        recent = WsStreamFrame(stream_id="recent", data="x", is_binary=False)
+        ghost = WsStreamFrame(stream_id="ghost", data="x", is_binary=False)
+
+        with caplog.at_level(logging.WARNING, logger="hle_client.tunnel"):
+            await tunnel._handle_ws_frame(
+                ProtocolMessage(type=MessageType.WS_FRAME, payload=recent.model_dump())
+            )
+        assert not any("recent" in r.message for r in caplog.records)
+
+        with caplog.at_level(logging.WARNING, logger="hle_client.tunnel"):
+            await tunnel._handle_ws_frame(
+                ProtocolMessage(type=MessageType.WS_FRAME, payload=ghost.model_dump())
+            )
+        assert any("unknown stream_id=ghost" in r.message for r in caplog.records)
+
     async def test_closed_connection_removes_stream(self):
         import websockets.exceptions
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -448,6 +448,49 @@ class TestTunnelRegistrationHandshake:
                 await tunnel._connect_once()
             await tunnel._proxy.stop()
 
+    async def test_ping_before_ack_is_tolerated(self):
+        # Regression: a keepalive PING arriving before TUNNEL_ACK (common right
+        # after a reconnect) must not tear down the fresh tunnel. The client
+        # should PONG and keep waiting for the ACK.
+        tunnel = _tunnel(api_key="hle_testkey_ping_ack", service_label="myapp")
+
+        ping = ProtocolMessage(type=MessageType.PING, tunnel_id="t-ping-1")
+        ack = ProtocolMessage(
+            type=MessageType.TUNNEL_ACK,
+            payload={
+                "tunnel_id": "t-ping-1",
+                "subdomain": "myapp-abc",
+                "public_url": "https://myapp-abc.hle.world",
+                "websocket_enabled": True,
+                "user_code": "abc",
+                "service_label": "myapp",
+            },
+        )
+        mock_ws = AsyncMock()
+        sent_messages: list[str] = []
+        mock_ws.send = AsyncMock(side_effect=lambda m: sent_messages.append(m))
+        mock_ws.recv = AsyncMock(side_effect=[ping.model_dump_json(), ack.model_dump_json()])
+        mock_ws.__aiter__ = MagicMock(return_value=_AsyncIter([]))
+
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=mock_ws)
+        mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("hle_client.tunnel.websockets.connect", return_value=mock_ctx):
+            await tunnel._proxy.start()
+            await tunnel._connect_once()
+            await tunnel._proxy.stop()
+
+        # Registered successfully despite the pre-ACK PING.
+        assert tunnel._tunnel_id == "t-ping-1"
+        # A PONG was sent in response to the PING.
+        pongs = [
+            m
+            for m in sent_messages
+            if ProtocolMessage.model_validate_json(m).type == MessageType.PONG
+        ]
+        assert len(pongs) == 1
+
 
 class TestTunnelHandleHttpRequest:
     """Test _handle_http_request: forwards to proxy, sends response back."""

--- a/tests/unit/test_service_cmd.py
+++ b/tests/unit/test_service_cmd.py
@@ -1,0 +1,106 @@
+"""Tests for `hle service` systemd unit generation."""
+
+from __future__ import annotations
+
+from hle_client.service_cmd import build_expose_args, render_unit, unit_name
+
+
+class TestUnitName:
+    def test_default(self):
+        assert unit_name("tv") == "hle-tv.service"
+
+    def test_explicit_name(self):
+        assert unit_name("tv", "my-tunnel") == "my-tunnel.service"
+
+    def test_explicit_name_with_suffix(self):
+        assert unit_name("tv", "my-tunnel.service") == "my-tunnel.service"
+
+
+class TestBuildExposeArgs:
+    def test_minimal(self):
+        assert build_expose_args(service="http://localhost:9998", label="tv") == [
+            "expose",
+            "--service",
+            "http://localhost:9998",
+            "--label",
+            "tv",
+        ]
+
+    def test_all_options(self):
+        args = build_expose_args(
+            service="https://192.168.2.200:8006",
+            label="prox",
+            zone="pr.t00t.us",
+            auth="none",
+            websocket=False,
+            verify_ssl=True,
+            forward_host=True,
+            allow=("a@x.com", "github:b@y.com"),
+            options=("k=v",),
+        )
+        assert "--zone" in args and "pr.t00t.us" in args
+        assert "--auth" in args and "none" in args
+        assert "--no-websocket" in args
+        assert "--verify-ssl" in args
+        assert "--forward-host" in args
+        assert args.count("--allow") == 2
+        assert "--option" in args and "k=v" in args
+
+    def test_apex_no_label_flag(self):
+        args = build_expose_args(service="http://x", label=None, zone="t00t.us", apex=True)
+        assert "--apex" in args
+        assert "--label" not in args
+
+    def test_no_service_secrets(self):
+        # API key must never appear in the generated args.
+        args = build_expose_args(service="http://x", label="tv")
+        assert not any("api" in a.lower() or "key" in a.lower() for a in args)
+
+
+class TestRenderUnit:
+    def test_system_unit_has_user_and_multiuser_target(self):
+        unit = render_unit(
+            label="tv",
+            hle_path="/root/.local/bin/hle",
+            expose_args=["expose", "--service", "http://localhost:9998", "--label", "tv"],
+            user_mode=False,
+            run_as_user="ian",
+        )
+        assert "Description=HLE tunnel: tv" in unit
+        assert (
+            "ExecStart=/root/.local/bin/hle expose --service http://localhost:9998 --label tv"
+        ) in unit
+        assert "User=ian" in unit
+        assert "WantedBy=multi-user.target" in unit
+        assert "Restart=on-failure" in unit
+        assert "After=network-online.target" in unit
+
+    def test_user_unit_omits_user_and_uses_default_target(self):
+        unit = render_unit(
+            label="tv",
+            hle_path="/home/ian/.local/bin/hle",
+            expose_args=["expose", "--service", "http://localhost:9998", "--label", "tv"],
+            user_mode=True,
+            run_as_user="ian",
+        )
+        assert "User=" not in unit
+        assert "WantedBy=default.target" in unit
+
+    def test_args_with_spaces_are_quoted(self):
+        unit = render_unit(
+            label="tv",
+            hle_path="/opt/hle bin/hle",
+            expose_args=["expose", "--option", "note=hello world"],
+            user_mode=True,
+            run_as_user=None,
+        )
+        assert '"note=hello world"' in unit
+        assert '"/opt/hle bin/hle"' not in unit  # only args are quoted, not the leading path
+
+
+class TestServiceWiring:
+    def test_registered_on_cli(self):
+        from hle_client.cli import main
+
+        assert "service" in main.commands
+        assert "install" in main.commands["service"].commands

--- a/tests/unit/test_service_cmd.py
+++ b/tests/unit/test_service_cmd.py
@@ -2,7 +2,13 @@
 
 from __future__ import annotations
 
-from hle_client.service_cmd import build_expose_args, render_unit, unit_name
+from hle_client.service_cmd import (
+    build_expose_args,
+    launchd_label,
+    render_launchd_plist,
+    render_unit,
+    unit_name,
+)
 
 
 class TestUnitName:
@@ -96,6 +102,60 @@ class TestRenderUnit:
         )
         assert '"note=hello world"' in unit
         assert '"/opt/hle bin/hle"' not in unit  # only args are quoted, not the leading path
+
+
+class TestLaunchdLabel:
+    def test_default(self):
+        assert launchd_label("tv") == "world.hle.tv"
+
+    def test_explicit_name(self):
+        assert launchd_label("tv", "com.acme.tunnel") == "com.acme.tunnel"
+
+    def test_explicit_name_strips_plist_suffix(self):
+        assert launchd_label("tv", "com.acme.tunnel.plist") == "com.acme.tunnel"
+
+
+class TestRenderLaunchdPlist:
+    def test_system_daemon_has_username(self):
+        plist = render_launchd_plist(
+            label="tv",
+            plist_label="world.hle.tv",
+            hle_path="/usr/local/bin/hle",
+            expose_args=["expose", "--service", "http://localhost:9998", "--label", "tv"],
+            run_as_user="ian",
+            log_dir="/var/log",
+        )
+        assert "<string>world.hle.tv</string>" in plist
+        assert "<key>UserName</key>" in plist
+        assert "<string>ian</string>" in plist
+        assert "<string>/usr/local/bin/hle</string>" in plist
+        assert "<string>--label</string>" in plist
+        assert "<key>RunAtLoad</key>" in plist
+        assert "<key>KeepAlive</key>" in plist
+        assert "/var/log/tv.log" in plist
+
+    def test_user_agent_omits_username(self):
+        plist = render_launchd_plist(
+            label="tv",
+            plist_label="world.hle.tv",
+            hle_path="/opt/homebrew/bin/hle",
+            expose_args=["expose", "--service", "http://localhost:9998"],
+            run_as_user=None,
+            log_dir="/Users/ian/Library/Logs/hle",
+        )
+        assert "<key>UserName</key>" not in plist
+
+    def test_xml_special_chars_escaped(self):
+        plist = render_launchd_plist(
+            label="tv",
+            plist_label="world.hle.tv",
+            hle_path="/usr/local/bin/hle",
+            expose_args=["expose", "--option", "note=a&b<c"],
+            run_as_user=None,
+            log_dir="/var/log",
+        )
+        assert "a&amp;b&lt;c" in plist
+        assert "a&b<c" not in plist
 
 
 class TestServiceWiring:

--- a/tests/unit/test_update_cmd.py
+++ b/tests/unit/test_update_cmd.py
@@ -1,0 +1,81 @@
+"""Tests for the `hle update` self-upgrade logic."""
+
+from __future__ import annotations
+
+from hle_client.update_cmd import (
+    PIP,
+    PIPX,
+    UV,
+    VENV,
+    build_upgrade_command,
+    detect_install_method,
+)
+
+
+class TestDetectInstallMethod:
+    def test_pipx(self):
+        prefix = "/root/.local/share/pipx/venvs/hle-client"
+        assert detect_install_method(prefix, f"{prefix}/bin/python") == PIPX
+
+    def test_uv_tool(self):
+        prefix = "/root/.local/share/uv/tools/hle-client"
+        assert detect_install_method(prefix, f"{prefix}/bin/python") == UV
+
+    def test_installer_plain_venv(self):
+        prefix = "/root/.local/share/hle/venv"
+        assert detect_install_method(prefix, f"{prefix}/bin/python") == VENV
+
+    def test_installer_plain_venv_trailing_slash(self):
+        prefix = "/home/ian/.local/share/hle/venv/"
+        assert detect_install_method(prefix, f"{prefix}bin/python") == VENV
+
+    def test_system_pip(self):
+        # base prefix == prefix (no venv) → system pip
+        import sys
+
+        assert detect_install_method(sys.base_prefix, sys.executable) == PIP
+
+
+class TestBuildUpgradeCommand:
+    def test_pipx_latest(self):
+        assert build_upgrade_command(PIPX, "/x/python") == ["pipx", "upgrade", "hle-client"]
+
+    def test_pipx_pinned_forces_reinstall(self):
+        assert build_upgrade_command(PIPX, "/x/python", version="2607.2") == [
+            "pipx",
+            "install",
+            "--force",
+            "hle-client==2607.2",
+        ]
+
+    def test_uv_latest(self):
+        assert build_upgrade_command(UV, "/x/python") == ["uv", "tool", "upgrade", "hle-client"]
+
+    def test_venv_uses_running_interpreter_pip(self):
+        exe = "/root/.local/share/hle/venv/bin/python"
+        assert build_upgrade_command(VENV, exe) == [
+            exe,
+            "-m",
+            "pip",
+            "install",
+            "--upgrade",
+            "hle-client",
+        ]
+
+    def test_pip_pinned_version(self):
+        exe = "/usr/bin/python3"
+        assert build_upgrade_command(PIP, exe, version="2607.2") == [
+            exe,
+            "-m",
+            "pip",
+            "install",
+            "--upgrade",
+            "hle-client==2607.2",
+        ]
+
+
+class TestUpdateCommandWiring:
+    def test_registered_on_cli(self):
+        from hle_client.cli import main
+
+        assert "update" in main.commands


### PR DESCRIPTION
## Summary
Ships the `hle update` / `hle service` commands plus two tunnel-reliability fixes surfaced while debugging `tv-ian.hle.world`. Version bump 2607.2 → 2607.3.

### Added
- **`hle update`** — self-upgrade regardless of install method (pipx / uv tool / installer venv / pip). `--check` reports current vs latest; `--version X` pins.
- **`hle service`** — install/manage a background service for a tunnel:
  - **Linux** → systemd unit (system or `--user`)
  - **macOS** → launchd plist (LaunchDaemons or `--user` LaunchAgents)
  - Windows unsupported (clean refusal, no side effects)
  - API key read at runtime from config/`HLE_API_KEY`, never written into the service file.

### Fixed
- **Tunnel flapping (`1011 keepalive ping timeout`)**: relaxed control-WS keepalive (`ping_interval=30`, `ping_timeout=120`) so a large/continuous body (e.g. a live video stream) no longer starves the ping/pong. Pairs with relay-side jspanos/hle#295.
- **Reconnect handshake**: a keepalive `PING` before `TUNNEL_ACK` (common right after reconnect) no longer aborts registration — client now PONGs and keeps waiting.

## Tests
- `render_launchd_plist` + `launchd_label` unit tests; systemd tests unchanged.
- `test_ping_before_ack_is_tolerated` regression for the handshake fix.
- Full suite: 246 passed, ruff clean.

## Related
- Relay 401 path-shadowing fix: jspanos/hle#294
- Relay WS keepalive relaxation: jspanos/hle#295