### PR TITLE
feat(discovery): agent reports what services it can see

### DIFF
--- a/src/hle_client/agent.py
+++ b/src/hle_client/agent.py
@@ -22,6 +22,7 @@ from typing import Any
 import websockets
 
 from hle_client import __version__
+from hle_client.discovery import active_providers, scan_all
 from hle_client.firepuncher import FpAgentSide
 from hle_client.tunnel import Tunnel, TunnelConfig
 from hle_common.agent_protocol import (
@@ -32,6 +33,7 @@ from hle_common.agent_protocol import (
     EndpointSpec,
     EndpointStatus,
 )
+from hle_common.discovery import DiscoveryReport
 from hle_common.fp_protocol import ForwardRule, default_rules
 
 logger = logging.getLogger(__name__)
@@ -149,10 +151,15 @@ class AgentClient:
     async def _connect_once(self) -> None:
         logger.info("Connecting agent control to %s", self.control_uri)
         async with websockets.connect(self.control_uri, max_size=WS_MAX_MESSAGE_SIZE) as ws:
+            # Advertise what this agent can do so the dashboard only offers
+            # features the agent actually supports. Firepuncher is always
+            # available; discovery depends on what's detectable here.
+            capabilities = ["firepuncher"]
+            capabilities += [f"discovery:{p.name}" for p in active_providers()]
             hello = AgentHello(
                 token=self._token,
                 agent_version=__version__,
-                capabilities=["firepuncher"],
+                capabilities=capabilities,
             )
             await ws.send(hello.model_dump_json())
 
@@ -174,11 +181,14 @@ class AgentClient:
                 len(welcome.endpoints),
             )
             await self.reconcile(welcome.endpoints)
+            # Report the inventory once on connect so the dashboard has
+            # something to show immediately, then only on request.
+            await self._report_discovery(ws)
 
             status_task = asyncio.create_task(self._status_loop(ws))
             try:
                 async for raw in ws:
-                    await self._handle_message(raw)
+                    await self._handle_message(raw, ws)
             finally:
                 status_task.cancel()
                 with contextlib.suppress(asyncio.CancelledError):
@@ -187,7 +197,7 @@ class AgentClient:
                     await self._fp.close_all()
                     self._fp = None
 
-    async def _handle_message(self, raw: str | bytes) -> None:
+    async def _handle_message(self, raw: str | bytes, ws: Any = None) -> None:
         try:
             msg = json.loads(raw)
         except (ValueError, TypeError):
@@ -206,10 +216,30 @@ class AgentClient:
         elif isinstance(mtype, str) and mtype.startswith("fp_"):
             if self._fp is not None:
                 await self._fp.handle(msg)
+        elif mtype == "discovery_refresh":
+            if ws is not None:
+                await self._report_discovery(ws)
         elif mtype == "pong":
             pass
         else:
             logger.debug("Unhandled agent control message: %s", mtype)
+
+    async def _report_discovery(self, ws: Any) -> None:
+        """Scan every applicable provider and report the inventory.
+
+        Best-effort: discovery failing must never take down the control
+        connection, which is what actually keeps tunnels alive.
+        """
+        try:
+            services, providers, error = await scan_all()
+        except Exception as exc:  # noqa: BLE001 — discovery is not load-bearing
+            logger.warning("Discovery scan failed: %s", exc)
+            return
+        if not providers:
+            return  # nothing to discover here; stay quiet
+        report = DiscoveryReport(services=services, providers=providers, error=error)
+        with contextlib.suppress(Exception):
+            await ws.send(report.model_dump_json())
 
     async def _status_loop(self, ws: Any) -> None:
         while True:

--- a/src/hle_client/cli.py
+++ b/src/hle_client/cli.py
@@ -442,6 +442,59 @@ def agent_status() -> None:
         console.print("[dim]No agent token configured. Run 'hle agent enroll'.[/dim]")
 
 
