### PR TITLE
Release v2607.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2607.6 — 2026-07-25
+
+<!-- TODO: Fill in release notes before merging -->
+
 ## v2607.5 — 2026-07-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,33 @@
 
 ## v2607.6 — 2026-07-25
 
-<!-- TODO: Fill in release notes before merging -->
+### Fixed
+
+- **`hle fp` survives losing the relay.** It connected once with no recovery, so
+  a relay restart — which sends `1012 service restart`, and happens on every
+  deploy — crashed the command with a raw `ConnectionClosedError` traceback and
+  the forward was gone.
+
+  It now reconnects with backoff (1s, capped at 30s), the way the agent already
+  did. The asymmetry was the actual defect.
+
+  The listener stays bound across reconnects, so the local port doesn't
+  disappear: `ssh rpi` works again as soon as the relay returns, without
+  restarting anything. That matters most for forwards installed via
+  `hle service install --fp`, where the port is expected to simply be there.
+
+  Streams open at the moment of disconnect are closed — the far end is gone and
+  they can't be recovered, so existing SSH sessions break either way — but new
+  connections work immediately.
+
+  Connections arriving during an outage are refused straight away instead of
+  hanging until the dial timeout for a relay we already know is absent.
+
+  Close codes are classified: `4001`/`4003` mean the credential or request was
+  rejected, so retrying only repeats it and the command exits with a clear
+  message. Restarts, network loss, and a briefly-offline agent are all retried.
+
+  No failure path prints a traceback any more.
 
 ## v2607.5 — 2026-07-25
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ curl -fsSL https://get.hle.world | sh
 Installs via pipx (preferred), uv, or pip-in-venv. Supports `--version`:
 
 ```bash
-curl -fsSL https://get.hle.world | sh -s -- --version 2607.5
+curl -fsSL https://get.hle.world | sh -s -- --version 2607.6
 ```
 
 ### pipx
@@ -93,7 +93,7 @@ and runs the right upgrade.
 ```bash
 hle update            # upgrade to the latest release
 hle update --check    # just report current vs. latest, don't change anything
-hle update --version 2607.5   # pin an exact version
+hle update --version 2607.6   # pin an exact version
 ```
 
 After updating, restart any running tunnels (e.g. `systemctl restart hle-<label>`)

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 #
 # Usage:
 #   curl -fsSL https://get.hle.world | sh
-#   curl -fsSL https://get.hle.world | sh -s -- --version 2607.5
+#   curl -fsSL https://get.hle.world | sh -s -- --version 2607.6
 #
 #   # Install the agent and run it as a service (prompts for the token):
 #   curl -fsSL https://get.hle.world | sh -s -- --agent
@@ -263,7 +263,7 @@ main() {
         error "Install Python from https://python.org or via your package manager."
         exit 1
     }
-    info "Found Python: $PYTHON ($($PYTHON --version 2607.5>&1))"
+    info "Found Python: $PYTHON ($($PYTHON --version 2607.6>&1))"
 
     # Try install methods in order of preference
     if command -v pipx >/dev/null 2>&1; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hle-client"
-version = "2607.5"
+version = "2607.6"
 description = "HomeLab Everywhere — Expose homelab services to the internet with built-in SSO"
 readme = "README.md"
 license = "MIT"

--- a/src/hle_client/__init__.py
+++ b/src/hle_client/__init__.py
@@ -1,3 +1,3 @@
 """HLE Client — HomeLab Everywhere tunnel client."""
 
-__version__ = "2607.5"
+__version__ = "2607.6"


### PR DESCRIPTION
Bump version to `2607.6` and update all version references.

When this PR is merged, a GitHub release will be created automatically,
which triggers PyPI publish and Homebrew formula update.