### PR TITLE
Release v2607.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2607.4 — 2026-07-25
+
+<!-- TODO: Fill in release notes before merging -->
+
 ## v2607.3 — 2026-07-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,33 @@
 
 ## v2607.4 — 2026-07-25
 
-<!-- TODO: Fill in release notes before merging -->
+### Added
+- **`hle service install --agent`** — install the dashboard-managed agent as a
+  background service, so every endpoint you declare in the dashboard survives
+  reboots. Unit is `hle-agent.service` (systemd) / `world.hle.agent` (launchd),
+  with `Restart=always`.
+  - `hle service uninstall --agent` and `hle service status --agent` target it
+    without needing to remember the label.
+  - The enrollment token is read at runtime from `~/.config/hle/agent.toml` or
+    `HLE_AGENT_TOKEN` — never written into the service file.
+- **Service scope auto-detection** — with neither `--user` nor `--system`, root
+  installs a system service and a normal user installs a per-user one (with a
+  `loginctl enable-linger` hint). Both flags remain available to force it.
+- **Installer agent flags** — `--agent`, `--token`, `--no-service`, `--user`,
+  `--system`, and `--help`. `--agent` installs the client, enrolls the machine,
+  and installs the service in one command; without `--token` it prompts on the
+  terminal.
+
+### Fixed
+- Installer prompts read from `/dev/tty` instead of stdin. When the installer is
+  piped from the network, stdin is the script itself, so the "add ~/.local/bin to
+  PATH?" prompt consumed script text rather than the user's answer.
+
+### Changed
+- Internal: `service_cmd` now builds `run_args` (was `expose_args`) and takes
+  `description` / `restart`, so single-tunnel and agent modes share the systemd
+  and launchd backends. No change to existing `hle expose` or
+  `hle service install` behaviour.
 
 ## v2607.3 — 2026-07-17
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ curl -fsSL https://get.hle.world | sh
 Installs via pipx (preferred), uv, or pip-in-venv. Supports `--version`:
 
 ```bash
-curl -fsSL https://get.hle.world | sh -s -- --version 2607.2
+curl -fsSL https://get.hle.world | sh -s -- --version 2607.4
 ```
 
 ### pipx
@@ -93,7 +93,7 @@ and runs the right upgrade.
 ```bash
 hle update            # upgrade to the latest release
 hle update --check    # just report current vs. latest, don't change anything
-hle update --version 2607.2   # pin an exact version
+hle update --version 2607.4   # pin an exact version
 ```
 
 After updating, restart any running tunnels (e.g. `systemctl restart hle-<label>`)

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 #
 # Usage:
 #   curl -fsSL https://get.hle.world | sh
-#   curl -fsSL https://get.hle.world | sh -s -- --version 2607.3
+#   curl -fsSL https://get.hle.world | sh -s -- --version 2607.4
 #
 #   # Install the agent and run it as a service (prompts for the token):
 #   curl -fsSL https://get.hle.world | sh -s -- --agent
@@ -263,7 +263,7 @@ main() {
         error "Install Python from https://python.org or via your package manager."
         exit 1
     }
-    info "Found Python: $PYTHON ($($PYTHON --version 2>&1))"
+    info "Found Python: $PYTHON ($($PYTHON --version 2607.4>&1))"
 
     # Try install methods in order of preference
     if command -v pipx >/dev/null 2>&1; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hle-client"
-version = "2607.3"
+version = "2607.4"
 description = "HomeLab Everywhere — Expose homelab services to the internet with built-in SSO"
 readme = "README.md"
 license = "MIT"

--- a/src/hle_client/__init__.py
+++ b/src/hle_client/__init__.py
@@ -1,3 +1,3 @@
 """HLE Client — HomeLab Everywhere tunnel client."""
 
-__version__ = "2607.3"
+__version__ = "2607.4"


### PR DESCRIPTION
Bump version to `2607.4` and update all version references.

When this PR is merged, a GitHub release will be created automatically,
which triggers PyPI publish and Homebrew formula update.