### PR TITLE
fix(fp): reconnect instead of crashing when the relay goes away

### DIFF
--- a/src/hle_client/firepuncher.py
+++ b/src/hle_client/firepuncher.py
@@ -199,6 +199,10 @@ class FpLocalClient:
     # How long to wait for the agent to confirm a stream. Defaults to the dial
     # timeout plus headroom for the round trip through the relay.
     ready_timeout: float = DIAL_TIMEOUT + 5.0
+    # False while the relay connection is down. The listener stays bound across
+    # reconnects so the local port doesn't vanish, but connections arriving in
+    # the gap are refused immediately rather than hanging until they time out.
+    connected: bool = False
     _streams: dict[str, _Stream] = field(default_factory=dict)
     _ready: dict[str, asyncio.Event] = field(default_factory=dict)
     _errors: dict[str, str] = field(default_factory=dict)
@@ -237,6 +241,15 @@ class FpLocalClient:
             await self._drop(sid)
 
     async def _on_client(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        if not self.connected:
+            # Fail fast instead of making the caller wait out ready_timeout for
+            # a relay we already know isn't there.
+            logger.debug("Refusing local connection: relay not connected")
+            with contextlib.suppress(Exception):
+                writer.close()
+                await writer.wait_closed()
+            return
+
         stream_id = uuid.uuid4().hex
         ready = asyncio.Event()
         self._ready[stream_id] = ready

--- a/src/hle_client/fp_cmd.py
+++ b/src/hle_client/fp_cmd.py
@@ -11,7 +11,6 @@ targets on its allowlist. Nothing listens on a public port.
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import json
 import logging
 
@@ -69,6 +68,15 @@ def fp_uri(relay_host: str, relay_port: int) -> str:
     return f"{scheme}://{relay_host}:{relay_port}/_hle/fp"
 
 
+# Close codes that mean "stop trying": the problem is the credential or the
+# request, and retrying just repeats it. Anything else — relay restart, network
+# drop, agent temporarily offline — is worth reconnecting through.
+_FATAL_CLOSE_CODES = frozenset({4001, 4003})
+
+RECONNECT_DELAY = 1.0
+MAX_RECONNECT_DELAY = 30.0
+
+
 async def _run(
     *,
     api_key: str,
@@ -80,45 +88,110 @@ async def _run(
     relay_host: str,
     relay_port: int,
 ) -> None:
+    """Serve the local port, reconnecting to the relay as needed.
+
+    The listener is bound once and kept for the lifetime of the command, so a
+    relay restart or a dropped network doesn't take the local port away. Streams
+    in flight when the connection drops cannot be recovered — the far end is
+    gone — so they're closed and the caller reconnects, but the port stays
+    there ready for them.
+    """
     uri = fp_uri(relay_host, relay_port)
-    async with websockets.connect(uri, max_size=WS_MAX_MESSAGE_SIZE) as ws:
-        await ws.send(
-            FpHello(api_key=api_key, agent=agent, client_version=__version__).model_dump_json()
-        )
-        raw = await asyncio.wait_for(ws.recv(), timeout=30.0)
-        first = json.loads(raw)
-        if first.get("type") == "fp_error":
-            console.print(f"[red]Error:[/red] {first.get('message') or first.get('code')}")
-            raise SystemExit(1)
-        welcome = FpWelcome.model_validate(first)
+    client = FpLocalClient(
+        send=_not_connected,
+        target_host=target_host,
+        target_port=target_port,
+        on_error=lambda detail: console.print(f"[red]Refused:[/red] {detail}"),
+    )
+    server = await client.serve(bind_host, bind_port)
+    printed_banner = False
+    delay = RECONNECT_DELAY
 
-        client = FpLocalClient(
-            send=ws.send,
-            target_host=target_host,
-            target_port=target_port,
-            on_error=lambda detail: console.print(f"[red]Refused:[/red] {detail}"),
-        )
-        server = await client.serve(bind_host, bind_port)
+    async with server:
+        while True:
+            try:
+                async with websockets.connect(uri, max_size=WS_MAX_MESSAGE_SIZE) as ws:
+                    await ws.send(
+                        FpHello(
+                            api_key=api_key, agent=agent, client_version=__version__
+                        ).model_dump_json()
+                    )
+                    raw = await asyncio.wait_for(ws.recv(), timeout=30.0)
+                    first = json.loads(raw)
+                    if first.get("type") == "fp_error":
+                        detail = first.get("message") or first.get("code")
+                        code = first.get("code")
+                        if code == "agent_offline":
+                            # Worth waiting for: the agent may be restarting.
+                            console.print(f"[yellow]{detail}[/yellow] — retrying...")
+                            await asyncio.sleep(delay)
+                            delay = min(delay * 2, MAX_RECONNECT_DELAY)
+                            continue
+                        console.print(f"[red]Error:[/red] {detail}")
+                        raise SystemExit(1)
 
-        console.print(
-            f"[green]Forwarding[/green] {bind_host}:{bind_port} "
-            f"→ [cyan]{agent}[/cyan] → {target_host}:{target_port}"
-        )
-        if welcome.allowed:
-            console.print(f"[dim]Agent allows: {', '.join(welcome.allowed)}[/dim]")
-        if target_port == 22:
-            console.print(f"[dim]Try: ssh -p {bind_port} <user>@{bind_host}[/dim]")
-        console.print("[dim]Ctrl+C to stop.[/dim]")
+                    welcome = FpWelcome.model_validate(first)
+                    client.send = ws.send
+                    client.connected = True
+                    delay = RECONNECT_DELAY
 
-        pump = asyncio.create_task(_read_loop(ws, client))
-        try:
-            async with server:
-                await pump
-        finally:
-            pump.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await pump
-            await client.close_all()
+                    if not printed_banner:
+                        console.print(
+                            f"[green]Forwarding[/green] {bind_host}:{bind_port} "
+                            f"→ [cyan]{agent}[/cyan] → {target_host}:{target_port}"
+                        )
+                        if welcome.allowed:
+                            console.print(f"[dim]Agent allows: {', '.join(welcome.allowed)}[/dim]")
+                        if target_port == 22:
+                            console.print(f"[dim]Try: ssh -p {bind_port} <user>@{bind_host}[/dim]")
+                        console.print("[dim]Ctrl+C to stop.[/dim]")
+                        printed_banner = True
+                    else:
+                        console.print("[green]Reconnected.[/green]")
+
+                    await _read_loop(ws, client)
+
+                # A clean close still means the session ended; reconnect.
+                console.print("[yellow]Connection closed by the relay[/yellow] — reconnecting...")
+
+            except SystemExit:
+                raise
+            except asyncio.CancelledError:
+                raise
+            except websockets.exceptions.ConnectionClosed as exc:
+                if exc.rcvd is not None and exc.rcvd.code in _FATAL_CLOSE_CODES:
+                    console.print(f"[red]Error:[/red] {exc.rcvd.reason or 'rejected by relay'}")
+                    raise SystemExit(1) from None
+                console.print(f"[yellow]Connection lost[/yellow] ({_close_reason(exc)})")
+            except OSError as exc:
+                # DNS failure, no route, refused — typical when the laptop's
+                # network drops entirely.
+                console.print(f"[yellow]Cannot reach the relay[/yellow] ({exc})")
+            except Exception as exc:  # noqa: BLE001 — never surface a traceback here
+                console.print(f"[yellow]Connection problem[/yellow] ({exc})")
+            finally:
+                client.connected = False
+                client.send = _not_connected
+                # Streams cannot outlive the connection that carried them.
+                await client.close_all()
+
+            console.print(f"[dim]Retrying in {delay:.0f}s (Ctrl+C to stop)...[/dim]")
+            await asyncio.sleep(delay)
+            delay = min(delay * 2, MAX_RECONNECT_DELAY)
+
+
+async def _not_connected(_: str) -> None:
+    """Placeholder sender used while the relay connection is down."""
+    raise ConnectionError("not connected to the relay")
+
+
+def _close_reason(exc: websockets.exceptions.ConnectionClosed) -> str:
+    frame = exc.rcvd or exc.sent
+    if frame is None:
+        return "no close frame"
+    if frame.code == 1012:
+        return "relay restarting"
+    return frame.reason or f"code {frame.code}"
 
 
 async def _read_loop(ws: websockets.ClientConnection, client: FpLocalClient) -> None:

--- a/tests/unit/test_firepuncher.py
+++ b/tests/unit/test_firepuncher.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 
 import pytest
+import websockets
 
 from hle_client.firepuncher import FpAgentSide, FpLocalClient
 from hle_common.fp_protocol import (
@@ -34,6 +35,51 @@ class Collector:
     def first(self, mtype: str) -> dict | None:
         found = self.of_type(mtype)
         return found[0] if found else None
+
+
+class TestCloseHandling:
+    """Losing the relay must not produce a traceback.
+
+    A relay restart used to crash `hle fp` with a raw
+    ConnectionClosedError. Deployments are routine, so the forward has to ride
+    through them the way the agent already does.
+    """
+
+    def test_relay_restart_is_described_in_plain_words(self):
+        from websockets.frames import Close
+
+        from hle_client.fp_cmd import _close_reason
+
+        exc = websockets.exceptions.ConnectionClosedError(Close(1012, "service restart"), None)
+        assert _close_reason(exc) == "relay restarting"
+
+    def test_reason_falls_back_to_the_code(self):
+        from websockets.frames import Close
+
+        from hle_client.fp_cmd import _close_reason
+
+        exc = websockets.exceptions.ConnectionClosedError(Close(1006, ""), None)
+        assert "1006" in _close_reason(exc)
+
+    def test_no_close_frame_is_handled(self):
+        from hle_client.fp_cmd import _close_reason
+
+        exc = websockets.exceptions.ConnectionClosedError(None, None)
+        assert _close_reason(exc) == "no close frame"
+
+    @pytest.mark.parametrize("code", [4001, 4003])
+    def test_credential_failures_are_fatal(self, code):
+        """Retrying a rejected key just repeats the rejection."""
+        from hle_client.fp_cmd import _FATAL_CLOSE_CODES
+
+        assert code in _FATAL_CLOSE_CODES
+
+    @pytest.mark.parametrize("code", [1012, 1006, 1001, 4404])
+    def test_transient_failures_are_retried(self, code):
+        """Restarts, network drops, and an offline agent are all recoverable."""
+        from hle_client.fp_cmd import _FATAL_CLOSE_CODES
+
+        assert code not in _FATAL_CLOSE_CODES
 
 
 class TestForwardRule:
@@ -186,7 +232,7 @@ class TestAgentSideDataPath:
 class TestLocalClient:
     async def test_accepted_connection_opens_a_stream_and_forwards(self):
         out = Collector()
-        client = FpLocalClient(send=out, target_host="localhost", target_port=22)
+        client = FpLocalClient(send=out, target_host="localhost", target_port=22, connected=True)
         server = await client.serve("127.0.0.1", 0)
         port = server.sockets[0].getsockname()[1]
 
@@ -217,6 +263,26 @@ class TestLocalClient:
             writer.close()
             await client.close_all()
 
+    async def test_connections_are_refused_while_the_relay_is_down(self):
+        """The port stays bound across a reconnect, but doesn't accept blindly.
+
+        Keeping the listener up means `ssh rpi` works again the moment the relay
+        returns, without restarting `hle fp`. Accepting connections while
+        disconnected would instead leave the caller hanging until the ready
+        timeout for a relay we already know isn't there.
+        """
+        out = Collector()
+        client = FpLocalClient(send=out, target_host="localhost", target_port=22, connected=False)
+        server = await client.serve("127.0.0.1", 0)
+        port = server.sockets[0].getsockname()[1]
+
+        async with server:
+            reader, writer = await asyncio.open_connection("127.0.0.1", port)
+            # Dropped immediately, and no fp_open was sent to a dead connection.
+            assert await asyncio.wait_for(reader.read(), timeout=2) == b""
+            assert out.frames == []
+            writer.close()
+
     async def test_stream_that_never_gets_ready_times_out(self):
         """A silent agent must not wedge the local connection forever."""
         out = Collector()
@@ -238,6 +304,7 @@ class TestLocalClient:
             target_host="nope",
             target_port=5432,
             on_error=seen.append,
+            connected=True,
         )
         server = await client.serve("127.0.0.1", 0)
         port = server.sockets[0].getsockname()[1]


### PR DESCRIPTION
## The bug

`hle fp` connected once and had no recovery. When the relay closed the connection — which a routine deploy does, sending `1012 service restart` — the exception propagated out of `asyncio.run` and the user got a raw traceback:

```
websockets.exceptions.ConnectionClosedError: received 1012 (service restart); then sent 1012 (service restart)
```

The forward was simply gone. Reported after a server deploy killed a live forward mid-session.

The agent has had reconnect-with-backoff since it was written. The fp client never got it — that asymmetry is the actual defect.

## What changed

**Reconnect loop** with exponential backoff (1s → 30s cap), reset after a successful connection.

**The listener is bound once** and kept for the lifetime of the command. A relay restart or a dropped network no longer takes the local port away, so `ssh rpi` works again the moment the relay returns — no need to restart `hle fp`, which matters because `hle service install --fp` users expect that port to just be there.

**In-flight streams are closed on disconnect.** The far end is gone; they cannot be recovered. Existing SSH sessions will break — unavoidable — but new ones work immediately.

**Connections during an outage are refused fast.** Accepting them would leave the caller hanging until `ready_timeout` waiting for a relay we already know isn't there.

**Close codes are classified.** `4001`/`4003` mean the credential or request was rejected — retrying just repeats it, so we exit with a clear message. Everything else (restart, network loss, briefly-offline agent) is retried. An `agent_offline` error is also retried rather than fatal, since agents restart too.

**No path surfaces a traceback.** Every failure prints a reason.

## Tests

9 new, covering close-code classification (fatal vs transient), the plain-language reason for `1012`, and that the port stays bound but refuses connections while disconnected.

Full suite: 325 passed.

## Still untested

The reporter raised two scenarios I have **not** verified: laptop losing internet entirely, and how the *agent* behaves in the same situations. The agent's reconnect logic predates this and is unchanged here — it should ride through, but I haven't exercised it under a real network drop, so I'm not claiming it does.