### PR TITLE
fp: recover faster when the agent is briefly offline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## v2607.7 — 2026-07-25
 
-<!-- TODO: Fill in release notes before merging -->
-
-## v2607.7 — 2026-07-25
-
 ### Added
 
 - **`hle agent list`** — shows your agents and whether they're online:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Changelog
 
+## v2607.7 — 2026-07-25
+
+### Added
+
+- **`hle agent list`** — shows your agents and whether they're online:
+
+  ```console
+  $ hle agent list
+                            Agents
+  ┏━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━┓
+  ┃ Name     ┃ Status  ┃ Endpoints ┃ Version ┃ Last seen ┃
+  ┡━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━┩
+  │ trikala  │ online  │         2 │ 2607.7  │ 4s ago    │
+  │ nas      │ offline │         1 │ 2607.5  │ 3h ago    │
+  └──────────┴─────────┴───────────┴─────────┴───────────┘
+  ```
+
+  There was previously no way to see this from the CLI — `hle agent status`
+  only inspects the local machine — so finding the name that `hle fp --agent`
+  expects meant opening the dashboard. `--json` for scripting.
+
+  It authenticates with your API key rather than the agent token, since it's an
+  account-level question. Needs hle-server 2607.12, which is what made
+  `/api/agents` reachable with a key at all.
+
+### Fixed
+
+- **The agent's reconnect backoff never reset.** It only reset when a session
+  ended cleanly, but a relay restart ends it with an exception, so a session
+  that had been healthy for 19 minutes still inherited the delay from an
+  earlier unrelated blip:
+
+  ```
+  18:46:25  lost -> retry in 1.0s
+  18:46:29  502  -> retry in 4.0s
+  18:46:34  Agent registered           # healthy for 19 minutes
+  19:05:55  lost -> retry in 8.0s      # should have been 1.0s
+  ```
+
+  The delay only ever grew over a process's lifetime, so a long-running agent
+  drifted toward the 60s ceiling and every routine relay deploy cost up to a
+  minute of downtime for no reason. It now resets after any session that got as
+  far as registering.
+
 ## v2607.6 — 2026-07-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v2607.7 — 2026-07-25
 
+<!-- TODO: Fill in release notes before merging -->
+
+## v2607.7 — 2026-07-25
+
 ### Added
 
 - **`hle agent list`** — shows your agents and whether they're online:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ curl -fsSL https://get.hle.world | sh
 Installs via pipx (preferred), uv, or pip-in-venv. Supports `--version`:
 
 ```bash
-curl -fsSL https://get.hle.world | sh -s -- --version 2607.6
+curl -fsSL https://get.hle.world | sh -s -- --version 2607.7
 ```
 
 ### pipx
@@ -93,7 +93,7 @@ and runs the right upgrade.
 ```bash
 hle update            # upgrade to the latest release
 hle update --check    # just report current vs. latest, don't change anything
-hle update --version 2607.6   # pin an exact version
+hle update --version 2607.7   # pin an exact version
 ```
 
 After updating, restart any running tunnels (e.g. `systemctl restart hle-<label>`)

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 #
 # Usage:
 #   curl -fsSL https://get.hle.world | sh
-#   curl -fsSL https://get.hle.world | sh -s -- --version 2607.6
+#   curl -fsSL https://get.hle.world | sh -s -- --version 2607.7
 #
 #   # Install the agent and run it as a service (prompts for the token):
 #   curl -fsSL https://get.hle.world | sh -s -- --agent
@@ -263,7 +263,7 @@ main() {
         error "Install Python from https://python.org or via your package manager."
         exit 1
     }
-    info "Found Python: $PYTHON ($($PYTHON --version 2607.6>&1))"
+    info "Found Python: $PYTHON ($($PYTHON --version 2607.7>&1))"
 
     # Try install methods in order of preference
     if command -v pipx >/dev/null 2>&1; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hle-client"
-version = "2607.6"
+version = "2607.7"
 description = "HomeLab Everywhere — Expose homelab services to the internet with built-in SSO"
 readme = "README.md"
 license = "MIT"

--- a/src/hle_client/__init__.py
+++ b/src/hle_client/__init__.py
@@ -1,3 +1,3 @@
 """HLE Client — HomeLab Everywhere tunnel client."""
 
-__version__ = "2607.6"
+__version__ = "2607.7"

--- a/src/hle_client/fp_cmd.py
+++ b/src/hle_client/fp_cmd.py
@@ -76,6 +76,14 @@ _FATAL_CLOSE_CODES = frozenset({4001, 4003})
 RECONNECT_DELAY = 1.0
 MAX_RECONNECT_DELAY = 30.0
 
