### PR TITLE
feat(agent): run the agent as a service + one-command installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,15 @@
 #!/bin/sh
 # HLE Client installer
-# Usage: curl -fsSL https://get.hle.world | sh
-#        curl -fsSL https://get.hle.world | sh -s -- --version 2607.2
+#
+# Usage:
+#   curl -fsSL https://get.hle.world | sh
+#   curl -fsSL https://get.hle.world | sh -s -- --version 2607.3
+#
+#   # Install the agent and run it as a service (prompts for the token):
+#   curl -fsSL https://get.hle.world | sh -s -- --agent
+#
+#   # Fully unattended (CI, cloud-init, Ansible):
+#   curl -fsSL https://get.hle.world | sh -s -- --agent --token hlea_xxxxx
 set -e
 
 PACKAGE="hle-client"
@@ -9,12 +17,42 @@ VERSION=""
 MIN_PYTHON_MAJOR=3
 MIN_PYTHON_MINOR=11
 
+AGENT=0
+AGENT_TOKEN=""
+INSTALL_SERVICE=1
+SERVICE_SCOPE=""   # "", "--user", or "--system"; empty lets the CLI auto-detect
+
+usage() {
+    cat <<'EOF'
+HLE Client installer
+
+Options:
+  --version <v>     Install a specific hle-client version
+  --agent           Enroll this machine as an HLE agent and run it as a service
+  --token <token>   Agent enrollment token (hlea_...); implies --agent.
+                    Without it, --agent prompts on the terminal.
+  --no-service      With --agent: enroll only, don't install a service
+  --user            Install a per-user service (no sudo; needs linger on Linux)
+  --system          Install a system-wide service (starts at boot; needs sudo)
+  -h, --help        Show this help
+
+Without --agent this installs the CLI only, exactly as before.
+EOF
+}
+
 # Parse arguments
 while [ $# -gt 0 ]; do
     case "$1" in
         --version) VERSION="$2"; shift 2 ;;
         --version=*) VERSION="${1#*=}"; shift ;;
-        *) echo "Unknown option: $1"; exit 1 ;;
+        --agent) AGENT=1; shift ;;
+        --token) AGENT_TOKEN="$2"; AGENT=1; shift 2 ;;
+        --token=*) AGENT_TOKEN="${1#*=}"; AGENT=1; shift ;;
+        --no-service) INSTALL_SERVICE=0; shift ;;
+        --user) SERVICE_SCOPE="--user"; shift ;;
+        --system) SERVICE_SCOPE="--system"; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "Unknown option: $1"; usage; exit 1 ;;
     esac
 done
 
@@ -29,9 +67,16 @@ fi
 info() { printf '\033[0;34m[hle]\033[0m %s\n' "$1"; }
 success() { printf '\033[0;32m[hle]\033[0m %s\n' "$1"; }
 error() { printf '\033[0;31m[hle]\033[0m %s\n' "$1" >&2; }
+warn() { printf '\033[0;33m[hle]\033[0m %s\n' "$1" >&2; }
+
+# True when we can talk to a human. Under `curl ... | sh` stdin is the script
+# itself, so every prompt must read from /dev/tty instead.
+has_tty() { [ -r /dev/tty ] && [ -w /dev/tty ]; }
+
 prompt_yn() {
-    printf '\033[0;34m[hle]\033[0m %s [y/N] ' "$1"
-    read -r answer
+    has_tty || return 1
+    printf '\033[0;34m[hle]\033[0m %s [y/N] ' "$1" > /dev/tty
+    read -r answer < /dev/tty
     case "$answer" in
         [yY]|[yY][eE][sS]) return 0 ;;
         *) return 1 ;;
