### PR TITLE
Add 'hle agent list'; fix agent reconnect backoff never resetting

### DIFF
--- a/src/hle_client/agent.py
+++ b/src/hle_client/agent.py
@@ -108,6 +108,8 @@ class AgentClient:
         self._reconnect_delay = reconnect_delay
         self._max_reconnect_delay = max_reconnect_delay
         self._running = False
+        # True once the current session reached "registered"; see run().
+        self._registered = False
         self._endpoints: dict[str, _Running] = {}
         self._api_key: str | None = None
         self._base_domain: str | None = None
@@ -127,14 +129,21 @@ class AgentClient:
         self._running = True
         delay = self._reconnect_delay
         while self._running:
+            self._registered = False
             try:
                 await self._connect_once()
-                delay = self._reconnect_delay  # reset after a clean session
             except asyncio.CancelledError:
                 break
             except Exception as exc:  # noqa: BLE001 — control conn is best-effort
                 logger.warning("Agent control connection lost: %s", exc)
             finally:
+                # Reset on any session that got as far as registering, not just
+                # one that ended cleanly. Relay restarts end the session with an
+                # exception, so keying off a clean exit meant the backoff only
+                # ever grew: a healthy agent that saw three unrelated blips over
+                # a week would then wait 30s to recover from a routine deploy.
+                if self._registered:
+                    delay = self._reconnect_delay
                 await self._stop_all()
             if not self._running:
                 break
@@ -175,6 +184,9 @@ class AgentClient:
                 send=ws.send,
                 rules=self._forward_rules,
             )