+# "The relay is fine, your agent just isn't there yet" is a different situation
+# from "I can't reach the relay". The relay answered, so polling it is cheap,
+# and the thing we're waiting for (an agent reconnecting) typically returns in
+# seconds. Backing this off to MAX_RECONNECT_DELAY meant the forward stayed
+# dead for up to 30s after the agent was already available again.
+AGENT_WAIT_DELAY = 2.0
+MAX_AGENT_WAIT_DELAY = 5.0
+
 
 async def _run(
     *,
@@ -106,6 +114,18 @@ async def _run(
     server = await client.serve(bind_host, bind_port)
     printed_banner = False
     delay = RECONNECT_DELAY
+    agent_wait = AGENT_WAIT_DELAY
+    # Repeating an identical line every couple of seconds reads like a fault
+    # even when the retry is working exactly as intended. Say it once, then say
+    # it again only when the situation actually changes.
+    last_notice: str | None = None
+    last_retry_delay: float | None = None
+
+    def notice(message: str, *, style: str = "yellow") -> None:
+        nonlocal last_notice
+        if message != last_notice:
+            console.print(f"[{style}]{message}[/{style}]")
+            last_notice = message
 
     async with server:
         while True:
@@ -122,10 +142,15 @@ async def _run(
                         detail = first.get("message") or first.get("code")
                         code = first.get("code")
                         if code == "agent_offline":
-                            # Worth waiting for: the agent may be restarting.
-                            console.print(f"[yellow]{detail}[/yellow] — retrying...")
-                            await asyncio.sleep(delay)
-                            delay = min(delay * 2, MAX_RECONNECT_DELAY)
+                            # The relay is reachable — only the agent is missing,
+                            # and it is probably reconnecting. Poll on its own
+                            # short schedule rather than the connection backoff.
+                            notice(f"{detail} Waiting for it to come back...")
+                            await asyncio.sleep(agent_wait)
+                            agent_wait = min(agent_wait * 2, MAX_AGENT_WAIT_DELAY)
+                            # Reaching the relay at all means the network is
+                            # healthy, so don't carry a stale connection backoff.
+                            delay = RECONNECT_DELAY
                             continue
                         console.print(f"[red]Error:[/red] {detail}")
                         raise SystemExit(1)
@@ -134,6 +159,7 @@ async def _run(
                     client.send = ws.send
                     client.connected = True
                     delay = RECONNECT_DELAY
+                    agent_wait = AGENT_WAIT_DELAY
 
                     if not printed_banner:
                         console.print(
@@ -147,12 +173,14 @@ async def _run(
                         console.print("[dim]Ctrl+C to stop.[/dim]")
                         printed_banner = True
                     else:
-                        console.print("[green]Reconnected.[/green]")
+                        console.print("[green]Reconnected.[/green] Forward is live again.")
+                    last_notice = None
+                    last_retry_delay = None
 
                     await _read_loop(ws, client)
 
                 # A clean close still means the session ended; reconnect.
-                console.print("[yellow]Connection closed by the relay[/yellow] — reconnecting...")
+                notice("Connection closed by the relay")
 
             except SystemExit:
                 raise
@@ -162,20 +190,24 @@ async def _run(
                 if exc.rcvd is not None and exc.rcvd.code in _FATAL_CLOSE_CODES:
                     console.print(f"[red]Error:[/red] {exc.rcvd.reason or 'rejected by relay'}")
                     raise SystemExit(1) from None
-                console.print(f"[yellow]Connection lost[/yellow] ({_close_reason(exc)})")
+                notice(f"Connection lost ({_close_reason(exc)})")
             except OSError as exc:
                 # DNS failure, no route, refused — typical when the laptop's
                 # network drops entirely.
-                console.print(f"[yellow]Cannot reach the relay[/yellow] ({exc})")
+                notice(f"Cannot reach the relay ({exc})")
             except Exception as exc:  # noqa: BLE001 — never surface a traceback here
-                console.print(f"[yellow]Connection problem[/yellow] ({exc})")
+                notice(f"Connection problem ({exc})")
             finally:
                 client.connected = False
                 client.send = _not_connected
                 # Streams cannot outlive the connection that carried them.
                 await client.close_all()
 
-            console.print(f"[dim]Retrying in {delay:.0f}s (Ctrl+C to stop)...[/dim]")
+            # Once this reaches the ceiling it stops changing, so printing it
+            # every pass would just be the same line forever.
+            if delay != last_retry_delay:
+                console.print(f"[dim]Retrying in {delay:.0f}s (Ctrl+C to stop)...[/dim]")
+                last_retry_delay = delay
             await asyncio.sleep(delay)
             delay = min(delay * 2, MAX_RECONNECT_DELAY)
 

--- a/tests/unit/test_firepuncher.py
+++ b/tests/unit/test_firepuncher.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 
 import pytest
@@ -80,6 +81,186 @@ class TestCloseHandling:
         from hle_client.fp_cmd import _FATAL_CLOSE_CODES
 
         assert code not in _FATAL_CLOSE_CODES
+
+
+class _ScriptedWS:
+    """One fake relay session: replies to the hello, then ends.
+
+    ``first`` is the JSON the relay sends back after ``fp_hello``. ``then``
+    is an exception to raise from the message loop, standing in for the
+    connection dropping mid-session.
+    """
+
+    def __init__(self, first: dict, then: Exception | None = None) -> None:
+        self._first = first
+        self._then = then
+        self.sent: list[str] = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc) -> bool:
+        return False
+
+    async def send(self, raw: str) -> None:
+        self.sent.append(raw)
+
+    async def recv(self) -> str:
+        return json.dumps(self._first)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._then is not None:
+            raise self._then
+        raise StopAsyncIteration
+
+
+class TestReconnectPacing:
+    """How `hle fp` behaves while it can't serve the forward.
+
+    Reported from a real relay deploy: the forward printed the same
+    "agent is not connected" line repeatedly and took far too long to come
+    back, because waiting for an agent shared the backoff counter used for
+    unreachable-relay retries.
+    """
+
+    async def _run_until_exhausted(self, monkeypatch, sessions, capsys):
+        """Drive _run through `sessions`, returning (sleeps, output)."""
+        from hle_client import fp_cmd
+
+        remaining = list(sessions)
+        sleeps: list[float] = []
+
+        def fake_connect(uri, **kw):
+            if not remaining:
+                raise KeyboardInterrupt  # ends the loop deterministically
+            nxt = remaining.pop(0)
+            if isinstance(nxt, Exception):
+                raise nxt
+            return nxt
+
+        async def fake_sleep(seconds: float) -> None:
+            sleeps.append(seconds)
+
+        monkeypatch.setattr(fp_cmd.websockets, "connect", fake_connect)
+        monkeypatch.setattr(fp_cmd.asyncio, "sleep", fake_sleep)
+
+        with contextlib.suppress(KeyboardInterrupt):
+            await fp_cmd._run(
+                api_key="hle_x",
+                agent="rpi",
+                target_host="localhost",
+                target_port=22,
+                bind_host="127.0.0.1",
+                bind_port=0,
+                relay_host="hle.world",
+                relay_port=443,
+            )
+        return sleeps, capsys.readouterr().out
+
+    def _offline(self):
+        return _ScriptedWS(
+            {
+                "type": "fp_error",
+                "code": "agent_offline",
+                "message": "Agent 'rpi' is not connected right now.",
+            }
+        )
+
+    def _welcome(self, then=None):
+        return _ScriptedWS(
+            {"type": "fp_welcome", "agent_public_id": "abc-123", "allowed": ["localhost:*"]},
+            then=then,
+        )
+
+    async def test_waiting_for_an_agent_uses_the_short_schedule(self, monkeypatch, capsys):
+        """Not the connection backoff: the relay answered, so polling is cheap."""
+        sleeps, _ = await self._run_until_exhausted(
+            monkeypatch, [self._offline(), self._offline(), self._offline()], capsys
+        )
+        from hle_client.fp_cmd import AGENT_WAIT_DELAY, MAX_AGENT_WAIT_DELAY
+
+        assert sleeps[0] == AGENT_WAIT_DELAY
+        assert max(sleeps) <= MAX_AGENT_WAIT_DELAY
+
+    async def test_agent_wait_never_reaches_the_connection_ceiling(self, monkeypatch, capsys):
+        """The bug: an agent that returned after a blip still cost up to 30s."""
+        from hle_client.fp_cmd import MAX_RECONNECT_DELAY
+
+        sleeps, _ = await self._run_until_exhausted(
+            monkeypatch, [self._offline() for _ in range(8)], capsys
+        )
+        assert len(sleeps) == 8, sleeps
+        assert max(sleeps) < MAX_RECONNECT_DELAY, sleeps
+
+    async def test_the_offline_message_is_not_repeated(self, monkeypatch, capsys):
+        """Four identical lines read as a fault; the retry is working."""
+        _, out = await self._run_until_exhausted(
+            monkeypatch, [self._offline() for _ in range(4)], capsys
+        )
+        assert out.count("not connected right now") == 1
+
+    async def test_reaching_the_relay_clears_a_stale_connection_backoff(self, monkeypatch, capsys):
+        """A network outage then an agent wait must not inherit the old delay.
+
+        Two unreachable-relay failures grow the connection delay to 4s. Once the
+        relay answers — even with 'agent offline' — the network is demonstrably
+        fine, so the next real reconnect should start from 1s again.
+        """
+        sessions = [
+            OSError("no route to host"),
+            OSError("no route to host"),
+            self._offline(),
+            self._welcome(then=ConnectionResetError("dropped")),
+        ]
+        sleeps, _ = await self._run_until_exhausted(monkeypatch, sessions, capsys)
+        # 1s, 2s (connection backoff), 2s (agent wait), then back to 1s.
+        assert sleeps[:2] == [1.0, 2.0]
+        assert sleeps[-1] == 1.0
+
+    async def test_first_connection_prints_the_banner(self, monkeypatch, capsys):
+        _, out = await self._run_until_exhausted(
+            monkeypatch,
+            [self._offline(), self._welcome(then=ConnectionResetError("dropped"))],
+            capsys,
+        )
+        assert "Forwarding" in out
+        assert "Reconnected" not in out
+
+    async def test_recovery_after_a_drop_is_announced(self, monkeypatch, capsys):
+        """Coming back must be as visible as going away, or the user can't tell
+        whether the forward is usable again."""
+        _, out = await self._run_until_exhausted(
+            monkeypatch,
+            [
+                self._welcome(then=ConnectionResetError("dropped")),
+                self._offline(),
+                self._welcome(then=ConnectionResetError("dropped again")),
+            ],
+            capsys,
+        )
+        assert "Reconnected" in out
+
+    async def test_a_rejected_key_still_exits_rather_than_looping(self, monkeypatch, capsys):
+        from hle_client import fp_cmd
+
+        session = _ScriptedWS({"type": "fp_error", "code": "forbidden", "message": "nope"})
+        monkeypatch.setattr(fp_cmd.websockets, "connect", lambda uri, **kw: session)
+        monkeypatch.setattr(fp_cmd.asyncio, "sleep", lambda s: asyncio.sleep(0))
+
+        with pytest.raises(SystemExit):
+            await fp_cmd._run(
+                api_key="hle_x",
+                agent="rpi",
+                target_host="localhost",
+                target_port=22,
+                bind_host="127.0.0.1",
+                bind_port=0,
+                relay_host="hle.world",
+                relay_port=443,
+            )
 
 
 class TestForwardRule:


### PR DESCRIPTION
From a real relay deploy:

```
Connection lost (relay restarting)
Retrying in 1s (Ctrl+C to stop)...
Connection problem (server rejected WebSocket connection: HTTP 502)
Retrying in 2s (Ctrl+C to stop)...
Connection problem (server rejected WebSocket connection: HTTP 502)
Retrying in 4s (Ctrl+C to stop)...
Agent 'rpi trikala' is not connected right now. — retrying...
Agent 'rpi trikala' is not connected right now. — retrying...
```

Two problems.

**Waiting for an agent used the connection backoff.** `agent_offline` shares the counter that unreachable-relay retries grow, so after a deploy it was already at 8s and kept doubling toward 30s — the forward stayed dead for up to half a minute after the agent was available again. But that case is different in kind: the relay *answered*, so the network is fine and only the agent is missing. It gets its own schedule now (2s, capped at 5s), and reaching the relay clears any stale connection backoff.

**The output read like a fault.** Identical lines repeated with no indication anything was progressing, because that branch `continue`s past the retry countdown. Status lines are now printed once and repeated only when the situation changes; recovery says `Reconnected. Forward is live again.`

## Technical details

- `AGENT_WAIT_DELAY` / `MAX_AGENT_WAIT_DELAY` separate from `RECONNECT_DELAY` / `MAX_RECONNECT_DELAY`
- `notice()` dedupes consecutive identical messages; reset on a successful session
- The retry countdown prints only when the interval changes (it stops changing at the ceiling)

Tests drive `_run` through scripted relay sessions with a fake `websockets.connect`, asserting the pacing and the output. All three new pacing tests were verified to fail against `origin/main` and pass with the fix.

Note the agent side had a related bug fixed in 2607.7 — its own backoff never reset — which made this worse in practice: the Pi was itself waiting 8s+ to reconnect.