### PR TITLE
feat(fp): firepuncher — private TCP port forwarding through an agent

### DIFF
--- a/src/hle_client/agent.py
+++ b/src/hle_client/agent.py
@@ -22,6 +22,7 @@ from typing import Any
 import websockets
 
 from hle_client import __version__
+from hle_client.firepuncher import FpAgentSide
 from hle_client.tunnel import Tunnel, TunnelConfig
 from hle_common.agent_protocol import (
     AgentHello,
@@ -31,6 +32,7 @@ from hle_common.agent_protocol import (
     EndpointSpec,
     EndpointStatus,
 )
+from hle_common.fp_protocol import ForwardRule, default_rules
 
 logger = logging.getLogger(__name__)
 
@@ -107,6 +109,9 @@ class AgentClient:
         self._endpoints: dict[str, _Running] = {}
         self._api_key: str | None = None
         self._base_domain: str | None = None
+        self._fp: FpAgentSide | None = None
+        # Until the server tells us otherwise, only loopback is forwardable.
+        self._forward_rules: list[ForwardRule] = default_rules()
 
     # -- public API ----------------------------------------------------------
 
@@ -144,13 +149,25 @@ class AgentClient:
     async def _connect_once(self) -> None:
         logger.info("Connecting agent control to %s", self.control_uri)
         async with websockets.connect(self.control_uri, max_size=WS_MAX_MESSAGE_SIZE) as ws:
-            hello = AgentHello(token=self._token, agent_version=__version__)
+            hello = AgentHello(
+                token=self._token,
+                agent_version=__version__,
+                capabilities=["firepuncher"],
+            )
             await ws.send(hello.model_dump_json())
 
             raw = await asyncio.wait_for(ws.recv(), timeout=30.0)
             welcome = AgentWelcome.model_validate_json(raw)
             self._api_key = welcome.api_key
             self._base_domain = welcome.base_domain
+            if welcome.forward_rules:
+                self._forward_rules = list(welcome.forward_rules)
+            # Firepuncher frames arrive on this same control connection, so the
+            # handler is rebuilt per session and torn down with it.
+            self._fp = FpAgentSide(
+                send=ws.send,
+                rules=self._forward_rules,
+            )
             logger.info(
                 "Agent registered: public_id=%s endpoints=%d",
                 welcome.agent_public_id,
@@ -166,6 +183,9 @@ class AgentClient:
                 status_task.cancel()
                 with contextlib.suppress(asyncio.CancelledError):
                     await status_task
+                if self._fp is not None:
+                    await self._fp.close_all()
+                    self._fp = None
 
     async def _handle_message(self, raw: str | bytes) -> None:
         try:
@@ -176,7 +196,16 @@ class AgentClient:
         mtype = msg.get("type") if isinstance(msg, dict) else None
         if mtype == "state_sync":
             sync = AgentStateSync.model_validate(msg)
+            if sync.forward_rules is not None:
+                self._forward_rules = list(sync.forward_rules)
+                if self._fp is not None:
+                    # Rules are swapped live: revoking access shouldn't require
+                    # the operator to restart the agent.
+                    self._fp.rules = self._forward_rules
             await self.reconcile(sync.endpoints)
+        elif isinstance(mtype, str) and mtype.startswith("fp_"):
+            if self._fp is not None:
+                await self._fp.handle(msg)
         elif mtype == "pong":
             pass
         else:

--- a/src/hle_client/cli.py
+++ b/src/hle_client/cli.py
@@ -20,6 +20,7 @@ from hle_client.agent import (
     save_agent_token,
 )
 from hle_client.config_cmd import config as config_group
+from hle_client.fp_cmd import fp as fp_command
 from hle_client.service_cmd import service as service_group
 from hle_client.tunnel import (
     Tunnel,
@@ -373,6 +374,7 @@ def logout() -> None:
 main.add_command(config_group, name="config")
 main.add_command(update_command, name="update")
 main.add_command(service_group, name="service")
+main.add_command(fp_command, name="fp")
 
 
 @main.group()

--- a/src/hle_client/firepuncher.py
+++ b/src/hle_client/firepuncher.py
@@ -1,0 +1,290 @@
+"""Firepuncher — agent-side dialer and local-client listener.
+
+Two halves of the same feature (see ``hle_common.fp_protocol`` for the wire
+format and the trust model):
+
+``FpAgentSide``
+    Runs inside the agent. On ``fp_open`` it checks the target against the
+    allowlist, dials it, and pumps bytes both ways.
+
+``FpLocalClient``
+    Runs on your laptop as ``hle fp``. Binds a local port; every accepted TCP
+    connection becomes a new multiplexed stream to the agent.
+
+Neither side ever listens on a public port — the relay pairs the two authenticated
+WebSocket connections.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import uuid
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from hle_common.fp_protocol import (
+    FP_MAX_CHUNK,
+    ForwardRule,
+    FpClose,
+    FpData,
+    FpError,
+    FpErrorCode,
+    FpMsgType,
+    FpOpen,
+    FpReady,
+    is_allowed,
+)
+
+logger = logging.getLogger(__name__)
+
+# How long to wait for the remote TCP service to accept a connection.
+DIAL_TIMEOUT = 10.0
+
+# Bounds the number of concurrent forwarded connections per session, so one
+# runaway client can't exhaust the agent's file descriptors.
+MAX_STREAMS = 128
+
+Sender = Callable[[str], Awaitable[None]]
+
+
+@dataclass
+class _Stream:
+    reader: asyncio.StreamReader
+    writer: asyncio.StreamWriter
+    pump: asyncio.Task[None] | None = None
+
+
+@dataclass
+class FpAgentSide:
+    """Handles firepuncher streams on the agent.
+
+    ``send`` is how we write a JSON frame back toward the client (through the
+    agent's control connection). ``rules`` is the allowlist; an empty list means
+    nothing is forwardable, which is the safe reading of "not configured".
+    """
+
+    send: Sender
+    rules: list[ForwardRule] = field(default_factory=list)
+    _streams: dict[str, _Stream] = field(default_factory=dict)
+
+    async def handle(self, msg: dict[str, Any]) -> None:
+        """Dispatch one firepuncher frame. Never raises — errors go on the wire."""
+        mtype = msg.get("type")
+        try:
+            if mtype == FpMsgType.OPEN:
+                await self._on_open(FpOpen.model_validate(msg))
+            elif mtype == FpMsgType.DATA:
+                await self._on_data(FpData.model_validate(msg))
+            elif mtype == FpMsgType.CLOSE:
+                await self._close_stream(FpClose.model_validate(msg).stream_id)
+            else:
+                logger.debug("Unhandled firepuncher frame: %s", mtype)
+        except Exception as exc:  # noqa: BLE001 — a bad frame must not kill the agent
+            logger.warning("Firepuncher frame failed (%s): %s", mtype, exc)
+            sid = msg.get("stream_id")
+            if isinstance(sid, str):
+                await self._fail(sid, FpErrorCode.INTERNAL, str(exc))
+
+    async def close_all(self) -> None:
+        for sid in list(self._streams):
+            await self._close_stream(sid, notify=False)
+
+    # -- individual frames ---------------------------------------------------
+
+    async def _on_open(self, msg: FpOpen) -> None:
+        if len(self._streams) >= MAX_STREAMS:
+            await self._fail(msg.stream_id, FpErrorCode.INTERNAL, "too many open streams")
+            return
+
+        # The allowlist check is the whole point: the relay already proved the
+        # caller owns this agent, but owning an agent must not imply the right
+        # to reach arbitrary hosts on the network behind it.
+        if not is_allowed(self.rules, msg.target_host, msg.target_port):
+            allowed = ", ".join(str(r) for r in self.rules) or "(nothing configured)"
+            logger.warning(
+                "Firepuncher refused %s:%s — not in allowlist",
+                msg.target_host,
+                msg.target_port,
+            )
+            await self._fail(
+                msg.stream_id,
+                FpErrorCode.NOT_ALLOWED,
+                f"{msg.target_host}:{msg.target_port} is not allowed. Allowed: {allowed}",
+            )
+            return
+
+        try:
+            reader, writer = await asyncio.wait_for(
+                asyncio.open_connection(msg.target_host, msg.target_port),
+                timeout=DIAL_TIMEOUT,
+            )
+        except TimeoutError:
+            await self._fail(msg.stream_id, FpErrorCode.TIMEOUT, "dial timed out")
+            return
+        except OSError as exc:
+            await self._fail(msg.stream_id, FpErrorCode.UNREACHABLE, str(exc))
+            return
+
+        stream = _Stream(reader=reader, writer=writer)
+        self._streams[msg.stream_id] = stream
+        await self.send(FpReady(stream_id=msg.stream_id).model_dump_json())
+        stream.pump = asyncio.create_task(self._pump(msg.stream_id, reader))
+        logger.info(
+            "Firepuncher stream %s -> %s:%s open",
+            msg.stream_id[:8],
+            msg.target_host,
+            msg.target_port,
+        )
+
+    async def _on_data(self, msg: FpData) -> None:
+        stream = self._streams.get(msg.stream_id)
+        if stream is None:
+            return
+        stream.writer.write(msg.payload())
+        await stream.writer.drain()
+
+    async def _pump(self, stream_id: str, reader: asyncio.StreamReader) -> None:
+        """Forward bytes from the local service back to the client."""
+        try:
+            while True:
+                chunk = await reader.read(FP_MAX_CHUNK)
+                if not chunk:
+                    break
+                await self.send(FpData.of(stream_id, chunk).model_dump_json())
+        except (asyncio.CancelledError, ConnectionResetError):
+            raise
+        except Exception as exc:  # noqa: BLE001 — one stream dying is not fatal
+            logger.debug("Firepuncher pump %s ended: %s", stream_id[:8], exc)
+        finally:
+            with contextlib.suppress(Exception):
+                await self.send(FpClose(stream_id=stream_id, reason="eof").model_dump_json())
+            self._streams.pop(stream_id, None)
+
+    async def _close_stream(self, stream_id: str, *, notify: bool = True) -> None:
+        stream = self._streams.pop(stream_id, None)
+        if stream is None:
+            return
+        if stream.pump is not None:
+            stream.pump.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await stream.pump
+        with contextlib.suppress(Exception):
+            stream.writer.close()
+            await stream.writer.wait_closed()
+        if notify:
+            with contextlib.suppress(Exception):
+                await self.send(FpClose(stream_id=stream_id).model_dump_json())
+
+    async def _fail(self, stream_id: str, code: FpErrorCode, message: str) -> None:
+        with contextlib.suppress(Exception):
+            await self.send(
+                FpError(stream_id=stream_id, code=code, message=message).model_dump_json()
+            )
+
+
+@dataclass
+class FpLocalClient:
+    """Local end of a firepuncher session: a TCP listener that tunnels.
+
+    Each accepted connection opens a stream toward the agent and pumps bytes
+    until either side closes.
+    """
+
+    send: Sender
+    target_host: str
+    target_port: int
+    # How long to wait for the agent to confirm a stream. Defaults to the dial
+    # timeout plus headroom for the round trip through the relay.
+    ready_timeout: float = DIAL_TIMEOUT + 5.0
+    _streams: dict[str, _Stream] = field(default_factory=dict)
+    _ready: dict[str, asyncio.Event] = field(default_factory=dict)
+    _errors: dict[str, str] = field(default_factory=dict)
+    on_error: Callable[[str], None] | None = None
+
+    async def serve(self, bind_host: str, bind_port: int) -> asyncio.AbstractServer:
+        # Default bind is loopback — a firepuncher listener re-exposes a remote
+        # service, and binding 0.0.0.0 by accident would share it with the LAN.
+        return await asyncio.start_server(self._on_client, bind_host, bind_port)
+
+    async def handle(self, msg: dict[str, Any]) -> None:
+        mtype = msg.get("type")
+        sid = msg.get("stream_id")
+        if not isinstance(sid, str):
+            return
+        if mtype == FpMsgType.READY:
+            self._ready.setdefault(sid, asyncio.Event()).set()
+        elif mtype == FpMsgType.DATA:
+            stream = self._streams.get(sid)
+            if stream is not None:
+                stream.writer.write(FpData.model_validate(msg).payload())
+                await stream.writer.drain()
+        elif mtype == FpMsgType.CLOSE:
+            await self._drop(sid)
+        elif mtype == FpMsgType.ERROR:
+            err = FpError.model_validate(msg)
+            detail = err.message or err.code.value
+            self._errors[sid] = detail
+            if self.on_error is not None:
+                self.on_error(detail)
+            self._ready.setdefault(sid, asyncio.Event()).set()
+            await self._drop(sid)
+
+    async def close_all(self) -> None:
+        for sid in list(self._streams):
+            await self._drop(sid)
+
+    async def _on_client(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        stream_id = uuid.uuid4().hex
+        ready = asyncio.Event()
+        self._ready[stream_id] = ready
+        await self.send(
+            FpOpen(
+                stream_id=stream_id,
+                target_host=self.target_host,
+                target_port=self.target_port,
+            ).model_dump_json()
+        )
+
+        try:
+            await asyncio.wait_for(ready.wait(), timeout=self.ready_timeout)
+        except TimeoutError:
+            writer.close()
+            self._ready.pop(stream_id, None)
+            return
+
+        # An error arrived instead of a ready — the agent refused or couldn't dial.
+        if stream_id in self._errors:
+            self._errors.pop(stream_id, None)
+            self._ready.pop(stream_id, None)
+            with contextlib.suppress(Exception):
+                writer.close()
+                await writer.wait_closed()
+            return
+
+        self._streams[stream_id] = _Stream(reader=reader, writer=writer)
+        try:
+            while True:
+                chunk = await reader.read(FP_MAX_CHUNK)
+                if not chunk:
+                    break
+                await self.send(FpData.of(stream_id, chunk).model_dump_json())
+        except (asyncio.CancelledError, ConnectionResetError):
+            pass
+        except Exception as exc:  # noqa: BLE001 — one connection dying is not fatal
+            logger.debug("Firepuncher local stream %s ended: %s", stream_id[:8], exc)
+        finally:
+            with contextlib.suppress(Exception):
+                await self.send(FpClose(stream_id=stream_id).model_dump_json())
+            await self._drop(stream_id)
+
+    async def _drop(self, stream_id: str) -> None:
+        self._ready.pop(stream_id, None)
+        stream = self._streams.pop(stream_id, None)
+        if stream is None:
+            return
+        with contextlib.suppress(Exception):
+            stream.writer.close()
+            await stream.writer.wait_closed()

--- a/src/hle_client/fp_cmd.py
+++ b/src/hle_client/fp_cmd.py
@@ -1,0 +1,206 @@
+"""``hle fp`` — firepuncher: forward a remote agent's TCP port to a local one.
+
+    hle fp --agent rpi --to localhost:22 --port 9922
+    ssh -p 9922 root@localhost
+
+The connection is private end to end: this client authenticates to the relay
+with your API key, the relay pairs it to your agent, and the agent only dials
+targets on its allowlist. Nothing listens on a public port.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+
+import click
+import websockets
+from rich.console import Console
+
+from hle_client import __version__
+from hle_client.firepuncher import FpLocalClient
+from hle_client.tunnel import _load_api_key
+from hle_common.fp_protocol import FpHello, FpWelcome
+
+logger = logging.getLogger(__name__)
+console = Console()
+
+WS_MAX_MESSAGE_SIZE = 4 * 1024 * 1024
+
+
+def parse_target(target: str) -> tuple[str, int]:
+    """Parse ``host:port``; a bare port means loopback on the agent.
+
+    ``22`` -> ``("localhost", 22)``, ``nas:8096`` -> ``("nas", 8096)``.
+    IPv6 literals must be bracketed: ``[::1]:22``.
+    """
+    raw = target.strip()
+    if raw.isdigit():
+        return "localhost", int(raw)
+
+    if raw.startswith("["):  # [::1]:22
+        host, _, port = raw.rpartition("]:")
+        if not port:
+            raise click.BadParameter(f"Expected [host]:port, got {target!r}")
+        return host.lstrip("["), _parse_port(port, target)
+
+    host, sep, port = raw.rpartition(":")
+    if not sep or not host:
+        raise click.BadParameter(
+            f"Expected host:port or a bare port, got {target!r} (e.g. --to localhost:22 or --to 22)"
+        )
+    return host, _parse_port(port, target)
+
+
+def _parse_port(value: str, original: str) -> int:
+    try:
+        port = int(value)
+    except ValueError:
+        raise click.BadParameter(f"Port must be a number in {original!r}") from None
+    if not 1 <= port <= 65535:
+        raise click.BadParameter(f"Port out of range in {original!r}")
+    return port
+
+
+def fp_uri(relay_host: str, relay_port: int) -> str:
+    scheme = "ws" if relay_host.startswith("localhost") else "wss"
+    return f"{scheme}://{relay_host}:{relay_port}/_hle/fp"
+
+
+async def _run(
+    *,
+    api_key: str,
+    agent: str,
+    target_host: str,
+    target_port: int,
+    bind_host: str,
+    bind_port: int,
+    relay_host: str,
+    relay_port: int,
+) -> None:
+    uri = fp_uri(relay_host, relay_port)
+    async with websockets.connect(uri, max_size=WS_MAX_MESSAGE_SIZE) as ws:
+        await ws.send(
+            FpHello(api_key=api_key, agent=agent, client_version=__version__).model_dump_json()
+        )
+        raw = await asyncio.wait_for(ws.recv(), timeout=30.0)
+        first = json.loads(raw)
+        if first.get("type") == "fp_error":
+            console.print(f"[red]Error:[/red] {first.get('message') or first.get('code')}")
+            raise SystemExit(1)
+        welcome = FpWelcome.model_validate(first)
+
+        client = FpLocalClient(
+            send=ws.send,
+            target_host=target_host,
+            target_port=target_port,
+            on_error=lambda detail: console.print(f"[red]Refused:[/red] {detail}"),
+        )
+        server = await client.serve(bind_host, bind_port)
+
+        console.print(
+            f"[green]Forwarding[/green] {bind_host}:{bind_port} "
+            f"→ [cyan]{agent}[/cyan] → {target_host}:{target_port}"
+        )
+        if welcome.allowed:
+            console.print(f"[dim]Agent allows: {', '.join(welcome.allowed)}[/dim]")
+        if target_port == 22:
+            console.print(f"[dim]Try: ssh -p {bind_port} <user>@{bind_host}[/dim]")
+        console.print("[dim]Ctrl+C to stop.[/dim]")
+
+        pump = asyncio.create_task(_read_loop(ws, client))
+        try:
+            async with server:
+                await pump
+        finally:
+            pump.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await pump
+            await client.close_all()
+
+
+async def _read_loop(ws: websockets.ClientConnection, client: FpLocalClient) -> None:
+    async for raw in ws:
+        try:
+            msg = json.loads(raw)
+        except (ValueError, TypeError):
+            continue
+        if isinstance(msg, dict):
+            await client.handle(msg)
+
+
+@click.command("fp")
+@click.option("--agent", required=True, help="Agent name or id to forward through")
+@click.option(
+    "--to",
+    "target",
+    required=True,
+    metavar="HOST:PORT",
+    help="Target as seen by the agent (e.g. localhost:22, or just 22)",
+)
+@click.option(
+    "--port",
+    "bind_port",
+    type=int,
+    default=None,
+    help="Local port to listen on (default: target port + 9000, capped)",
+)
+@click.option(
+    "--bind",
+    "bind_host",
+    default="127.0.0.1",
+    help="Local address to bind (default loopback — think before widening)",
+)
+@click.option("--api-key", default=None, help="API key (else env/config)")
+@click.option("--relay-host", default="hle.world", help="Relay host")
+@click.option("--relay-port", default=443, type=int, help="Relay port")
+def fp(
+    agent: str,
+    target: str,
+    bind_port: int | None,
+    bind_host: str,
+    api_key: str | None,
+    relay_host: str,
+    relay_port: int,
+) -> None:
+    """Forward a TCP port from a remote agent to this machine.
+
+    \b
+    Examples:
+      hle fp --agent rpi --to 22 --port 9922      # then: ssh -p 9922 root@localhost
+      hle fp --agent nas --to 192.168.1.50:5432   # postgres on the agent's LAN
+
+    The agent must allow the target. Loopback is allowed by default; other hosts
+    are opt-in per agent in the dashboard.
+    """
+    target_host, target_port = parse_target(target)
+    if bind_port is None:
+        # 22 -> 9022, 5432 -> 14432; keeps the mapping guessable and off
+        # privileged ports without colliding with the target itself.
+        bind_port = target_port + 9000 if target_port + 9000 <= 65535 else target_port + 1000
+
+    key = api_key or _load_api_key()
+    if not key:
+        console.print("[red]Error:[/red] No API key. Run [cyan]hle auth login[/cyan] first.")
+        raise SystemExit(1)
+
+    try:
+        asyncio.run(
+            _run(
+                api_key=key,
+                agent=agent,
+                target_host=target_host,
+                target_port=target_port,
+                bind_host=bind_host,
+                bind_port=bind_port,
+                relay_host=relay_host,
+                relay_port=relay_port,
+            )
+        )
+    except KeyboardInterrupt:
+        console.print("\n[yellow]Stopped.[/yellow]")
+    except OSError as exc:
+        console.print(f"[red]Error:[/red] could not bind {bind_host}:{bind_port} — {exc}")
+        raise SystemExit(1) from None

--- a/src/hle_client/service_cmd.py
+++ b/src/hle_client/service_cmd.py
@@ -116,6 +116,43 @@ def build_agent_args(
     return args
 
 
+def build_fp_args(
+    *,
+    agent: str,
+    target: str,
+    bind_port: int | None = None,
+    bind_host: str | None = None,
+    relay_host: str | None = None,
+    relay_port: int | None = None,
+) -> list[str]:
+    """Build the ``fp`` argv (no secrets) for the service definition.
+
+    The API key is read at runtime from the running user's config or
+    ``HLE_API_KEY``, never written into the unit.
+    """
+    args = ["fp", "--agent", agent, "--to", target]
+    if bind_port:
+        args += ["--port", str(bind_port)]
+    if bind_host:
+        args += ["--bind", bind_host]
+    if relay_host:
+        args += ["--relay-host", relay_host]
+    if relay_port:
+        args += ["--relay-port", str(relay_port)]
+    return args
+
+
+def fp_label(agent: str, target: str) -> str:
+    """Unit label for a forward, e.g. ``fp-rpi-22`` -> ``hle-fp-rpi-22.service``.
+
+    Includes the port so several forwards through one agent can coexist.
+    """
+    port = target.rsplit(":", 1)[-1] if ":" in target else target
+    safe_agent = "".join(c if c.isalnum() or c in "-_" else "-" for c in agent)
+    safe_port = "".join(c for c in port if c.isalnum())
+    return f"fp-{safe_agent}-{safe_port}" if safe_port else f"fp-{safe_agent}"
+
+
 def resolve_user_mode(*, user_flag: bool, system_flag: bool) -> bool:
     """Decide between a per-user and a system service.
 
@@ -487,8 +524,21 @@ def service() -> None:
     default=False,
     help="Install the dashboard-driven agent (`hle agent run`) instead of a single tunnel",
 )
-@click.option("--relay-host", default=None, help="Agent mode: relay host (default hle.world)")
-@click.option("--relay-port", default=None, type=int, help="Agent mode: relay port (default 443)")
+@click.option(
+    "--fp",
+    "fp_mode",
+    is_flag=True,
+    default=False,
+    help="Install a firepuncher forward (`hle fp`) — needs --agent-name and --to",
+)
+@click.option("--agent-name", default=None, help="fp mode: agent to forward through")
+@click.option("--to", "fp_target", default=None, metavar="HOST:PORT", help="fp mode: target")
+@click.option("--port", "fp_port", default=None, type=int, help="fp mode: local port to bind")
+@click.option("--bind", "fp_bind", default=None, help="fp mode: local address to bind")
+@click.option("--relay-host", default=None, help="Agent/fp mode: relay host (default hle.world)")
+@click.option(
+    "--relay-port", default=None, type=int, help="Agent/fp mode: relay port (default 443)"
+)
 @click.option("--service", "service_url", default=None, help="Local service URL")
 @click.option("--label", default=None, help="Service label (also names the unit hle-<label>)")
 @click.option("--zone", default=None, help="Custom zone to publish under")
@@ -510,6 +560,11 @@ def service() -> None:
 @click.option("--start/--no-start", default=True, help="Enable + start the service now")
 def install(
     agent_mode: bool,
+    fp_mode: bool,
+    agent_name: str | None,
+    fp_target: str | None,
+    fp_port: int | None,
+    fp_bind: str | None,
     relay_host: str | None,
     relay_port: int | None,
     service_url: str | None,
@@ -530,9 +585,15 @@ def install(
 ) -> None:
     """Install (and start) a background service.
 
-    Default: a single tunnel (`hle expose`) — requires --service and --label.
-    With --agent: the dashboard-driven agent (`hle agent run`), which serves
-    every endpoint you declare in the dashboard from one process.
+    Three modes:
+
+    \b
+      (default)  a single tunnel — requires --service and --label
+      --agent    the dashboard-driven agent, serving every endpoint you
+                 declare in the dashboard from one process
+      --fp       a firepuncher forward, so a remote port is always
+                 available locally:
+                   hle service install --fp --agent-name rpi --to 22 --port 9922
 
     Credentials are never written into the service file. They are read at
     runtime from the running user's ~/.config/hle/ (config.toml for the API key,
@@ -546,7 +607,31 @@ def install(
     plat = _require_supported()
     user_mode = resolve_user_mode(user_flag=user_mode, system_flag=system_mode)
 
-    if agent_mode:
+    if agent_mode and fp_mode:
+        console.print("[red]Pass either --agent or --fp, not both.[/red]")
+        raise SystemExit(1)
+
+    if fp_mode:
+        if not agent_name or not fp_target:
+            console.print(
+                "[red]--agent-name and --to are required with --fp.[/red]\n"
+                "Example: hle service install --fp --agent-name rpi --to 22 --port 9922"
+            )
+            raise SystemExit(1)
+        label = label or fp_label(agent_name, fp_target)
+        run_args = build_fp_args(
+            agent=agent_name,
+            target=fp_target,
+            bind_port=fp_port,
+            bind_host=fp_bind,
+            relay_host=relay_host,
+            relay_port=relay_port,
+        )
+        description = f"HLE firepuncher: {agent_name} {fp_target}"
+        # A forward is only useful if it's there when you reach for it, so keep
+        # it up across relay blips rather than only on failure.
+        restart = "always"
+    elif agent_mode:
         if service_url:
             console.print("[red]--service is not used with --agent.[/red] Endpoints come from")
             console.print("the dashboard. Drop --service, or drop --agent for a single tunnel.")
@@ -605,6 +690,12 @@ def install(
         console.print(
             "\n[dim]Add endpoints at https://hle.world/dashboard — the agent picks them "
             "up within seconds, no restart needed.[/dim]"
+        )
+    elif fp_mode:
+        port_hint = fp_port or "the bound port"
+        console.print(
+            f"\n[dim]The forward is now always on. Point your client at "
+            f"{fp_bind or '127.0.0.1'}:{port_hint}.[/dim]"
         )
 
 

--- a/src/hle_common/agent_protocol.py
+++ b/src/hle_common/agent_protocol.py
@@ -15,7 +15,12 @@ from enum import StrEnum
 
 from pydantic import BaseModel, Field
 
-AGENT_PROTOCOL_VERSION = "1.0"
+# Runtime import, not just typing: pydantic resolves this to build the model.
+from hle_common.fp_protocol import ForwardRule  # noqa: TC001
+
+# 1.1 adds firepuncher: `forward_rules` on welcome/state_sync, and `fp_*` frames
+# multiplexed onto this same control connection.
+AGENT_PROTOCOL_VERSION = "1.1"
 
 
 class AgentMsgType(StrEnum):
@@ -65,11 +70,15 @@ class AgentWelcome(BaseModel):
     # server so a single enrollment yields both control + data-plane auth.
     api_key: str | None = None
     endpoints: list[EndpointSpec] = Field(default_factory=list)
+    # Firepuncher allowlist. None means "server said nothing" — the agent keeps
+    # its safe default (loopback only) rather than assuming everything is open.
+    forward_rules: list[ForwardRule] | None = None
 
 
 class AgentStateSync(BaseModel):
     type: AgentMsgType = AgentMsgType.STATE_SYNC
     endpoints: list[EndpointSpec] = Field(default_factory=list)
+    forward_rules: list[ForwardRule] | None = None
 
 
 class EndpointStatus(BaseModel):

--- a/src/hle_common/fp_protocol.py
+++ b/src/hle_common/fp_protocol.py
@@ -1,0 +1,163 @@
+"""Firepuncher protocol — forward a remote TCP port to a local one.
+
+Firepuncher ("firewall puncher") lets you reach a TCP service that only a remote
+agent can see, without opening a port anywhere::
+
+    laptop                        relay                      rpi
+      hle fp --to localhost:22  ──WSS+API key──▶  ◀──WSS──  agent
+      listens 127.0.0.1:9922                                  │
+                                                              ▼
+                                                      127.0.0.1:22
+
+This inverts the normal data plane. In ``protocol.py`` the relay is the *server*
+side of every connection: public traffic arrives and is proxied to the agent.
+Here an **authenticated client dials in** and the relay pairs it to one of that
+user's agents. There is never a public TCP port — both ends authenticate.
+
+One session multiplexes many TCP connections by ``stream_id``: SSH opens one,
+but ``scp``, ``rsync``, and SSH's own forwarding open more. Payloads are
+base64-encoded because the transport is JSON over WebSocket.
+
+Authorization is enforced twice, deliberately:
+
+1. The **relay** checks that the API key's owner owns the target agent.
+2. The **agent** checks the target against its allowlist.
+
+The second check is what stops a leaked API key from turning an agent into a
+general-purpose pivot into the private network behind it.
+"""
+
+from __future__ import annotations
+
+import base64
+from enum import StrEnum
+
+from pydantic import BaseModel, Field
+
+FP_PROTOCOL_VERSION = "1.0"
+
+# Cap on a single fp_data payload (pre-base64). Keeps one noisy stream from
+# starving others sharing the control connection.
+FP_MAX_CHUNK = 64 * 1024
+
+
+class FpMsgType(StrEnum):
+    OPEN = "fp_open"  # client -> relay -> agent: dial this target
+    READY = "fp_ready"  # agent -> relay -> client: connected, send data
+    DATA = "fp_data"  # bidirectional: payload bytes
+    CLOSE = "fp_close"  # bidirectional: this stream is done
+    ERROR = "fp_error"  # agent/relay -> client: dial failed or was refused
+
+
+class FpErrorCode(StrEnum):
+    """Why a stream was refused. Distinct codes so the CLI can explain itself."""
+
+    NOT_ALLOWED = "not_allowed"  # target not in the agent's allowlist
+    UNREACHABLE = "unreachable"  # agent could not connect (refused/no route)
+    TIMEOUT = "timeout"  # dial exceeded the deadline
+    AGENT_OFFLINE = "agent_offline"  # no live control connection for that agent
+    FORBIDDEN = "forbidden"  # caller does not own the agent
+    INTERNAL = "internal"
+
+
+class FpOpen(BaseModel):
+    """Ask the agent to dial ``target_host:target_port`` for a new stream."""
+
+    type: FpMsgType = FpMsgType.OPEN
+    stream_id: str
+    target_host: str
+    target_port: int
+
+
+class FpReady(BaseModel):
+    type: FpMsgType = FpMsgType.READY
+    stream_id: str
+
+
+class FpData(BaseModel):
+    type: FpMsgType = FpMsgType.DATA
+    stream_id: str
+    data: str  # base64
+
+    @classmethod
+    def of(cls, stream_id: str, payload: bytes) -> FpData:
+        return cls(stream_id=stream_id, data=base64.b64encode(payload).decode())
+
+    def payload(self) -> bytes:
+        return base64.b64decode(self.data)
+
+
+class FpClose(BaseModel):
+    type: FpMsgType = FpMsgType.CLOSE
+    stream_id: str
+    reason: str | None = None
+
+
+class FpError(BaseModel):
+    type: FpMsgType = FpMsgType.ERROR
+    stream_id: str
+    code: FpErrorCode = FpErrorCode.INTERNAL
+    message: str | None = None
+
+
+class FpHello(BaseModel):
+    """First frame from an ``hle fp`` client to the relay."""
+
+    type: str = "fp_hello"
+    api_key: str
+    agent: str  # agent public id or name
+    fp_version: str = FP_PROTOCOL_VERSION
+    client_version: str | None = None
+
+
+class FpWelcome(BaseModel):
+    type: str = "fp_welcome"
+    agent_public_id: str
+    # Echoed back so the CLI can show what it is actually allowed to reach,
+    # rather than failing per-connection with a confusing refusal.
+    allowed: list[str] = Field(default_factory=list)
+
+
+class ForwardRule(BaseModel):
+    """One allowlist entry, e.g. ``localhost:22`` or ``192.168.1.50:*``.
+
+    ``port`` of ``None`` means any port on that host.
+    """
+
+    host: str
+    port: int | None = None
+
+    def matches(self, host: str, port: int) -> bool:
+        if self.port is not None and self.port != port:
+            return False
+        return _normalize_host(self.host) == _normalize_host(host)
+
+    def __str__(self) -> str:
+        return f"{self.host}:{self.port if self.port is not None else '*'}"
+
+
+# Hostnames that all mean "the machine the agent runs on". Treated as one target
+# so an allowlist of `localhost:22` isn't trivially bypassed (or accidentally
+# missed) by asking for `127.0.0.1:22`.
+_LOOPBACK_ALIASES = frozenset({"localhost", "127.0.0.1", "::1", "ip6-localhost"})
+
+
+def _normalize_host(host: str) -> str:
+    h = host.strip().lower().rstrip(".")
+    # Strip brackets from IPv6 literals like [::1].
+    if h.startswith("[") and h.endswith("]"):
+        h = h[1:-1]
+    return "localhost" if h in _LOOPBACK_ALIASES else h
+
+
+def default_rules() -> list[ForwardRule]:
+    """Allowlist used when an agent has no explicit rules configured.
+
+    Loopback only: enough for the common "SSH to the box the agent runs on"
+    case with zero setup, while anything else on the LAN stays opt-in.
+    """
+    return [ForwardRule(host="localhost")]
+
+
+def is_allowed(rules: list[ForwardRule], host: str, port: int) -> bool:
+    return any(rule.matches(host, port) for rule in rules)

--- a/tests/unit/test_firepuncher.py
+++ b/tests/unit/test_firepuncher.py
@@ -1,0 +1,257 @@
+"""Tests for firepuncher: allowlist enforcement and the byte path."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from hle_client.firepuncher import FpAgentSide, FpLocalClient
+from hle_common.fp_protocol import (
+    ForwardRule,
+    FpData,
+    FpErrorCode,
+    FpMsgType,
+    FpOpen,
+    default_rules,
+    is_allowed,
+)
+
+
+class Collector:
+    """Captures frames an fp side would have sent."""
+
+    def __init__(self) -> None:
+        self.frames: list[dict] = []
+
+    async def __call__(self, raw: str) -> None:
+        self.frames.append(json.loads(raw))
+
+    def of_type(self, mtype: str) -> list[dict]:
+        return [f for f in self.frames if f.get("type") == mtype]
+
+    def first(self, mtype: str) -> dict | None:
+        found = self.of_type(mtype)
+        return found[0] if found else None
+
+
+class TestForwardRule:
+    def test_exact_host_and_port(self):
+        rule = ForwardRule(host="localhost", port=22)
+        assert rule.matches("localhost", 22)
+        assert not rule.matches("localhost", 23)
+        assert not rule.matches("nas", 22)
+
+    def test_wildcard_port(self):
+        rule = ForwardRule(host="nas")
+        assert rule.matches("nas", 22)
+        assert rule.matches("nas", 8096)
+        assert not rule.matches("other", 22)
+
+    @pytest.mark.parametrize("alias", ["127.0.0.1", "LOCALHOST", "::1", "[::1]", "localhost."])
+    def test_loopback_aliases_are_one_target(self, alias):
+        # An allowlist of localhost:22 must not be bypassable (or accidentally
+        # missed) by spelling loopback differently.
+        assert ForwardRule(host="localhost", port=22).matches(alias, 22)
+
+    def test_loopback_alias_in_rule_matches_plain(self):
+        assert ForwardRule(host="127.0.0.1", port=22).matches("localhost", 22)
+
+    def test_str_renders_wildcard(self):
+        assert str(ForwardRule(host="nas")) == "nas:*"
+        assert str(ForwardRule(host="nas", port=22)) == "nas:22"
+
+
+class TestIsAllowed:
+    def test_default_is_loopback_only(self):
+        rules = default_rules()
+        assert is_allowed(rules, "localhost", 22)
+        assert is_allowed(rules, "127.0.0.1", 5432)
+        assert not is_allowed(rules, "192.168.1.50", 22)
+
+    def test_empty_rules_allow_nothing(self):
+        # "Not configured" must read as closed, not open.
+        assert not is_allowed([], "localhost", 22)
+
+
+class TestAgentSideAuthorization:
+    async def test_refuses_target_outside_allowlist(self):
+        out = Collector()
+        agent = FpAgentSide(send=out, rules=[ForwardRule(host="localhost", port=22)])
+
+        await agent.handle(
+            FpOpen(stream_id="s1", target_host="192.168.1.50", target_port=5432).model_dump()
+        )
+
+        err = out.first(FpMsgType.ERROR)
+        assert err is not None
+        assert err["code"] == FpErrorCode.NOT_ALLOWED
+        assert "192.168.1.50:5432" in err["message"]
+        assert not out.of_type(FpMsgType.READY)
+
+    async def test_refuses_allowed_host_on_wrong_port(self):
+        out = Collector()
+        agent = FpAgentSide(send=out, rules=[ForwardRule(host="localhost", port=22)])
+
+        await agent.handle(
+            FpOpen(stream_id="s1", target_host="localhost", target_port=5432).model_dump()
+        )
+
+        assert out.first(FpMsgType.ERROR)["code"] == FpErrorCode.NOT_ALLOWED
+
+    async def test_empty_allowlist_refuses_everything(self):
+        out = Collector()
+        agent = FpAgentSide(send=out, rules=[])
+
+        await agent.handle(
+            FpOpen(stream_id="s1", target_host="localhost", target_port=22).model_dump()
+        )
+
+        assert out.first(FpMsgType.ERROR)["code"] == FpErrorCode.NOT_ALLOWED
+
+    async def test_unreachable_target_reports_cleanly(self):
+        out = Collector()
+        agent = FpAgentSide(send=out, rules=[ForwardRule(host="localhost")])
+
+        # Port 1 on loopback: allowed by the rules, but nothing is listening.
+        await agent.handle(
+            FpOpen(stream_id="s1", target_host="localhost", target_port=1).model_dump()
+        )
+
+        err = out.first(FpMsgType.ERROR)
+        assert err is not None
+        assert err["code"] in (FpErrorCode.UNREACHABLE, FpErrorCode.TIMEOUT)
+
+    async def test_malformed_frame_does_not_raise(self):
+        out = Collector()
+        agent = FpAgentSide(send=out, rules=default_rules())
+        # Missing required fields — must be reported, not propagated.
+        await agent.handle({"type": FpMsgType.OPEN, "stream_id": "s1"})
+        assert out.first(FpMsgType.ERROR)["code"] == FpErrorCode.INTERNAL
+
+    async def test_unknown_frame_is_ignored(self):
+        out = Collector()
+        agent = FpAgentSide(send=out, rules=default_rules())
+        await agent.handle({"type": "fp_bogus", "stream_id": "s1"})
+        assert out.frames == []
+
+
+class TestAgentSideDataPath:
+    async def test_forwards_bytes_both_ways(self):
+        """Agent dials a real echo server and relays bytes in both directions."""
+        received: list[bytes] = []
+
+        async def echo(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+            data = await reader.read(100)
+            received.append(data)
+            writer.write(b"PONG:" + data)
+            await writer.drain()
+
+        server = await asyncio.start_server(echo, "127.0.0.1", 0)
+        port = server.sockets[0].getsockname()[1]
+
+        out = Collector()
+        agent = FpAgentSide(send=out, rules=[ForwardRule(host="localhost", port=port)])
+
+        async with server:
+            await agent.handle(
+                FpOpen(stream_id="s1", target_host="127.0.0.1", target_port=port).model_dump()
+            )
+            assert out.first(FpMsgType.READY) is not None
+
+            await agent.handle(FpData.of("s1", b"PING").model_dump())
+            await asyncio.sleep(0.1)  # let the echo round-trip
+
+            await agent.close_all()
+
+        assert received == [b"PING"]
+        data_frames = out.of_type(FpMsgType.DATA)
+        assert data_frames, "expected the echo to come back as fp_data"
+        assert FpData.model_validate(data_frames[0]).payload() == b"PONG:PING"
+
+    async def test_data_for_unknown_stream_is_dropped(self):
+        out = Collector()
+        agent = FpAgentSide(send=out, rules=default_rules())
+        await agent.handle(FpData.of("never-opened", b"x").model_dump())
+        assert out.frames == []
+
+
+class TestLocalClient:
+    async def test_accepted_connection_opens_a_stream_and_forwards(self):
+        out = Collector()
+        client = FpLocalClient(send=out, target_host="localhost", target_port=22)
+        server = await client.serve("127.0.0.1", 0)
+        port = server.sockets[0].getsockname()[1]
+
+        async with server:
+            reader, writer = await asyncio.open_connection("127.0.0.1", port)
+            await asyncio.sleep(0.05)
+
+            opened = out.first(FpMsgType.OPEN)
+            assert opened is not None
+            assert opened["target_host"] == "localhost"
+            assert opened["target_port"] == 22
+            sid = opened["stream_id"]
+
+            # The agent accepts, so local bytes start flowing as fp_data.
+            await client.handle({"type": FpMsgType.READY, "stream_id": sid})
+            writer.write(b"SSH-2.0-test")
+            await writer.drain()
+            await asyncio.sleep(0.05)
+
+            sent = out.of_type(FpMsgType.DATA)
+            assert sent, "expected local bytes to be forwarded"
+            assert FpData.model_validate(sent[0]).payload() == b"SSH-2.0-test"
+
+            # And bytes from the agent reach the local socket.
+            await client.handle(FpData.of(sid, b"SSH-2.0-remote").model_dump())
+            assert await asyncio.wait_for(reader.read(14), timeout=2) == b"SSH-2.0-remote"
+
+            writer.close()
+            await client.close_all()
+
+    async def test_stream_that_never_gets_ready_times_out(self):
+        """A silent agent must not wedge the local connection forever."""
+        out = Collector()
+        client = FpLocalClient(send=out, target_host="localhost", target_port=22, ready_timeout=0.1)
+        server = await client.serve("127.0.0.1", 0)
+        port = server.sockets[0].getsockname()[1]
+        async with server:
+            reader, writer = await asyncio.open_connection("127.0.0.1", port)
+            # No ready, no error — the handler gives up and drops the socket.
+            assert await asyncio.wait_for(reader.read(), timeout=5) == b""
+            writer.close()
+
+    async def test_refusal_closes_the_local_connection(self):
+        """A refused stream must drop the local socket, not hang the caller."""
+        out = Collector()
+        seen: list[str] = []
+        client = FpLocalClient(
+            send=out,
+            target_host="nope",
+            target_port=5432,
+            on_error=seen.append,
+        )
+        server = await client.serve("127.0.0.1", 0)
+        port = server.sockets[0].getsockname()[1]
+
+        async with server:
+            reader, writer = await asyncio.open_connection("127.0.0.1", port)
+            await asyncio.sleep(0.05)
+            sid = out.first(FpMsgType.OPEN)["stream_id"]
+
+            await client.handle(
+                {
+                    "type": FpMsgType.ERROR,
+                    "stream_id": sid,
+                    "code": FpErrorCode.NOT_ALLOWED,
+                    "message": "nope:5432 is not allowed",
+                }
+            )
+            # The local side should see EOF rather than blocking forever.
+            assert await asyncio.wait_for(reader.read(), timeout=2) == b""
+            assert seen == ["nope:5432 is not allowed"]
+
+            writer.close()
+            await client.close_all()

--- a/tests/unit/test_firepuncher.py
+++ b/tests/unit/test_firepuncher.py
@@ -147,6 +147,12 @@ class TestAgentSideDataPath:
             received.append(data)
             writer.write(b"PONG:" + data)
             await writer.drain()
+            # Must close: from 3.12, `Server.wait_closed()` waits for open
+            # connections, so a handler that returns without closing hangs
+            # `async with server` forever. On 3.11 it returned immediately and
+            # this leak was invisible.
+            writer.close()
+            await writer.wait_closed()
 
         server = await asyncio.start_server(echo, "127.0.0.1", 0)
         port = server.sockets[0].getsockname()[1]

--- a/tests/unit/test_service_cmd.py
+++ b/tests/unit/test_service_cmd.py
@@ -8,12 +8,54 @@ from hle_client.service_cmd import (
     AGENT_LABEL,
     build_agent_args,
     build_expose_args,
+    build_fp_args,
+    fp_label,
     launchd_label,
     render_launchd_plist,
     render_unit,
     resolve_user_mode,
     unit_name,
 )
+
+
+class TestBuildFpArgs:
+    def test_minimal(self):
+        assert build_fp_args(agent="rpi", target="22") == ["fp", "--agent", "rpi", "--to", "22"]
+
+    def test_full(self):
+        assert build_fp_args(
+            agent="rpi", target="localhost:22", bind_port=9922, bind_host="127.0.0.1"
+        ) == [
+            "fp",
+            "--agent",
+            "rpi",
+            "--to",
+            "localhost:22",
+            "--port",
+            "9922",
+            "--bind",
+            "127.0.0.1",
+        ]
+
+    def test_never_contains_a_key(self):
+        # The API key is read at runtime, never baked into the unit.
+        assert not any(a.startswith("hle_") for a in build_fp_args(agent="rpi", target="22"))
+
+
+class TestFpLabel:
+    def test_includes_port_so_forwards_coexist(self):
+        assert fp_label("rpi", "22") == "fp-rpi-22"
+        assert fp_label("rpi", "localhost:5432") == "fp-rpi-5432"
+        # Two forwards through one agent must not collide on the unit name.
+        assert fp_label("rpi", "22") != fp_label("rpi", "5432")
+
+    def test_unit_name(self):
+        assert unit_name(fp_label("rpi", "22")) == "hle-fp-rpi-22.service"
+
+    def test_sanitizes_unsafe_characters(self):
+        # Agent names are user-supplied; they must not escape into the filename.
+        assert "/" not in fp_label("a/b", "22")
+        assert fp_label("a/b", "22") == "fp-a-b-22"
 
 
 class TestBuildAgentArgs:


### PR DESCRIPTION
## Summary

**Firepuncher** ("firewall puncher") forwards a TCP port that only a remote agent can reach to a local port on your machine, with no inbound port anywhere:

```bash
hle fp --agent rpi --to 22 --port 9922
```

Then point your SSH client at `localhost:9922`, or make it permanent:

```
Host rpi
  HostName localhost
  Port 9922
  User root
```

Pairs with the relay bridge in jspanos/hle#299.

## Why this isn't just another tunnel

The existing data plane is *public traffic → relay → agent*: the relay is the server side of every connection. Firepuncher inverts it — an authenticated client dials in and the relay pairs it with an agent. New topology, hence a new endpoint and message set rather than a variation on `hle expose`.

## What's here

- **`hle_common/fp_protocol.py`** — wire format (`fp_open` / `ready` / `data` / `close` / `error`), the `ForwardRule` allowlist, and the trust model written down.
- **`hle_client/firepuncher.py`** — `FpAgentSide` (checks the allowlist, dials, pumps bytes) and `FpLocalClient` (binds a local port; one multiplexed stream per accepted connection, so `scp`/`rsync`/SSH forwarding work too).
- **`hle_client/fp_cmd.py`** — the `hle fp` command.
- The agent advertises a `firepuncher` capability and handles `fp_*` frames on its **existing** control connection — no second connection to manage.

## Trust model

Authorization is enforced twice on purpose. The relay proves the caller owns the agent; the agent then checks the target against its allowlist. The second check is what stops a leaked API key turning an agent into a general-purpose pivot into the private network behind it.

Two deliberate defaults:
- The allowlist defaults to **loopback only** — covers "SSH to the box the agent runs on" with zero setup, while LAN targets stay opt-in.
- An **empty** rule list denies everything. "Not configured" reads as closed, not open.

Loopback aliases (`localhost`, `127.0.0.1`, `::1`, `[::1]`, trailing dot, any case) normalise to one target, so a rule can't be sidestepped — or accidentally missed — by spelling it differently.

Rules arrive in `welcome` / `state_sync` and are swapped live, so revoking access doesn't need an agent restart. Agent protocol → 1.1.

## Technical details

- `FpLocalClient.ready_timeout` is a field rather than a hardcoded `DIAL_TIMEOUT + 5`, so the "agent never answers" path is testable and the local socket is dropped instead of hanging.
- Payloads are base64 (transport is JSON over WebSocket); `FP_MAX_CHUNK` (64 KiB) keeps one noisy stream from starving others, and `MAX_STREAMS` bounds file-descriptor use.
- Frame handling never raises: a malformed frame becomes an `fp_error` on the wire rather than killing the agent.

22 new tests covering allowlist matching, refusal paths, and the byte path in both directions against a real socket. Full suite: 279 passed.