+            # Marks the session as having worked, so the reconnect backoff in
+            # run() starts over rather than compounding across the process life.
+            self._registered = True
             logger.info(
                 "Agent registered: public_id=%s endpoints=%d",
                 welcome.agent_public_id,

--- a/src/hle_client/api.py
+++ b/src/hle_client/api.py
@@ -93,6 +93,17 @@ class ApiClient:
             result: list[dict[str, Any]] = resp.json()
             return result
 
+    async def list_agents(self) -> list[dict[str, Any]]:
+        """List the authenticated user's agents."""
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(
+                f"{self._base_url}/api/agents",
+                headers=self._headers,
+            )
+            resp.raise_for_status()
+            result: list[dict[str, Any]] = resp.json()
+            return result
+
     async def list_access_rules(self, subdomain: str) -> list[dict[str, Any]]:
         """List access rules for a subdomain."""
         async with httpx.AsyncClient() as client:

--- a/src/hle_client/cli.py
+++ b/src/hle_client/cli.py
@@ -7,6 +7,8 @@ import logging
 import os
 import re
 import webbrowser
+from datetime import UTC
+from typing import Any
 
 import click
 from rich.console import Console
@@ -440,6 +442,107 @@ def agent_status() -> None:
         console.print(f"Token: [dim]{masked}[/dim]")
     else:
         console.print("[dim]No agent token configured. Run 'hle agent enroll'.[/dim]")
+
+
+@agent.command("list")
+@click.option("--api-key", "api_key", default=None, help="API key (else env/config)")
+@click.option("--json", "as_json", is_flag=True, default=False, help="Machine-readable output")
+def agent_list(api_key: str | None, as_json: bool) -> None:
+    """List the agents on your account, and whether they're online.
+
+    Unlike 'hle agent status', which only inspects this machine, this asks the
+    relay. The Name column is what 'hle fp --agent' expects.
+    """
+    import json as _json
+
+    import httpx
+    from rich.table import Table
+
+    from hle_client.api import ApiClient, ApiClientConfig
+
+    key = api_key or _load_api_key()
+    if not key:
+        console.print("[red]Error:[/red] No API key. Run [cyan]hle auth login[/cyan] first.")
+        raise SystemExit(1)
+
+    async def _fetch() -> list[dict[str, Any]]:
+        return await ApiClient(ApiClientConfig(api_key=key)).list_agents()
+
+    try:
+        agents = asyncio.run(_fetch())
+    except httpx.HTTPStatusError as exc:
+        status = exc.response.status_code
+        if status == 401:
+            console.print("[red]Error:[/red] API key rejected. Run [cyan]hle auth login[/cyan].")
+        elif status == 404:
+            # The endpoint 404s (rather than 403s) when the feature flag is off.
+            console.print("[yellow]Agents are not enabled on this server.[/yellow]")
+        else:
+            console.print(f"[red]Error:[/red] server returned {status}")
+        raise SystemExit(1) from None
+    except httpx.HTTPError as exc:
+        console.print(f"[red]Error:[/red] could not reach the relay — {exc}")
+        raise SystemExit(1) from None
+
+    if as_json:
+        console.print(_json.dumps(agents, indent=2))
+        return
+
+    if not agents:
+        console.print("[dim]No agents yet.[/dim]")
+        console.print(
+            "[dim]Create one at https://hle.world/dashboard → Agents, "
+            "then run 'hle agent enroll <token>'.[/dim]"
+        )
+        return
+
+    table = Table(title="Agents")
+    table.add_column("Name", style="cyan")
+    table.add_column("Status")
+    table.add_column("Endpoints", justify="right")
+    table.add_column("Version", style="dim")
+    table.add_column("Last seen", style="dim")
+    for a in sorted(agents, key=lambda a: str(a.get("name", ""))):
+        online = a.get("online", False)
+        state = "[green]online[/green]" if online else "[dim]offline[/dim]"
+        if not a.get("is_active", True):
+            state = "[yellow]disabled[/yellow]"
+        table.add_row(
+            str(a.get("name", "?")),
+            state,
+            str(a.get("endpoint_count", 0)),
+            a.get("agent_version") or "-",
+            _humanize_last_seen(a.get("last_seen_at")),
+        )
+    console.print(table)
+
+
+def _humanize_last_seen(value: str | None) -> str:
+    """Render an ISO timestamp as a rough age. Falls back to the raw string.
+
+    Exact timestamps aren't the useful thing here — "3m ago" answers "did this
+    agent just drop?" at a glance, which is what you want when a forward fails.
+    """
+    if not value:
+        return "never"
+    from datetime import datetime
+
+    try:
+        seen = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return value
+    if seen.tzinfo is None:
+        seen = seen.replace(tzinfo=UTC)
+    seconds = (datetime.now(UTC) - seen).total_seconds()
+    if seconds < 0:
+        return "just now"
+    if seconds < 90:
+        return f"{int(seconds)}s ago"
+    if seconds < 5400:
+        return f"{int(seconds // 60)}m ago"
+    if seconds < 172800:
+        return f"{int(seconds // 3600)}h ago"
+    return f"{int(seconds // 86400)}d ago"
 
 
 @agent.command("services")

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -120,6 +120,79 @@ class TestReconcile:
         assert all(t.disconnect_calls == 1 for t in created)
 
 
+class TestReconnectBackoff:
+    """The backoff must reset after a session that actually worked.
+
+    Observed in production: an agent that had been up for 19 minutes waited 8s
+    to reconnect after a relay restart, because a previous unrelated blip had
+    already doubled the delay and nothing ever reset it. Left alone, a
+    long-lived agent drifts to the 60s ceiling and every routine deploy costs a
+    full minute of downtime.
+    """
+
+    async def _delays_for(self, monkeypatch, sessions) -> list[float]:
+        """Run run() through `sessions` outcomes, returning the sleeps taken.
+
+        Each session is True (registers, then drops) or False (fails to connect).
+        """
+        client = AgentClient("hlea_x")
+        slept: list[float] = []
+        remaining = list(sessions)
+
+        async def fake_connect_once() -> None:
+            if not remaining:
+                client._running = False
+                return
+            registered = remaining.pop(0)
+            client._registered = registered
+            raise ConnectionError("relay went away")
+
+        async def fake_sleep(seconds: float) -> None:
+            slept.append(seconds)
+
+        monkeypatch.setattr(client, "_connect_once", fake_connect_once)
+        monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+        await client.run()
+        return slept
+
+    async def test_backoff_grows_while_connections_keep_failing(self, monkeypatch):
+        delays = await self._delays_for(monkeypatch, [False, False, False])
+        assert delays[:3] == [1.0, 2.0, 4.0]
+
+    async def test_backoff_resets_after_a_registered_session(self, monkeypatch):
+        # Two failures grow the delay to 1s, 2s. The third session registers
+        # before dropping, so the next wait is 1s again rather than 4s — the
+        # 4.0 in the failure-only case above is exactly what must not appear.
+        delays = await self._delays_for(monkeypatch, [False, False, True, False])
+        assert delays[:4] == [1.0, 2.0, 1.0, 2.0]
+
+    async def test_a_session_that_never_registered_does_not_reset(self, monkeypatch):
+        # Connecting but dying before the welcome is not evidence of health.
+        delays = await self._delays_for(monkeypatch, [False, False, False])
+        assert delays[2] == 4.0
+
+    async def test_backoff_is_capped(self, monkeypatch):
+        client = AgentClient("hlea_x", reconnect_delay=1.0, max_reconnect_delay=5.0)
+        slept: list[float] = []
+        count = 0
+
+        async def fake_connect_once() -> None:
+            nonlocal count
+            count += 1
+            if count > 6:
+                client._running = False
+                return
+            raise ConnectionError("nope")
+
+        async def fake_sleep(seconds: float) -> None:
+            slept.append(seconds)
+
+        monkeypatch.setattr(client, "_connect_once", fake_connect_once)
+        monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+        await client.run()
+        assert max(slept) == 5.0
+
+
 class TestControlUri:
     def test_wss_for_remote(self):
         client = AgentClient("hlea_x", relay_host="hle.world", relay_port=443)

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -8,6 +8,8 @@ from unittest.mock import AsyncMock, patch
 if typing.TYPE_CHECKING:
     from pathlib import Path
 
+from datetime import UTC
+
 from click.testing import CliRunner
 
 from hle_client.cli import main
@@ -510,3 +512,109 @@ class TestExposeNoAutoSave:
             )
         assert result.exit_code == 0
         assert mock_run.called
