### PR TITLE
ci: wait for PyPI propagation before downstream dispatch (fixes ha-addon sync stall)

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -20,16 +20,18 @@ jobs:
 
       - name: Wait for PyPI availability
         run: |
-          echo "Waiting for hle-client==${VERSION} on PyPI..."
-          for i in $(seq 1 30); do
-            if pip index versions hle-client 2>/dev/null | grep -q "$VERSION"; then
-              echo "Package available on PyPI"
+          echo "Waiting for hle-client==${VERSION} to be installable from PyPI..."
+          # pip download actually fetches the artifact — a stronger check than
+          # `pip index versions`, whose listing can be cached and lag the file.
+          for i in $(seq 1 60); do
+            if pip download --no-deps --dest /tmp/pypi-check "hle-client==${VERSION}" >/dev/null 2>&1; then
+              echo "hle-client==${VERSION} installable after attempt ${i}."
               exit 0
             fi
-            echo "Attempt $i/30 — waiting 20s..."
-            sleep 20
+            echo "Attempt $i/60 — not installable yet, waiting 15s..."
+            sleep 15
           done
-          echo "Timed out waiting for PyPI"
+          echo "::error::Timed out waiting for hle-client==${VERSION} on PyPI"
           exit 1
 
       - name: Install git

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,6 +51,29 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: twine upload dist/*
 
+      # PyPI upload succeeding does NOT mean the version is installable yet —
+      # the CDN/index takes a bit to propagate. Downstream repos (hle-webapp →
+      # ha-addon, Homebrew) pip-install this exact version immediately on the
+      # dispatch and fail if it isn't there yet, then never retry. Block the
+      # job here until the version is actually installable so every downstream
+      # only fires once PyPI serves it.
+      - name: Wait for PyPI propagation
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          VERSION="${RELEASE_TAG#v}"
+          echo "Waiting for hle-client==${VERSION} to be installable from PyPI..."
+          for i in $(seq 1 60); do
+            if pip download --no-deps --dest /tmp/pypi-check "hle-client==${VERSION}" >/dev/null 2>&1; then
+              echo "hle-client==${VERSION} installable after attempt ${i}."
+              exit 0
+            fi
+            echo "  not on PyPI yet (attempt ${i}/60); sleeping 15s..."
+            sleep 15
+          done
+          echo "::error::hle-client==${VERSION} did not become installable within ~15 minutes"
+          exit 1
+
   notify-operator:
     name: Notify hle-operator
     needs: publish


### PR DESCRIPTION
## Summary
PyPI upload succeeding does not mean the version is installable — index/CDN propagation lags. Downstream repos pip-install the exact new version the instant the release dispatch fires and fail if it isn't served yet, then never retry. This silently froze **ha-addon at hle-client 2605.5** (May): every hle-webapp `sync-client` PR since has a red `Backend compile + lint` (`Could not find a version that satisfies hle-client==<new>`), so auto-merge never engaged and the ha-addon cascade never ran.

- `publish.yml`: after `twine upload`, block the publish job until `pip download --no-deps hle-client==<version>` succeeds. Downstream `needs: publish` dispatches (hle-webapp, hle-operator) now only fire once installable.
- `homebrew.yml`: strengthen the existing wait from `pip index versions | grep` (reads a cacheable listing) to the same `pip download` check.

Pairs with a retry-with-backoff on the hle-webapp side (belt-and-suspenders).