### PR TITLE
Release v2607.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2607.5 — 2026-07-25
+
+<!-- TODO: Fill in release notes before merging -->
+
 ## v2607.4 — 2026-07-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,50 @@
 
 ## v2607.5 — 2026-07-25
 
-<!-- TODO: Fill in release notes before merging -->
+### Added
+
+- **Firepuncher (`hle fp`)** — forward a TCP port that only a remote agent can
+  reach to a local port, with no inbound port anywhere:
+
+  ```bash
+  hle fp --agent rpi --to 22 --port 9922
+  ```
+
+  Then point your SSH client at `localhost:9922`. One session multiplexes many
+  connections, so `scp`, `rsync`, and SSH's own forwarding work too.
+
+  Both ends authenticate over WSS and there is never a public TCP port.
+  Authorization is enforced twice: the relay proves you own the agent, and the
+  agent independently checks the target against an allowlist — so a leaked API
+  key can't turn an agent into a pivot into the network behind it. The allowlist
+  defaults to loopback only, and an empty rule list denies everything.
+
+- **`hle service install --fp`** — install a forward as a systemd unit or
+  launchd job, so a remote port is simply always available locally:
+
+  ```bash
+  hle service install --fp --agent-name rpi --to 22 --port 9922
+  ```
+
+- **Service discovery** — an agent on a Kubernetes cluster or Docker host
+  reports what's running there, so you can expose it from the dashboard instead
+  of copying URLs by hand. `hle agent services` lists the same inventory
+  locally. Providers self-detect; an agent on a plain VM reports nothing.
+
+  Both providers are read-only and add no dependencies — they use httpx rather
+  than the Docker SDK or the Kubernetes client.
+
+### Security
+
+- The Kubernetes discovery provider never skips TLS verification. An earlier
+  draft fell back to an unverified connection when the cluster CA was missing,
+  which would have sent the ServiceAccount bearer token to an unverified
+  endpoint. It now fails closed.
+
+### Fixed
+
+- Agent protocol 1.1: `forward_rules` in `welcome` / `state_sync`, so changing
+  what an agent may forward to takes effect within seconds without a restart.
 
 ## v2607.4 — 2026-07-25
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ curl -fsSL https://get.hle.world | sh
 Installs via pipx (preferred), uv, or pip-in-venv. Supports `--version`:
 
 ```bash
-curl -fsSL https://get.hle.world | sh -s -- --version 2607.4
+curl -fsSL https://get.hle.world | sh -s -- --version 2607.5
 ```
 
 ### pipx
@@ -93,7 +93,7 @@ and runs the right upgrade.
 ```bash
 hle update            # upgrade to the latest release
 hle update --check    # just report current vs. latest, don't change anything
-hle update --version 2607.4   # pin an exact version
+hle update --version 2607.5   # pin an exact version
 ```
 
 After updating, restart any running tunnels (e.g. `systemctl restart hle-<label>`)

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 #
 # Usage:
 #   curl -fsSL https://get.hle.world | sh
-#   curl -fsSL https://get.hle.world | sh -s -- --version 2607.4
+#   curl -fsSL https://get.hle.world | sh -s -- --version 2607.5
 #
 #   # Install the agent and run it as a service (prompts for the token):
 #   curl -fsSL https://get.hle.world | sh -s -- --agent
@@ -263,7 +263,7 @@ main() {
         error "Install Python from https://python.org or via your package manager."
         exit 1
     }
-    info "Found Python: $PYTHON ($($PYTHON --version 2607.4>&1))"
+    info "Found Python: $PYTHON ($($PYTHON --version 2607.5>&1))"
 
     # Try install methods in order of preference
     if command -v pipx >/dev/null 2>&1; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hle-client"
-version = "2607.4"
+version = "2607.5"
 description = "HomeLab Everywhere — Expose homelab services to the internet with built-in SSO"
 readme = "README.md"
 license = "MIT"

--- a/src/hle_client/__init__.py
+++ b/src/hle_client/__init__.py
@@ -1,3 +1,3 @@
 """HLE Client — HomeLab Everywhere tunnel client."""
 
-__version__ = "2607.4"
+__version__ = "2607.5"


### PR DESCRIPTION
Bump version to `2607.5` and update all version references.

When this PR is merged, a GitHub release will be created automatically,
which triggers PyPI publish and Homebrew formula update.