@@ -105,13 +150,23 @@ verify_install() {
 # --- Installation methods ---
 
 install_with_pipx() {
-    info "Installing with pipx..."
-    pipx install "$INSTALL_SPEC"
+    if pipx list --short 2>/dev/null | grep -q "^${PACKAGE} "; then
+        info "Upgrading with pipx..."
+        pipx upgrade "$PACKAGE"
+    else
+        info "Installing with pipx..."
+        pipx install "$INSTALL_SPEC"
+    fi
 }
 
 install_with_uv() {
-    info "Installing with uv tool..."
-    uv tool install "$INSTALL_SPEC"
+    if uv tool list 2>/dev/null | grep -q "^${PACKAGE} "; then
+        info "Upgrading with uv tool..."
+        uv tool upgrade "$PACKAGE"
+    else
+        info "Installing with uv tool..."
+        uv tool install "$INSTALL_SPEC"
+    fi
 }
 
 install_with_venv() {
@@ -130,6 +185,71 @@ install_with_venv() {
     # Symlink the hle binary
     ensure_local_bin
     ln -sf "$VENV_DIR/bin/hle" "$HOME/.local/bin/hle"
+}
+
+# --- Agent setup ---
+
+# Enroll this machine as an agent. The token is passed to `hle agent enroll`,
+# which validates the hlea_ prefix and writes ~/.config/hle/agent.toml (0600).
+# It is never written to disk by this script, nor echoed back.
+agent_enroll() {
+    if [ -n "$AGENT_TOKEN" ]; then
+        hle agent enroll "$AGENT_TOKEN" || return 1
+        return 0
+    fi
+
+    if ! has_tty; then
+        warn "No agent token and no terminal to prompt on."
+        warn "Re-run with: --agent --token hlea_xxxxx"
+        return 1
+    fi
+
+    info "Create an agent at https://hle.world/dashboard and copy its token."
+    info "The token is shown only once."
+    # `hle agent enroll` prompts (with echo off) and validates; bind its stdin
+    # to the terminal so it works under `curl ... | sh`.
+    hle agent enroll < /dev/tty || return 1
+}
+
+agent_install_service() {
+    if [ "$INSTALL_SERVICE" -eq 0 ]; then
+        info "Skipping service install (--no-service). Start it with: hle agent run"
+        return 0
+    fi
+
+    # Scope is auto-detected by the CLI (root -> system, otherwise per-user)
+    # unless the caller pinned it with --user / --system.
+    # shellcheck disable=SC2086 -- SERVICE_SCOPE is intentionally unquoted (may be empty)
+    if hle service install --agent $SERVICE_SCOPE; then
+        return 0
+    fi
+
+    warn "Could not install the service automatically."
+    warn "Install it manually with: sudo hle service install --agent --system"
+    warn "Or just run the agent in the foreground: hle agent run"
+    return 1
+}
+
+setup_agent() {
+    if ! command -v hle >/dev/null 2>&1; then
+        error "hle is not on PATH yet — cannot set up the agent."
+        error "Restart your shell, then run: hle agent enroll && hle service install --agent"
+        exit 1
+    fi
+
+    if ! agent_enroll; then
+        error "Agent enrollment failed. The client is installed; you can retry with:"
+        error "  hle agent enroll"
+        error "  hle service install --agent"
+        exit 1
+    fi
+    success "Agent enrolled."
+
+    agent_install_service || exit 1
+
+    success "Agent is set up."
+    info "Add endpoints at https://hle.world/dashboard — the agent picks them up in seconds."
+    info "Check on it with: hle service status --agent"
 }
 
 # --- Main ---
@@ -158,10 +278,21 @@ main() {
     if command -v hle >/dev/null 2>&1; then
         success "HLE client installed successfully!"
         info "Version: $(hle --version)"
-        info "Run 'hle expose --service http://localhost:8080' to get started."
     else
         success "HLE client installed. Restart your shell or run:"
         info "  export PATH=\"\$HOME/.local/bin:\$PATH\""
+        if [ "$AGENT" -eq 1 ]; then
+            warn "Then finish agent setup with:"
+            warn "  hle agent enroll && hle service install --agent"
+        fi
+        exit 0
+    fi
+
+    if [ "$AGENT" -eq 1 ]; then
+        setup_agent
+    else
+        info "Run 'hle expose --service http://localhost:8080' to expose one service,"
+        info "or re-run this installer with --agent to manage many from the dashboard."
     fi
 }
 

--- a/src/hle_client/service_cmd.py
+++ b/src/hle_client/service_cmd.py
@@ -1,8 +1,9 @@
-"""``hle service`` — install and manage a background service for a tunnel.
+"""``hle service`` — install and manage a background service.
 
-Generates a service definition that runs ``hle expose ...`` with the given
-options, so a homelab tunnel survives reboots and restarts on failure without
-the user hand-writing service files.
+Generates a service definition that runs either ``hle expose ...`` (a single
+tunnel) or ``hle agent run`` (the dashboard-driven multi-tunnel agent), so a
+homelab stays reachable across reboots and restarts on failure without the user
+hand-writing service files.
 
 Backends:
   * Linux  → systemd unit (``systemctl`` / ``/etc/systemd/system`` or ``--user``)
@@ -14,6 +15,7 @@ Windows is not supported (use Task Scheduler / NSSM manually).
 from __future__ import annotations
 
 import getpass
+import os
 import shutil
 import subprocess
 import sys
@@ -27,6 +29,9 @@ console = Console()
 
 _SYSTEM_UNIT_DIR = Path("/etc/systemd/system")
 _LAUNCHD_LABEL_PREFIX = "world.hle"
+
+# Label used for the agent's unit/plist when the user doesn't override it.
+AGENT_LABEL = "agent"
 
 
 # --------------------------------------------------------------------------- #
@@ -93,6 +98,42 @@ def build_expose_args(
     return args
 
 
+def build_agent_args(
+    *,
+    relay_host: str | None = None,
+    relay_port: int | None = None,
+) -> list[str]:
+    """Build the ``agent run`` argv (no secrets) for the service definition.
+
+    The enrollment token is *not* baked in — the agent reads it at runtime from
+    the running user's ``~/.config/hle/agent.toml`` or ``HLE_AGENT_TOKEN``.
+    """
+    args = ["agent", "run"]
+    if relay_host:
+        args += ["--relay-host", relay_host]
+    if relay_port:
+        args += ["--relay-port", str(relay_port)]
+    return args
+
+
+def resolve_user_mode(*, user_flag: bool, system_flag: bool) -> bool:
+    """Decide between a per-user and a system service.
+
+    Explicit ``--user`` / ``--system`` always win. Otherwise auto-detect: root
+    installs a system service (starts at boot), non-root installs a per-user one
+    (no sudo needed).
+    """
+    if user_flag and system_flag:
+        console.print("[red]Pass either --user or --system, not both.[/red]")
+        raise SystemExit(1)
+    if user_flag:
+        return True
+    if system_flag:
+        return False
+    is_root = hasattr(os, "geteuid") and os.geteuid() == 0
+    return not is_root
+
+
 def current_platform() -> str:
     """Return ``"linux"``, ``"darwin"``, or the raw ``sys.platform`` value."""
     if sys.platform.startswith("linux"):
@@ -142,22 +183,24 @@ def render_unit(
     *,
     label: str,
     hle_path: str,
-    expose_args: list[str],
+    run_args: list[str],
     user_mode: bool,
     run_as_user: str | None,
+    description: str | None = None,
+    restart: str = "on-failure",
 ) -> str:
     """Render the systemd unit file text. Pure function (unit-testable)."""
-    exec_start = f"{hle_path} {_quote_exec_args(expose_args)}"
+    exec_start = f"{hle_path} {_quote_exec_args(run_args)}"
     lines = [
         "[Unit]",
-        f"Description=HLE tunnel: {label}",
+        f"Description={description or f'HLE tunnel: {label}'}",
         "After=network-online.target",
         "Wants=network-online.target",
         "",
         "[Service]",
         "Type=simple",
         f"ExecStart={exec_start}",
-        "Restart=on-failure",
+        f"Restart={restart}",
         "RestartSec=5",
     ]
     # System units run as root by default; pin an explicit user when asked so
@@ -192,19 +235,23 @@ def _unit_dir(user_mode: bool) -> Path:
 def _systemd_install(
     *,
     label: str,
-    expose_args: list[str],
+    run_args: list[str],
     name: str | None,
     user_mode: bool,
     run_as: str | None,
     start: bool,
+    description: str | None = None,
+    restart: str = "on-failure",
 ) -> None:
     run_as_user = run_as or (None if user_mode else getpass.getuser())
     unit = render_unit(
         label=label,
         hle_path=find_hle_path(),
-        expose_args=expose_args,
+        run_args=run_args,
         user_mode=user_mode,
         run_as_user=run_as_user,
+        description=description,
+        restart=restart,
     )
     uname = unit_name(label, name)
     path = _unit_dir(user_mode) / uname
@@ -227,6 +274,13 @@ def _systemd_install(
             console.print(f"[yellow]Installed but failed to start {uname}.[/yellow]")
     else:
         console.print(f"Run: systemctl {'--user ' if user_mode else ''}enable --now {uname}")
+
+    if user_mode:
+        # Per-user units stop when the user logs out unless lingering is on.
+        console.print(
+            f"[dim]Tip: run `sudo loginctl enable-linger {getpass.getuser()}` so the "
+            f"service keeps running after logout and starts at boot.[/dim]"
+        )
 
 
 def _systemd_uninstall(*, label: str, name: str | None, user_mode: bool) -> None:
@@ -263,7 +317,7 @@ def render_launchd_plist(
     label: str,
     plist_label: str,
     hle_path: str,
-    expose_args: list[str],
+    run_args: list[str],
     run_as_user: str | None,
     log_dir: str,
 ) -> str:
@@ -272,7 +326,7 @@ def render_launchd_plist(
     ``run_as_user`` adds a ``UserName`` key (system daemons only); pass ``None``
     for per-user agents that already run as the invoking user.
     """
-    prog = [hle_path, *expose_args]
+    prog = [hle_path, *run_args]
     prog_xml = "\n".join(f"        <string>{_xml_escape(a)}</string>" for a in prog)
     out_log = f"{log_dir.rstrip('/')}/{label}.log"
     err_log = f"{log_dir.rstrip('/')}/{label}.err.log"
@@ -330,7 +384,7 @@ def _launchd_log_dir(user_mode: bool) -> str:
 def _launchd_install(
     *,
     label: str,
-    expose_args: list[str],
+    run_args: list[str],
     name: str | None,
     user_mode: bool,
     run_as: str | None,
@@ -344,7 +398,7 @@ def _launchd_install(
         label=label,
         plist_label=plabel,
         hle_path=find_hle_path(),
-        expose_args=expose_args,
+        run_args=run_args,
         run_as_user=run_as_user,
         log_dir=_launchd_log_dir(user_mode),
     )
@@ -410,14 +464,33 @@ def _launchd_list(*, user_mode: bool) -> None:
 # --------------------------------------------------------------------------- #
 # CLI
 # --------------------------------------------------------------------------- #
+def _resolve_label(label: str | None, agent_mode: bool) -> str:
+    """Resolve the label for uninstall/status: --agent implies the agent label."""
+    if label:
+        return label
+    if agent_mode:
+        return AGENT_LABEL
+    console.print("[red]--label is required[/red] (or pass --agent for the agent service).")
+    raise SystemExit(1)
+
+
 @click.group()
 def service() -> None:
-    """Install and manage a background service for a tunnel (systemd/launchd)."""
+    """Install and manage a background service (systemd/launchd)."""
 
 
 @service.command("install")
-@click.option("--service", "service_url", required=True, help="Local service URL")
-@click.option("--label", required=True, help="Service label (also names the unit hle-<label>)")
+@click.option(
+    "--agent",
+    "agent_mode",
+    is_flag=True,
+    default=False,
+    help="Install the dashboard-driven agent (`hle agent run`) instead of a single tunnel",
+)
+@click.option("--relay-host", default=None, help="Agent mode: relay host (default hle.world)")
+@click.option("--relay-port", default=None, type=int, help="Agent mode: relay port (default 443)")
+@click.option("--service", "service_url", default=None, help="Local service URL")
+@click.option("--label", default=None, help="Service label (also names the unit hle-<label>)")
 @click.option("--zone", default=None, help="Custom zone to publish under")
 @click.option("--apex", is_flag=True, default=False, help="Serve at the bare zone root")
 @click.option("--auth", type=click.Choice(["sso", "none"]), default="sso", help="Auth mode")
@@ -430,11 +503,17 @@ def service() -> None:
 )
 @click.option("--name", default=None, help="Override the unit/plist name")
 @click.option("--user", "user_mode", is_flag=True, default=False, help="Install a per-user service")
+@click.option(
+    "--system", "system_mode", is_flag=True, default=False, help="Install a system-wide service"
+)
 @click.option("--run-as", "run_as", default=None, help="System service user (default: current)")
 @click.option("--start/--no-start", default=True, help="Enable + start the service now")
 def install(
-    service_url: str,
-    label: str,
+    agent_mode: bool,
+    relay_host: str | None,
+    relay_port: int | None,
+    service_url: str | None,
+    label: str | None,
     zone: str | None,
     apex: bool,
     auth: str,
@@ -445,33 +524,66 @@ def install(
     options: tuple[str, ...],
     name: str | None,
     user_mode: bool,
+    system_mode: bool,
     run_as: str | None,
     start: bool,
 ) -> None:
-    """Install (and start) a background service running this tunnel.
+    """Install (and start) a background service.
 
-    The API key is read from the running user's ~/.config/hle/config.toml or
-    HLE_API_KEY at runtime — it is never written into the service file. For a
+    Default: a single tunnel (`hle expose`) — requires --service and --label.
+    With --agent: the dashboard-driven agent (`hle agent run`), which serves
+    every endpoint you declare in the dashboard from one process.
+
+    Credentials are never written into the service file. They are read at
+    runtime from the running user's ~/.config/hle/ (config.toml for the API key,
+    agent.toml for the agent token) or from HLE_API_KEY / HLE_AGENT_TOKEN. For a
     system service, pass --run-as <user> (defaults to the current user) so the
     service reads that user's config.
+
+    Scope is auto-detected when neither --user nor --system is given: root
+    installs a system service, a normal user installs a per-user one.
     """
     plat = _require_supported()
-    expose_args = build_expose_args(
-        service=service_url,
-        label=label,
-        zone=zone,
-        apex=apex,
-        auth=auth,
-        websocket=websocket,
-        verify_ssl=verify_ssl,
-        forward_host=forward_host,
-        allow=allow,
-        options=options,
-    )
+    user_mode = resolve_user_mode(user_flag=user_mode, system_flag=system_mode)
+
+    if agent_mode:
+        if service_url:
+            console.print("[red]--service is not used with --agent.[/red] Endpoints come from")
+            console.print("the dashboard. Drop --service, or drop --agent for a single tunnel.")
+            raise SystemExit(1)
+        label = label or AGENT_LABEL
+        run_args = build_agent_args(relay_host=relay_host, relay_port=relay_port)
+        description = "HLE agent (dashboard-managed tunnels)"
+        # The agent is the homelab's front door: always bring it back, not just
+        # on failure (a clean exit from a dropped control channel still needs a
+        # restart).
+        restart = "always"
+    else:
+        if not service_url or not label:
+            console.print(
+                "[red]--service and --label are required[/red] (or pass --agent to install "
+                "the dashboard-managed agent)."
+            )
+            raise SystemExit(1)
+        run_args = build_expose_args(
+            service=service_url,
+            label=label,
+            zone=zone,
+            apex=apex,
+            auth=auth,
+            websocket=websocket,
+            verify_ssl=verify_ssl,
+            forward_host=forward_host,
+            allow=allow,
+            options=options,
+        )
+        description = f"HLE tunnel: {label}"
+        restart = "on-failure"
+
     if plat == "darwin":
         _launchd_install(
             label=label,
-            expose_args=expose_args,
+            run_args=run_args,
             name=name,
             user_mode=user_mode,
             run_as=run_as,
@@ -480,21 +592,37 @@ def install(
     else:
         _systemd_install(
             label=label,
-            expose_args=expose_args,
+            run_args=run_args,
             name=name,
             user_mode=user_mode,
             run_as=run_as,
             start=start,
+            description=description,
+            restart=restart,
+        )
+
+    if agent_mode:
+        console.print(
+            "\n[dim]Add endpoints at https://hle.world/dashboard — the agent picks them "
+            "up within seconds, no restart needed.[/dim]"
         )
 
 
 @service.command("uninstall")
-@click.option("--label", required=True, help="Service label")
+@click.option("--agent", "agent_mode", is_flag=True, default=False, help="Target the agent service")
+@click.option("--label", default=None, help="Service label")
 @click.option("--name", default=None, help="Explicit unit/plist name")
 @click.option("--user", "user_mode", is_flag=True, default=False, help="Target a per-user service")
-def uninstall(label: str, name: str | None, user_mode: bool) -> None:
-    """Stop, disable, and remove a tunnel's background service."""
+@click.option(
+    "--system", "system_mode", is_flag=True, default=False, help="Target a system service"
+)
+def uninstall(
+    agent_mode: bool, label: str | None, name: str | None, user_mode: bool, system_mode: bool
+) -> None:
+    """Stop, disable, and remove a background service."""
     plat = _require_supported()
+    label = _resolve_label(label, agent_mode)
+    user_mode = resolve_user_mode(user_flag=user_mode, system_flag=system_mode)
     if plat == "darwin":
         _launchd_uninstall(label=label, name=name, user_mode=user_mode)
     else:
@@ -502,12 +630,20 @@ def uninstall(label: str, name: str | None, user_mode: bool) -> None:
 
 
 @service.command("status")
-@click.option("--label", required=True, help="Service label")
+@click.option("--agent", "agent_mode", is_flag=True, default=False, help="Target the agent service")
+@click.option("--label", default=None, help="Service label")
 @click.option("--name", default=None, help="Explicit unit/plist name")
 @click.option("--user", "user_mode", is_flag=True, default=False, help="Target a per-user service")
-def status(label: str, name: str | None, user_mode: bool) -> None:
-    """Show status for a tunnel's background service."""
+@click.option(
+    "--system", "system_mode", is_flag=True, default=False, help="Target a system service"
+)
+def status(
+    agent_mode: bool, label: str | None, name: str | None, user_mode: bool, system_mode: bool
+) -> None:
+    """Show status for a background service."""
     plat = _require_supported()
+    label = _resolve_label(label, agent_mode)
+    user_mode = resolve_user_mode(user_flag=user_mode, system_flag=system_mode)
     if plat == "darwin":
         _launchd_status(label=label, name=name, user_mode=user_mode)
     else:

--- a/tests/unit/test_service_cmd.py
+++ b/tests/unit/test_service_cmd.py
@@ -2,13 +2,90 @@
 
 from __future__ import annotations
 
+import pytest
+
 from hle_client.service_cmd import (
+    AGENT_LABEL,
+    build_agent_args,
     build_expose_args,
     launchd_label,
     render_launchd_plist,
     render_unit,
+    resolve_user_mode,
     unit_name,
 )
+
+
+class TestBuildAgentArgs:
+    def test_minimal(self):
+        assert build_agent_args() == ["agent", "run"]
+
+    def test_relay_override(self):
+        assert build_agent_args(relay_host="staging.hle.world", relay_port=8443) == [
+            "agent",
+            "run",
+            "--relay-host",
+            "staging.hle.world",
+            "--relay-port",
+            "8443",
+        ]
+
+    def test_never_contains_a_token(self):
+        # The enrollment token is read at runtime, never baked into the unit.
+        assert not any(a.startswith("hlea_") for a in build_agent_args())
+
+
+class TestResolveUserMode:
+    def test_explicit_user_wins(self, monkeypatch):
+        monkeypatch.setattr("os.geteuid", lambda: 0, raising=False)
+        assert resolve_user_mode(user_flag=True, system_flag=False) is True
+
+    def test_explicit_system_wins(self, monkeypatch):
+        monkeypatch.setattr("os.geteuid", lambda: 1000, raising=False)
+        assert resolve_user_mode(user_flag=False, system_flag=True) is False
+
+    def test_autodetect_root_is_system(self, monkeypatch):
+        monkeypatch.setattr("os.geteuid", lambda: 0, raising=False)
+        assert resolve_user_mode(user_flag=False, system_flag=False) is False
+
+    def test_autodetect_nonroot_is_user(self, monkeypatch):
+        monkeypatch.setattr("os.geteuid", lambda: 1000, raising=False)
+        assert resolve_user_mode(user_flag=False, system_flag=False) is True
+
+    def test_both_flags_rejected(self):
+        with pytest.raises(SystemExit):
+            resolve_user_mode(user_flag=True, system_flag=True)
+
+
+class TestAgentUnit:
+    def test_unit_name_and_restart_always(self):
+        assert unit_name(AGENT_LABEL) == "hle-agent.service"
+        unit = render_unit(
+            label=AGENT_LABEL,
+            hle_path="/usr/local/bin/hle",
+            run_args=build_agent_args(),
+            user_mode=False,
+            run_as_user="homelab",
+            description="HLE agent (dashboard-managed tunnels)",
+            restart="always",
+        )
+        assert "ExecStart=/usr/local/bin/hle agent run" in unit
+        assert "Restart=always" in unit
+        assert "Description=HLE agent (dashboard-managed tunnels)" in unit
+        assert "User=homelab" in unit
+
+    def test_launchd_plist(self):
+        plist = render_launchd_plist(
+            label=AGENT_LABEL,
+            plist_label=launchd_label(AGENT_LABEL),
+            hle_path="/usr/local/bin/hle",
+            run_args=build_agent_args(),
+            run_as_user=None,
+            log_dir="/tmp/logs",
+        )
+        assert "<string>world.hle.agent</string>" in plist
+        assert "<string>agent</string>" in plist
+        assert "<string>run</string>" in plist
 
 
 class TestUnitName:
@@ -68,7 +145,7 @@ class TestRenderUnit:
         unit = render_unit(
             label="tv",
             hle_path="/root/.local/bin/hle",
-            expose_args=["expose", "--service", "http://localhost:9998", "--label", "tv"],
+            run_args=["expose", "--service", "http://localhost:9998", "--label", "tv"],
             user_mode=False,
             run_as_user="ian",
         )
@@ -85,7 +162,7 @@ class TestRenderUnit:
         unit = render_unit(
             label="tv",
             hle_path="/home/ian/.local/bin/hle",
-            expose_args=["expose", "--service", "http://localhost:9998", "--label", "tv"],
+            run_args=["expose", "--service", "http://localhost:9998", "--label", "tv"],
             user_mode=True,
             run_as_user="ian",
         )
@@ -96,7 +173,7 @@ class TestRenderUnit:
         unit = render_unit(
             label="tv",
             hle_path="/opt/hle bin/hle",
-            expose_args=["expose", "--option", "note=hello world"],
+            run_args=["expose", "--option", "note=hello world"],
             user_mode=True,
             run_as_user=None,
         )
@@ -121,7 +198,7 @@ class TestRenderLaunchdPlist:
             label="tv",
             plist_label="world.hle.tv",
             hle_path="/usr/local/bin/hle",
-            expose_args=["expose", "--service", "http://localhost:9998", "--label", "tv"],
+            run_args=["expose", "--service", "http://localhost:9998", "--label", "tv"],
             run_as_user="ian",
             log_dir="/var/log",
         )
@@ -139,7 +216,7 @@ class TestRenderLaunchdPlist:
             label="tv",
             plist_label="world.hle.tv",
             hle_path="/opt/homebrew/bin/hle",
-            expose_args=["expose", "--service", "http://localhost:9998"],
+            run_args=["expose", "--service", "http://localhost:9998"],
             run_as_user=None,
             log_dir="/Users/ian/Library/Logs/hle",
         )
@@ -150,7 +227,7 @@ class TestRenderLaunchdPlist:
             label="tv",
             plist_label="world.hle.tv",
             hle_path="/usr/local/bin/hle",
-            expose_args=["expose", "--option", "note=a&b<c"],
+            run_args=["expose", "--option", "note=a&b<c"],
             run_as_user=None,
             log_dir="/var/log",
         )


### PR DESCRIPTION
## Summary

Makes the dashboard-managed agent installable and durable. `hle service install --agent` renders a systemd unit / launchd job running `hle agent run`, and the get.hle.world installer gains `--agent` to do install + enroll + service in one command.

- `hle service install --agent` — installs the agent instead of a single tunnel. Unit `hle-agent.service` (systemd) / `world.hle.agent` (launchd), `Restart=always`.
- `--user` / `--system` flags, auto-detected when neither is given: root → system service, normal user → per-user service (with a `loginctl enable-linger` hint).
- `hle service uninstall --agent` / `status --agent` — no need to remember the label.
- `install.sh`: `--agent`, `--token`, `--no-service`, `--user`, `--system`, `--help`.
- Fixes `prompt_yn` reading from stdin — when the installer is piped from the network, stdin is the script, so the prompt ate script text instead of the user's answer. Now reads `/dev/tty`.

## Technical details

- Token handling: never written into the service definition. The agent reads it at runtime from `~/.config/hle/agent.toml` (0600) or `HLE_AGENT_TOKEN`, so unit files stay safe to read, back up, or template. `install.sh` delegates the interactive prompt to `hle agent enroll` (stdin bound to `/dev/tty`) rather than reimplementing token validation in shell.
- `service_cmd.py`: renamed `expose_args` → `run_args` and added `description` / `restart` params to `render_unit`, so the single-tunnel and agent modes share the systemd/launchd backends. New `build_agent_args()` and `resolve_user_mode()`, both pure and unit-tested.
- `--service` and `--label` are no longer Click-`required`; validated in the body so `--agent` can supply its own defaults. Passing both `--agent` and `--service` is rejected with an explanatory message.
- New tests cover agent argv construction (including that no token leaks into it), scope auto-detection, and the rendered unit/plist. 257 tests pass.

No behaviour change for existing `hle expose` or `hle service install` users.