+@agent.command("services")
+@click.option("--provider", default=None, help="Only show one provider (k8s, docker)")
+@click.option("--json", "as_json", is_flag=True, default=False, help="Machine-readable output")
+def agent_services(provider: str | None, as_json: bool) -> None:
+    """List services this machine can see and could expose.
+
+    Runs the same discovery the agent reports to the dashboard, locally — useful
+    for checking what an agent would find before enrolling it, or for debugging
+    why something isn't showing up.
+    """
+    import json as _json
+
+    from rich.table import Table
+
+    from hle_client.discovery import active_providers, scan_all
+
+    providers = active_providers()
+    if provider:
+        providers = [p for p in providers if p.name == provider]
+
+    if not providers:
+        console.print("[yellow]No discovery providers are active here.[/yellow]")
+        console.print(
+            "[dim]Kubernetes needs an in-cluster ServiceAccount; Docker needs "
+            "/var/run/docker.sock mounted.[/dim]"
+        )
+        return
+
+    services, names, error = asyncio.run(scan_all(providers))
+
+    if as_json:
+        console.print(_json.dumps([s.model_dump() for s in services], indent=2))
+        return
+
+    if error:
+        console.print(f"[yellow]Some providers had trouble:[/yellow] {error}")
+    if not services:
+        console.print(f"[dim]No services found (scanned: {', '.join(names)}).[/dim]")
+        return
+
+    table = Table(title=f"Discovered services ({', '.join(names)})")
+    table.add_column("Name", style="cyan")
+    table.add_column("Where", style="dim")
+    table.add_column("Address")
+    table.add_column("Suggested label", style="green")
+    for s in sorted(services, key=lambda s: (s.provider, s.namespace or "", s.name)):
+        table.add_row(s.name, s.namespace or s.provider, s.address, s.suggested_label())
+    console.print(table)
+    console.print(
+        "\n[dim]Expose any of these from https://hle.world/dashboard → Agents → Endpoints.[/dim]"
+    )
+
+
 @agent.command("logout")
 def agent_logout() -> None:
     """Remove the saved agent token."""