+
+
+class TestAgentList:
+    """`hle agent list` — the lookup for what to pass to `hle fp --agent`."""
+
+    def _invoke(self, agents, extra=None):
+        runner = CliRunner()
+        mock_client = AsyncMock()
+        mock_client.list_agents.return_value = agents
+        with patch("hle_client.api.ApiClient", return_value=mock_client):
+            return runner.invoke(main, ["agent", "list", "--api-key", _KEY, *(extra or [])])
+
+    def test_shows_name_status_and_endpoints(self) -> None:
+        result = self._invoke(
+            [
+                {
+                    "name": "trikala",
+                    "online": True,
+                    "endpoint_count": 2,
+                    "agent_version": "2607.6",
+                    "last_seen_at": None,
+                }
+            ]
+        )
+        assert result.exit_code == 0
+        assert "trikala" in result.output
+        assert "online" in result.output
+
+    def test_offline_agent_is_marked(self) -> None:
+        result = self._invoke([{"name": "nas", "online": False, "endpoint_count": 0}])
+        assert result.exit_code == 0
+        assert "offline" in result.output
+
+    def test_empty_list_explains_what_to_do(self) -> None:
+        result = self._invoke([])
+        assert result.exit_code == 0
+        assert "No agents yet" in result.output
+
+    def test_json_output_is_machine_readable(self) -> None:
+        import json
+
+        agents = [{"name": "rpi", "online": True, "endpoint_count": 1}]
+        result = self._invoke(agents, ["--json"])
+        assert result.exit_code == 0
+        assert json.loads(result.output) == agents
+
+    def test_missing_key_is_a_clear_error(self) -> None:
+        runner = CliRunner()
+        with patch("hle_client.cli._load_api_key", return_value=None):
+            result = runner.invoke(main, ["agent", "list"])
+        assert result.exit_code == 1
+        assert "No API key" in result.output
+
+    def test_disabled_feature_is_explained_not_a_traceback(self) -> None:
+        import httpx
+
+        runner = CliRunner()
+        mock_client = AsyncMock()
+        mock_client.list_agents.side_effect = httpx.HTTPStatusError(
+            "404",
+            request=httpx.Request("GET", "https://hle.world/api/agents"),
+            response=httpx.Response(404),
+        )
+        with patch("hle_client.api.ApiClient", return_value=mock_client):
+            result = runner.invoke(main, ["agent", "list", "--api-key", _KEY])
+        assert result.exit_code == 1
+        assert "not enabled" in result.output
+
+
+class TestHumanizeLastSeen:
+    def test_never(self) -> None:
+        from hle_client.cli import _humanize_last_seen
+
+        assert _humanize_last_seen(None) == "never"
+
+    def test_recent_is_seconds(self) -> None:
+        from datetime import datetime, timedelta
+
+        from hle_client.cli import _humanize_last_seen
+
+        ts = (datetime.now(UTC) - timedelta(seconds=20)).isoformat()
+        assert _humanize_last_seen(ts).endswith("s ago")
+
+    def test_hours(self) -> None:
+        from datetime import datetime, timedelta
+
+        from hle_client.cli import _humanize_last_seen
+
+        ts = (datetime.now(UTC) - timedelta(hours=5)).isoformat()
+        assert _humanize_last_seen(ts) == "5h ago"
+
+    def test_naive_timestamp_is_treated_as_utc(self) -> None:
+        """The server serialises without a tz suffix; subtracting a naive from
+        an aware datetime raises, so this would crash the table not misformat it.
+        """
+        from datetime import datetime, timedelta
+
+        from hle_client.cli import _humanize_last_seen
+
+        ts = (datetime.now(UTC) - timedelta(minutes=10)).replace(tzinfo=None).isoformat()
+        assert _humanize_last_seen(ts) == "10m ago"
+
+    def test_unparseable_falls_back_to_the_raw_value(self) -> None:
+        from hle_client.cli import _humanize_last_seen
+
+        assert _humanize_last_seen("not-a-date") == "not-a-date"


