### PR TITLE
Release v2607.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,29 @@
 
 ## v2607.8 — 2026-07-25
 
-<!-- TODO: Fill in release notes before merging -->
+### Fixed
+
+- **`hle fp` recovers quickly when the agent is briefly offline.** Waiting for
+  an agent shared the backoff counter that unreachable-relay retries grow, so
+  after a relay deploy it was already at 8s and kept doubling toward 30s — the
+  forward stayed dead for up to half a minute after the agent was back.
+
+  Those two situations aren't alike. If the relay answered "that agent isn't
+  connected", the network is demonstrably fine and only the agent is missing —
+  usually for a few seconds while it reconnects. That now polls on its own
+  schedule (2s, capped at 5s), and reaching the relay clears any stale
+  connection backoff.
+
+- **Status lines no longer repeat.** The same line every couple of seconds with
+  no countdown read like a fault rather than a retry working as intended:
+
+  ```
+  Agent 'rpi trikala' is not connected right now. — retrying...
+  Agent 'rpi trikala' is not connected right now. — retrying...
+  ```
+
+  Each message is printed once and repeated only when the situation changes.
+  Recovery is announced with `Reconnected. Forward is live again.`
 
 ## v2607.7 — 2026-07-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2607.8 — 2026-07-25
+
+<!-- TODO: Fill in release notes before merging -->
+
 ## v2607.7 — 2026-07-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ curl -fsSL https://get.hle.world | sh
 Installs via pipx (preferred), uv, or pip-in-venv. Supports `--version`:
 
 ```bash
-curl -fsSL https://get.hle.world | sh -s -- --version 2607.7
+curl -fsSL https://get.hle.world | sh -s -- --version 2607.8
 ```
 
 ### pipx
@@ -93,7 +93,7 @@ and runs the right upgrade.
 ```bash
 hle update            # upgrade to the latest release
 hle update --check    # just report current vs. latest, don't change anything
-hle update --version 2607.7   # pin an exact version
+hle update --version 2607.8   # pin an exact version
 ```
 
 After updating, restart any running tunnels (e.g. `systemctl restart hle-<label>`)

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 #
 # Usage:
 #   curl -fsSL https://get.hle.world | sh
-#   curl -fsSL https://get.hle.world | sh -s -- --version 2607.7
+#   curl -fsSL https://get.hle.world | sh -s -- --version 2607.8
 #
 #   # Install the agent and run it as a service (prompts for the token):
 #   curl -fsSL https://get.hle.world | sh -s -- --agent
@@ -263,7 +263,7 @@ main() {
         error "Install Python from https://python.org or via your package manager."
         exit 1
     }
-    info "Found Python: $PYTHON ($($PYTHON --version 2607.7>&1))"
+    info "Found Python: $PYTHON ($($PYTHON --version 2607.8>&1))"
 
     # Try install methods in order of preference
     if command -v pipx >/dev/null 2>&1; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hle-client"
-version = "2607.7"
+version = "2607.8"
 description = "HomeLab Everywhere — Expose homelab services to the internet with built-in SSO"
 readme = "README.md"
 license = "MIT"

--- a/src/hle_client/__init__.py
+++ b/src/hle_client/__init__.py
@@ -1,3 +1,3 @@
 """HLE Client — HomeLab Everywhere tunnel client."""
 
-__version__ = "2607.7"
+__version__ = "2607.8"


### PR DESCRIPTION
Bump version to `2607.8` and update all version references.

When this PR is merged, a GitHub release will be created automatically,
which triggers PyPI publish and Homebrew formula update.