--- a/src/hle_client/discovery/__init__.py
+++ b/src/hle_client/discovery/__init__.py
@@ -1,0 +1,107 @@
+"""Service discovery providers — enumerate what an agent can see and expose.
+
+Not to be confused with *relay* discovery (``ApiClient.discover_relay``), which
+picks which relay a tunnel connects to. This is about inventorying the services
+running near an agent.
+
+A provider answers two questions: "am I applicable here?" and "what is running?"
+Everything else — the wire format, server storage, dashboard UI — is shared, so
+supporting a new environment means implementing one small interface.
+
+Providers are **opt-in and self-detecting**. `available()` must be cheap and
+must never raise: an agent on a plain VM asks every provider, gets "no" from all
+of them, and reports nothing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Protocol, runtime_checkable
+
+# Runtime import, not just typing: it appears in Protocol return annotations
+# that `runtime_checkable` evaluates.
+from hle_common.discovery import DiscoveredService  # noqa: TC001
+
+logger = logging.getLogger(__name__)
+
+# A scan shouldn't hold up the agent's control loop if a socket hangs.
+SCAN_TIMEOUT = 15.0
+
+
+@runtime_checkable
+class DiscoveryProvider(Protocol):
+    """Enumerates services in one kind of environment."""
+
+    name: str
+
+    def available(self) -> bool:
+        """Cheap, non-raising check for whether this provider applies here."""
+        ...
+
+    async def scan(self) -> list[DiscoveredService]:
+        """Return everything currently visible. May raise; callers isolate it."""
+        ...
+
+
+def default_providers() -> list[DiscoveryProvider]:
+    """All known providers, in preference order. Import errors are non-fatal."""
+    providers: list[DiscoveryProvider] = []
+    try:
+        from hle_client.discovery.kubernetes import KubernetesProvider
+
+        providers.append(KubernetesProvider())
+    except Exception as exc:  # noqa: BLE001 — a broken provider must not stop the agent
+        logger.debug("Kubernetes provider unavailable: %s", exc)
+    try:
+        from hle_client.discovery.docker import DockerProvider
+
+        providers.append(DockerProvider())
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Docker provider unavailable: %s", exc)
+    return providers
+
+
+def active_providers(
+    providers: list[DiscoveryProvider] | None = None,
+) -> list[DiscoveryProvider]:
+    """Providers that apply on this machine."""
+    candidates = default_providers() if providers is None else providers
+    active = []
+    for p in candidates:
+        try:
+            if p.available():
+                active.append(p)
+        except Exception as exc:  # noqa: BLE001 — availability checks never fail loudly
+            logger.debug("Provider %s availability check failed: %s", p.name, exc)
+    return active
+
+
+async def scan_all(
+    providers: list[DiscoveryProvider] | None = None,
+) -> tuple[list[DiscoveredService], list[str], str | None]:
+    """Scan every applicable provider.
+
+    Returns ``(services, provider_names, error)``. One provider failing doesn't
+    discard the others' results — a broken Docker socket shouldn't hide the
+    Kubernetes services an agent can still see.
+    """
+    active = active_providers(providers)
+    services: list[DiscoveredService] = []
+    names: list[str] = []
+    errors: list[str] = []
+
+    for provider in active:
+        names.append(provider.name)
+        try:
+            found = await asyncio.wait_for(provider.scan(), timeout=SCAN_TIMEOUT)
+            services.extend(found)
+            logger.info("Discovery: %s found %d service(s)", provider.name, len(found))
+        except TimeoutError:
+            errors.append(f"{provider.name}: timed out")
+            logger.warning("Discovery: %s timed out", provider.name)
+        except Exception as exc:  # noqa: BLE001 — report, don't crash the agent
+            errors.append(f"{provider.name}: {exc}")
+            logger.warning("Discovery: %s failed: %s", provider.name, exc)
+
+    return services, names, "; ".join(errors) if errors else None

--- a/src/hle_client/discovery/docker.py
+++ b/src/hle_client/discovery/docker.py
@@ -1,0 +1,142 @@
+"""Docker discovery — enumerate containers with reachable ports.
+
+Talks to the Docker Engine API over its Unix socket using httpx (already a
+dependency), rather than pulling in the Docker SDK for two read-only calls.
+
+Security note: the Docker socket is root-equivalent on the host — anything that
+can *write* to it can start a privileged container. This provider only ever
+reads (``GET /containers/json``), and the socket should be mounted read-only,
+but mounting it at all is a real trust decision. Discovery stays opt-in.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+import httpx
+
+from hle_common.discovery import DiscoveredService
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SOCKET = "/var/run/docker.sock"
+# Pinned rather than "latest": the Engine API is versioned and an unpinned call
+# fails outright against an older daemon.
+API_VERSION = "v1.41"
+
+# Containers we should never offer to expose. HLE's own containers would be a
+# confusing loop, and infra sidecars are noise.
+_SKIP_IMAGE_PREFIXES = ("ghcr.io/hle-world/", "hle-server", "hle-docker")
+
+
+class DockerProvider:
+    """Lists running containers that publish or expose a usable port."""
+
+    name = "docker"
+
+    def __init__(self, socket_path: str | None = None) -> None:
+        self._socket = socket_path or os.environ.get("DOCKER_SOCKET", DEFAULT_SOCKET)
+
+    def available(self) -> bool:
+        try:
+            path = Path(self._socket)
+            return path.exists() and path.is_socket()
+        except OSError:
+            return False
+
+    async def scan(self) -> list[DiscoveredService]:
+        transport = httpx.AsyncHTTPTransport(uds=self._socket)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://docker", timeout=10.0
+        ) as client:
+            resp = await client.get(f"/{API_VERSION}/containers/json")
+            resp.raise_for_status()
+            containers = resp.json()
+
+        services: list[DiscoveredService] = []
+        for c in containers:
+            service = self._to_service(c)
+            if service is not None:
+                services.append(service)
+        return services
+
+    def _to_service(self, container: dict) -> DiscoveredService | None:
+        image = str(container.get("Image", ""))
+        if any(image.startswith(p) for p in _SKIP_IMAGE_PREFIXES):
+            return None
+
+        name = _container_name(container)
+        if not name:
+            return None
+
+        ports = _usable_ports(container)
+        if not ports:
+            return None
+
+        labels = {
+            k: v
+            for k, v in (container.get("Labels") or {}).items()
+            # Compose metadata is useful context; the rest is mostly build noise.
+            if k.startswith("com.docker.compose.") or k.startswith("hle.")
+        }
+
+        # Prefer reaching the container by its network alias rather than a
+        # published host port: it works even when nothing is published, and it
+        # doesn't depend on how the agent's own networking is set up.
+        host = _network_alias(container) or name
+        port = ports[0]
+
+        return DiscoveredService(
+            provider=self.name,
+            id=f"{container.get('Id', name)[:12]}:{port}",
+            name=name,
+            address=f"http://{host}:{port}",
+            ports=ports,
+            namespace=labels.get("com.docker.compose.project"),
+            labels=labels,
+        )
+
+
+def _container_name(container: dict) -> str | None:
+    names = container.get("Names") or []
+    if not names:
+        return None
+    # Docker returns names with a leading slash: "/jellyfin".
+    return str(names[0]).lstrip("/") or None
+
+
+def _network_alias(container: dict) -> str | None:
+    """A name other containers on the same network can resolve."""
+    networks = ((container.get("NetworkSettings") or {}).get("Networks") or {}).values()
+    for net in networks:
+        aliases = net.get("Aliases") or []
+        if aliases:
+            return str(aliases[0])
+    return None
+
+
+def _usable_ports(container: dict) -> list[int]:
+    """Container-side TCP ports, published ones first.
+
+    Published ports are listed first because they're the ones the operator
+    deliberately made reachable, which makes them the better default.
+    """
+    published: list[int] = []
+    internal: list[int] = []
+    for p in container.get("Ports") or []:
+        if p.get("Type") != "tcp":
+            continue  # firepuncher aside, tunnels are HTTP/TCP over WS
+        private = p.get("PrivatePort")
+        if not isinstance(private, int):
+            continue
+        if p.get("PublicPort"):
+            published.append(private)
+        else:
+            internal.append(private)
+
+    ordered = published + [p for p in internal if p not in published]
+    # Preserve order while removing duplicates (a port can appear per-protocol).
+    seen: set[int] = set()
+    return [p for p in ordered if not (p in seen or seen.add(p))]

