### PR TITLE
Release v2607.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## v2607.7 — 2026-07-25
 
-<!-- TODO: Fill in release notes before merging -->
-
-## v2607.7 — 2026-07-25
-
 ### Added
 
 - **`hle agent list`** — shows your agents and whether they're online:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Changelog
 
+## v2607.7 — 2026-07-25
+
+### Added
+
+- **`hle agent list`** — shows your agents and whether they're online:
+
+  ```console
+  $ hle agent list
+                            Agents
+  ┏━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━┓
+  ┃ Name     ┃ Status  ┃ Endpoints ┃ Version ┃ Last seen ┃
+  ┡━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━┩
+  │ trikala  │ online  │         2 │ 2607.7  │ 4s ago    │
+  │ nas      │ offline │         1 │ 2607.5  │ 3h ago    │
+  └──────────┴─────────┴───────────┴─────────┴───────────┘
+  ```
+
+  There was previously no way to see this from the CLI — `hle agent status`
+  only inspects the local machine — so finding the name that `hle fp --agent`
+  expects meant opening the dashboard. `--json` for scripting.
+
+  It authenticates with your API key rather than the agent token, since it's an
+  account-level question. Needs hle-server 2607.12, which is what made
+  `/api/agents` reachable with a key at all.
+
+### Fixed
+
+- **The agent's reconnect backoff never reset.** It only reset when a session
+  ended cleanly, but a relay restart ends it with an exception, so a session
+  that had been healthy for 19 minutes still inherited the delay from an
+  earlier unrelated blip:
+
+  ```
+  18:46:25  lost -> retry in 1.0s
+  18:46:29  502  -> retry in 4.0s
+  18:46:34  Agent registered           # healthy for 19 minutes
+  19:05:55  lost -> retry in 8.0s      # should have been 1.0s
+  ```
+
+  The delay only ever grew over a process's lifetime, so a long-running agent
+  drifted toward the 60s ceiling and every routine relay deploy cost up to a
+  minute of downtime for no reason. It now resets after any session that got as
+  far as registering.
+
 ## v2607.6 — 2026-07-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v2607.7 — 2026-07-25
 
+<!-- TODO: Fill in release notes before merging -->
+
+## v2607.7 — 2026-07-25
+
 ### Added
 
 - **`hle agent list`** — shows your agents and whether they're online:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ curl -fsSL https://get.hle.world | sh
 Installs via pipx (preferred), uv, or pip-in-venv. Supports `--version`:
 
 ```bash
-curl -fsSL https://get.hle.world | sh -s -- --version 2607.6
+curl -fsSL https://get.hle.world | sh -s -- --version 2607.7
 ```
 
 ### pipx
@@ -93,7 +93,7 @@ and runs the right upgrade.
 ```bash
 hle update            # upgrade to the latest release
 hle update --check    # just report current vs. latest, don't change anything
-hle update --version 2607.6   # pin an exact version
+hle update --version 2607.7   # pin an exact version
 ```
 
 After updating, restart any running tunnels (e.g. `systemctl restart hle-<label>`)

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 #
 # Usage:
 #   curl -fsSL https://get.hle.world | sh
-#   curl -fsSL https://get.hle.world | sh -s -- --version 2607.6
+#   curl -fsSL https://get.hle.world | sh -s -- --version 2607.7
 #
 #   # Install the agent and run it as a service (prompts for the token):
 #   curl -fsSL https://get.hle.world | sh -s -- --agent
@@ -263,7 +263,7 @@ main() {
         error "Install Python from https://python.org or via your package manager."
         exit 1
     }
-    info "Found Python: $PYTHON ($($PYTHON --version 2607.6>&1))"
+    info "Found Python: $PYTHON ($($PYTHON --version 2607.7>&1))"
 
     # Try install methods in order of preference
     if command -v pipx >/dev/null 2>&1; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hle-client"
-version = "2607.6"
+version = "2607.7"
 description = "HomeLab Everywhere — Expose homelab services to the internet with built-in SSO"
 readme = "README.md"
 license = "MIT"

--- a/src/hle_client/__init__.py
+++ b/src/hle_client/__init__.py
@@ -1,3 +1,3 @@
 """HLE Client — HomeLab Everywhere tunnel client."""
 
-__version__ = "2607.6"
+__version__ = "2607.7"


### PR DESCRIPTION
Bump version to `2607.7` and update all version references.

When this PR is merged, a GitHub release will be created automatically,
which triggers PyPI publish and Homebrew formula update.