### PR DESCRIPTION
Both changes came out of reading a few hours of production agent logs from a live Pi.

## The backoff bug

The agent's reconnect delay only reset when `_connect_once()` returned *normally*. A relay restart raises, so the reset was skipped even for a session that had been healthy for 19 minutes:

```
18:46:25  lost -> retry in 1.0s      # first drop
18:46:27  502  -> retry in 2.0s
18:46:29  502  -> retry in 4.0s
18:46:34  Agent registered           # back up, healthy for 19 minutes
19:05:55  lost -> retry in 8.0s      # <- should be 1.0s
```

The delay only ever grows over a process's lifetime, so a long-lived agent drifts to the 60s ceiling and a routine relay deploy costs a full minute of downtime for no reason. Now the reset keys off whether the session reached `registered`, not whether it ended tidily.

Worth noting the logs were also the first real evidence that agent reconnect *works* — three disconnects, all recovered unattended, discovery re-ran each time. That was previously untested.

## `hle agent list`

There was no way to see your agents from the CLI. `hle agent status` only reports whether a token file exists on the local machine; finding the name that `hle fp --agent` expects meant opening the dashboard.

```console
$ hle agent list
                          Agents
┏━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━┓
┃ Name     ┃ Status  ┃ Endpoints ┃ Version ┃ Last seen ┃
┡━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━┩
│ trikala  │ online  │         2 │ 2607.7  │ 4s ago    │
│ nas      │ offline │         1 │ 2607.5  │ 3h ago    │
└──────────┴─────────┴───────────┴─────────┴───────────┘
```

`--json` for scripting. Authenticates with the API key, not the agent token, since it's an account-level question.

## Technical details

- `agent.py`: `_registered` flag set at registration, checked in `run()`'s finally block. Merged the two `finally` blocks that resulted.
- `api.py`: `ApiClient.list_agents()`.
- `cli.py`: the command, plus `_humanize_last_seen` — relative ages answer "did this agent just drop?" better than a timestamp. Handles naive timestamps (the server serialises without a tz suffix, and subtracting naive from aware raises rather than misformatting).
- Errors are reported in words: a 404 means the agents feature is off server-side, not a missing endpoint.

**Requires jspanos/hle#304** — `GET /api/agents` is currently cookie-only and 401s an API key. Merge that first.

Tests: backoff growth, reset, cap, and that a session which never registered does *not* reset; the command's output, JSON mode, empty state, and error paths.