--- a/src/hle_client/discovery/kubernetes.py
+++ b/src/hle_client/discovery/kubernetes.py
@@ -43,10 +43,11 @@ class KubernetesProvider:
         self._port = os.environ.get("KUBERNETES_SERVICE_PORT", "443")
 
     def available(self) -> bool:
-        # Both the injected env and the mounted token must be present; either
-        # alone means we're not really running in a pod.
+        # Env, token, *and* CA must all be present. Requiring the CA here means
+        # we never reach scan() in a state where we'd have to choose between
+        # skipping verification and failing — see _verify().
         try:
-            return bool(self._host) and TOKEN_PATH.exists()
+            return bool(self._host) and TOKEN_PATH.exists() and CA_PATH.exists()
         except OSError:
             return False
 
@@ -55,8 +56,24 @@ class KubernetesProvider:
         # cached one silently starts returning 401 after an hour or so.
         return TOKEN_PATH.read_text().strip()
 
+    def _verify(self) -> str:
+        """Path to the cluster CA bundle.
+
+        Deliberately fails rather than falling back to an unverified connection:
+        we send the ServiceAccount bearer token on this request, and skipping
+        verification would hand that credential to anything that can intercept
+        the connection. A missing CA means we aren't really in a pod, so there
+        is nothing to usefully talk to anyway.
+        """
+        if not CA_PATH.exists():
+            raise RuntimeError(
+                f"Kubernetes CA bundle not found at {CA_PATH}; refusing to talk to the "
+                "API server without TLS verification."
+            )
+        return str(CA_PATH)
+
     async def scan(self) -> list[DiscoveredService]:
-        verify: str | bool = str(CA_PATH) if CA_PATH.exists() else False
+        verify = self._verify()
         headers = {"Authorization": f"Bearer {self._token()}"}
         base = f"https://{self._host}:{self._port}"
 

--- a/src/hle_client/discovery/kubernetes.py
+++ b/src/hle_client/discovery/kubernetes.py
@@ -1,0 +1,116 @@
+"""Kubernetes discovery — enumerate Services across the cluster.
+
+Uses the in-cluster ServiceAccount credentials and plain httpx rather than the
+official client library: this needs one read-only API call, and the k8s client
+is a large dependency to carry into every install of the CLI.
+
+Read-only by design. The agent never mutates cluster state, and the chart's
+ClusterRole grants only get/list/watch on services and endpoints.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+import httpx
+
+from hle_common.discovery import DiscoveredService
+
+logger = logging.getLogger(__name__)
+
+SA_DIR = Path("/var/run/secrets/kubernetes.io/serviceaccount")
+TOKEN_PATH = SA_DIR / "token"
+CA_PATH = SA_DIR / "ca.crt"
+NAMESPACE_PATH = SA_DIR / "namespace"
+
+# Infrastructure that is never interesting to expose, and in kube-system's case
+# actively dangerous to put on the internet.
+_SKIP_NAMESPACES = frozenset({"kube-system", "kube-public", "kube-node-lease"})
+# Ports whose names/numbers indicate cluster plumbing rather than a UI.
+_SKIP_PORT_NAMES = frozenset({"metrics", "telemetry", "health", "probe"})
+
+
+class KubernetesProvider:
+    """Lists Services the agent could tunnel to."""
+
+    name = "k8s"
+
+    def __init__(self, *, skip_namespaces: frozenset[str] = _SKIP_NAMESPACES) -> None:
+        self._skip_namespaces = skip_namespaces
+        self._host = os.environ.get("KUBERNETES_SERVICE_HOST")
+        self._port = os.environ.get("KUBERNETES_SERVICE_PORT", "443")
+
+    def available(self) -> bool:
+        # Both the injected env and the mounted token must be present; either
+        # alone means we're not really running in a pod.
+        try:
+            return bool(self._host) and TOKEN_PATH.exists()
+        except OSError:
+            return False
+
+    def _token(self) -> str:
+        # Re-read per scan: projected ServiceAccount tokens are rotated, and a
+        # cached one silently starts returning 401 after an hour or so.
+        return TOKEN_PATH.read_text().strip()
+
+    async def scan(self) -> list[DiscoveredService]:
+        verify: str | bool = str(CA_PATH) if CA_PATH.exists() else False
+        headers = {"Authorization": f"Bearer {self._token()}"}
+        base = f"https://{self._host}:{self._port}"
+
+        async with httpx.AsyncClient(verify=verify, timeout=10.0) as client:
+            resp = await client.get(f"{base}/api/v1/services", headers=headers)
+            resp.raise_for_status()
+            payload = resp.json()
+
+        services: list[DiscoveredService] = []
+        for item in payload.get("items", []):
+            services.extend(self._to_services(item))
+        return services
+
+    def _to_services(self, item: dict) -> list[DiscoveredService]:
+        meta = item.get("metadata") or {}
+        spec = item.get("spec") or {}
+        namespace = meta.get("namespace") or "default"
+        name = meta.get("name") or ""
+
+        if namespace in self._skip_namespaces or not name:
+            return []
+        # Headless services have no cluster IP to talk to.
+        if spec.get("clusterIP") in ("None", "", None):
+            return []
+
+        labels = {
+            k: v
+            for k, v in (meta.get("labels") or {}).items()
+            if k.startswith(("app", "app.kubernetes.io/name", "hle.world/"))
+        }
+
+        out: list[DiscoveredService] = []
+        for port in spec.get("ports") or []:
+            if port.get("protocol", "TCP") != "TCP":
+                continue
+            port_name = str(port.get("name") or "").lower()
+            if port_name in _SKIP_PORT_NAMES:
+                continue
+            number = port.get("port")
+            if not isinstance(number, int):
+                continue
+
+            # In-cluster DNS: reachable from the agent's pod regardless of node.
+            fqdn = f"{name}.{namespace}.svc.cluster.local"
+            scheme = "https" if number == 443 or port_name in ("https", "tls") else "http"
+            out.append(
+                DiscoveredService(
+                    provider=self.name,
+                    id=f"{namespace}/{name}:{number}",
+                    name=name,
+                    address=f"{scheme}://{fqdn}:{number}",
+                    ports=[number],
+                    namespace=namespace,
+                    labels=labels,
+                )
+            )
+        return out

--- a/src/hle_common/discovery.py
+++ b/src/hle_common/discovery.py
@@ -1,0 +1,73 @@
+"""Service discovery — shared models for "what can this agent see?".
+
+An agent that lives inside a Kubernetes cluster or on a Docker host already
+knows what is running there. Discovery reports that inventory to the server so
+you can browse it in the dashboard and expose something with a click, instead of
+hand-copying URLs into endpoint forms.
+
+Discovery is **provider-based**. The protocol, storage, API, and UI are shared;
+each environment contributes a provider that knows how to enumerate it. An agent
+on a plain VM runs no providers, reports nothing, and the UI hides the section.
+
+Reported inventory is *cache-like*, not configuration: the agent sends the full
+current set, the server replaces what it had, and nothing survives the agent
+being deleted. Turning a discovered service into a tunnel creates an ordinary
+endpoint, so everything downstream is unchanged.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from pydantic import BaseModel, Field
+
+DISCOVERY_PROTOCOL_VERSION = "1.0"
+
+
+class DiscoveryMsgType(StrEnum):
+    REPORT = "discovery_report"  # agent -> server: full current inventory
+    REFRESH = "discovery_refresh"  # server -> agent: re-scan now
+
+
+class DiscoveredService(BaseModel):
+    """One service an agent can see and could expose.
+
+    ``address`` is the URL the *agent* would use to reach it — not a public URL.
+    It goes straight into an endpoint's ``service_url`` if the user chooses to
+    expose it.
+    """
+
+    provider: str  # "k8s" | "docker" | ...
+    # Stable within a provider, so re-reports update rather than duplicate.
+    id: str
+    name: str
+    address: str
+    ports: list[int] = Field(default_factory=list)
+    namespace: str | None = None  # k8s namespace, compose project, ...
+    labels: dict[str, str] = Field(default_factory=dict)
+    # Set when the agent can tell this is already exposed, so the UI can show
+    # "already exposed" instead of offering a duplicate.
+    already_exposed: bool = False
+
+    def suggested_label(self) -> str:
+        """A tunnel label guess: DNS-safe, derived from the service name."""
+        out = []
+        for ch in self.name.lower():
+            if ch.isalnum():
+                out.append(ch)
+            elif ch in "-_. " and out and out[-1] != "-":
+                out.append("-")
+        return "".join(out).strip("-")[:63] or "service"
+
+
+class DiscoveryReport(BaseModel):
+    type: DiscoveryMsgType = DiscoveryMsgType.REPORT
+    services: list[DiscoveredService] = Field(default_factory=list)
+    # Providers that actually ran, so the server can distinguish "nothing found"
+    # from "discovery isn't enabled here" — they look identical otherwise.
+    providers: list[str] = Field(default_factory=list)
+    error: str | None = None
+
+
+class DiscoveryRefresh(BaseModel):
+    type: DiscoveryMsgType = DiscoveryMsgType.REFRESH

--- a/tests/unit/test_service_discovery.py
+++ b/tests/unit/test_service_discovery.py
@@ -1,0 +1,238 @@
+"""Tests for service discovery (the agent's inventory of nearby services).
+
+Distinct from ``test_discovery.py``, which covers *relay* discovery.
+
+Providers are tested against recorded API payloads so the suite runs without a
+Docker socket or a Kubernetes cluster.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hle_client.discovery import active_providers, scan_all
+from hle_client.discovery.docker import DockerProvider, _network_alias, _usable_ports
+from hle_client.discovery.kubernetes import KubernetesProvider
+from hle_common.discovery import DiscoveredService
+
+
+class FakeProvider:
+    def __init__(self, name: str, services: list[DiscoveredService], *, fail: bool = False) -> None:
+        self.name = name
+        self._services = services
+        self._fail = fail
+
+    def available(self) -> bool:
+        return True
+
+    async def scan(self) -> list[DiscoveredService]:
+        if self._fail:
+            raise RuntimeError("socket exploded")
+        return self._services
+
+
+def _svc(name: str, provider: str = "test") -> DiscoveredService:
+    return DiscoveredService(
+        provider=provider, id=f"{name}:80", name=name, address=f"http://{name}:80", ports=[80]
+    )
+
+
+class TestSuggestedLabel:
+    @pytest.mark.parametrize(
+        ("name", "expected"),
+        [
+            ("jellyfin", "jellyfin"),
+            ("Home Assistant", "home-assistant"),
+            ("my_app.v2", "my-app-v2"),
+            ("!!!", "service"),  # never produce an empty label
+        ],
+    )
+    def test_label_is_dns_safe(self, name, expected):
+        assert _svc(name).suggested_label() == expected
+
+    def test_label_is_truncated(self):
+        assert len(_svc("x" * 200).suggested_label()) <= 63
+
+
+class TestScanAll:
+    async def test_collects_from_every_provider(self):
+        services, names, error = await scan_all(
+            [FakeProvider("a", [_svc("one")]), FakeProvider("b", [_svc("two")])]
+        )
+        assert {s.name for s in services} == {"one", "two"}
+        assert names == ["a", "b"]
+        assert error is None
+
+    async def test_one_failing_provider_does_not_discard_the_others(self):
+        """A broken Docker socket must not hide the k8s services we can see."""
+        services, names, error = await scan_all(
+            [FakeProvider("broken", [], fail=True), FakeProvider("ok", [_svc("survivor")])]
+        )
+        assert [s.name for s in services] == ["survivor"]
+        assert "broken" in error
+        assert "ok" in names
+
+    async def test_no_providers_is_not_an_error(self):
+        services, names, error = await scan_all([])
+        assert services == []
+        assert names == []
+        assert error is None
+
+
+class TestActiveProviders:
+    def test_unavailable_providers_are_skipped(self):
+        class Unavailable:
+            name = "nope"
+
+            def available(self) -> bool:
+                return False
+
+            async def scan(self):
+                return []
+
+        assert active_providers([Unavailable()]) == []
+
+    def test_a_raising_availability_check_is_not_fatal(self):
+        class Exploding:
+            name = "boom"
+
+            def available(self) -> bool:
+                raise OSError("no")
+
+            async def scan(self):
+                return []
+
+        assert active_providers([Exploding()]) == []
+
+
+class TestDockerProvider:
+    def _container(self, **overrides) -> dict:
+        base = {
+            "Id": "abc123def456789",
+            "Names": ["/jellyfin"],
+            "Image": "jellyfin/jellyfin:latest",
+            "Labels": {"com.docker.compose.project": "media", "build.irrelevant": "x"},
+            "Ports": [{"PrivatePort": 8096, "PublicPort": 8096, "Type": "tcp"}],
+            "NetworkSettings": {"Networks": {"media_default": {"Aliases": ["jellyfin"]}}},
+        }
+        base.update(overrides)
+        return base
+
+    def test_maps_a_container_to_a_service(self):
+        svc = DockerProvider()._to_service(self._container())
+        assert svc is not None
+        assert svc.provider == "docker"
+        assert svc.name == "jellyfin"
+        # Reached by network alias, which works whether or not a port is published.
+        assert svc.address == "http://jellyfin:8096"
+        assert svc.namespace == "media"
+        assert "build.irrelevant" not in svc.labels
+
+    def test_skips_containers_without_ports(self):
+        assert DockerProvider()._to_service(self._container(Ports=[])) is None
+
+    def test_skips_hle_own_containers(self):
+        # Exposing HLE through HLE is a confusing loop.
+        assert (
+            DockerProvider()._to_service(
+                self._container(Image="ghcr.io/hle-world/hle-docker:latest")
+            )
+            is None
+        )
+
+    def test_falls_back_to_container_name_without_alias(self):
+        svc = DockerProvider()._to_service(self._container(NetworkSettings={"Networks": {}}))
+        assert svc.address == "http://jellyfin:8096"
+
+    def test_unavailable_when_socket_missing(self):
+        assert DockerProvider(socket_path="/nonexistent/docker.sock").available() is False
+
+
+class TestDockerPortSelection:
+    def test_published_ports_come_first(self):
+        ports = _usable_ports(
+            {
+                "Ports": [
+                    {"PrivatePort": 9000, "Type": "tcp"},
+                    {"PrivatePort": 8096, "PublicPort": 8096, "Type": "tcp"},
+                ]
+            }
+        )
+        # The operator deliberately published 8096; prefer it as the default.
+        assert ports[0] == 8096
+
+    def test_udp_is_ignored(self):
+        assert _usable_ports({"Ports": [{"PrivatePort": 53, "Type": "udp"}]}) == []
+
+    def test_duplicates_are_removed(self):
+        ports = _usable_ports(
+            {"Ports": [{"PrivatePort": 80, "Type": "tcp"}, {"PrivatePort": 80, "Type": "tcp"}]}
+        )
+        assert ports == [80]
+
+    def test_alias_extraction(self):
+        assert _network_alias({"NetworkSettings": {"Networks": {"n": {"Aliases": ["a"]}}}}) == "a"
+        assert _network_alias({"NetworkSettings": {"Networks": {}}}) is None
+
+
+class TestKubernetesProvider:
+    def _service(self, **overrides) -> dict:
+        base = {
+            "metadata": {
+                "name": "jellyfin",
+                "namespace": "media",
+                "labels": {"app": "jellyfin", "helm.sh/chart": "ignored"},
+            },
+            "spec": {
+                "clusterIP": "10.0.0.5",
+                "ports": [{"port": 8096, "protocol": "TCP", "name": "http"}],
+            },
+        }
+        base.update(overrides)
+        return base
+
+    def test_maps_a_service_to_cluster_dns(self):
+        out = KubernetesProvider()._to_services(self._service())
+        assert len(out) == 1
+        svc = out[0]
+        assert svc.address == "http://jellyfin.media.svc.cluster.local:8096"
+        assert svc.namespace == "media"
+        assert svc.id == "media/jellyfin:8096"
+        assert "helm.sh/chart" not in svc.labels
+
+    def test_skips_system_namespaces(self):
+        item = self._service()
+        item["metadata"]["namespace"] = "kube-system"
+        assert KubernetesProvider()._to_services(item) == []
+
+    def test_skips_headless_services(self):
+        item = self._service()
+        item["spec"]["clusterIP"] = "None"
+        assert KubernetesProvider()._to_services(item) == []
+
+    def test_skips_metrics_ports(self):
+        item = self._service()
+        item["spec"]["ports"] = [{"port": 9090, "protocol": "TCP", "name": "metrics"}]
+        assert KubernetesProvider()._to_services(item) == []
+
+    def test_https_port_uses_https_scheme(self):
+        item = self._service()
+        item["spec"]["ports"] = [{"port": 443, "protocol": "TCP", "name": "https"}]
+        assert KubernetesProvider()._to_services(item)[0].address.startswith("https://")
+
+    def test_multi_port_service_yields_one_entry_per_port(self):
+        item = self._service()
+        item["spec"]["ports"] = [
+            {"port": 80, "protocol": "TCP", "name": "http"},
+            {"port": 8443, "protocol": "TCP", "name": "alt"},
+        ]
+        assert len(KubernetesProvider()._to_services(item)) == 2
+
+    def test_udp_ports_are_skipped(self):
+        item = self._service()
+        item["spec"]["ports"] = [{"port": 53, "protocol": "UDP", "name": "dns"}]
+        assert KubernetesProvider()._to_services(item) == []
+
+    def test_unavailable_outside_a_cluster(self, monkeypatch):
+        monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
+        assert KubernetesProvider().available() is False

--- a/tests/unit/test_service_discovery.py
+++ b/tests/unit/test_service_discovery.py
@@ -8,6 +8,8 @@ Docker socket or a Kubernetes cluster.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from hle_client.discovery import active_providers, scan_all
@@ -236,3 +238,38 @@ class TestKubernetesProvider:
     def test_unavailable_outside_a_cluster(self, monkeypatch):
         monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
         assert KubernetesProvider().available() is False
+
+
+class TestKubernetesTls:
+    """TLS verification must never be skipped.
+
+    The request carries the ServiceAccount bearer token, so an unverified
+    connection would hand that credential to anything able to intercept it.
+    """
+
+    def test_missing_ca_raises_instead_of_disabling_verification(self, monkeypatch):
+        import hle_client.discovery.kubernetes as k8s
+
+        monkeypatch.setattr(k8s, "CA_PATH", Path("/nonexistent/ca.crt"))
+        with pytest.raises(RuntimeError, match="refusing to talk to the API server"):
+            k8s.KubernetesProvider()._verify()
+
+    def test_verify_returns_the_ca_path_when_present(self, monkeypatch, tmp_path):
+        import hle_client.discovery.kubernetes as k8s
+
+        ca = tmp_path / "ca.crt"
+        ca.write_text("-----BEGIN CERTIFICATE-----")
+        monkeypatch.setattr(k8s, "CA_PATH", ca)
+        # A path, never False — httpx treats False as "skip verification".
+        assert k8s.KubernetesProvider()._verify() == str(ca)
+
+    def test_unavailable_without_a_ca(self, monkeypatch, tmp_path):
+        import hle_client.discovery.kubernetes as k8s
+
+        token = tmp_path / "token"
+        token.write_text("t")
+        monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "10.0.0.1")
+        monkeypatch.setattr(k8s, "TOKEN_PATH", token)
+        monkeypatch.setattr(k8s, "CA_PATH", tmp_path / "missing.crt")
+        # Reported unavailable, so scan() is never reached in that state.
+        assert k8s.KubernetesProvider().available() is False


### PR DESCRIPTION
## Summary

Drop an agent onto a Kubernetes cluster or a Docker host and it reports what's running there, so you can browse the inventory and expose something with a click instead of hand-copying URLs into endpoint forms.

```bash
$ hle agent services
              Discovered services (k8s)
  Name       Where    Address                                       Suggested label
  jellyfin   media    http://jellyfin.media.svc.cluster.local:8096  jellyfin
  gitea      git      http://gitea.git.svc.cluster.local:3000       gitea
```

Client side only — server storage, API, and dashboard UI are DISC-4/DISC-5 in `docs/agent-power-plan.md`.

## Provider-based, not two features

Kubernetes and Docker are **peers behind one pipeline**: the protocol, and later the storage, API and UI, are shared, and each environment contributes a provider that knows how to enumerate it. Adding an environment means implementing one small interface (`available()` + `scan()`), not touching the wire format.

Providers self-detect and are advertised as `discovery:<provider>` in `AgentHello.capabilities`, so an agent on a plain VM reports nothing and the dashboard can hide the section.

| Provider | Sees | Needs |
|---|---|---|
| `k8s` | Services across all namespaces, via cluster DNS | in-cluster ServiceAccount |
| `docker` | Containers with usable ports | Docker socket |

## Technical details

**No new dependencies.** Both providers use `httpx`, which is already a dependency, rather than the Docker SDK or the Kubernetes client — each needs one read-only call, and those are large dependencies to carry into every CLI install. Docker goes over the Unix socket via `httpx.AsyncHTTPTransport(uds=...)`; Kubernetes uses the projected ServiceAccount token (re-read per scan, since those rotate and a cached one silently starts 401ing).

**Filtering.** k8s skips system namespaces, headless services, `metrics`-style ports, and non-TCP. Docker skips containers with no usable ports and HLE's own images (exposing HLE through HLE is a confusing loop). Docker prefers the container's **network alias** over a published host port, so it works regardless of how the agent's own networking is set up.

**Robustness.** Discovery is never load-bearing: a scan failing can't take down the control connection that keeps tunnels alive, and one provider failing doesn't discard another's results — a broken Docker socket shouldn't hide the k8s services an agent can still see. Scans are timeout-bounded so a hung socket can't wedge the agent.

**Read-only throughout.** The agent never mutates cluster or daemon state. Note that the Docker socket is root-equivalent on the host even when the provider only reads from it — the mount should be `:ro`, and the docs (DISC-3 follow-up) will say so plainly rather than burying it.

## Naming

`hle_client/discovery/` is *service* discovery. The codebase already uses "discovery" for **relay** discovery (`ApiClient.discover_relay`), which is unrelated; the module docstring calls out the distinction, and the tests are in `test_service_discovery.py` to sit alongside the existing `test_discovery.py`.

27 new tests against recorded API payloads, so they run without a Docker socket or a cluster. Full suite: 284 passed.