### PR TITLE
fix(release): stop the version bump corrupting shell redirects

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -312,7 +312,7 @@ main() {
             error "Install Python from https://python.org or via your package manager."
             exit 1
         }
-        info "Found Python: $PYTHON ($($PYTHON --version 2607.8>&1))"
+        info "Found Python: $PYTHON ($($PYTHON --version 2>&1))"
 
         # Try install methods in order of preference
         if command -v pipx >/dev/null 2>&1; then

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -115,7 +115,7 @@ echo "Updating README.md..."
 if $DRY_RUN; then
   grep -n "\-\-version" README.md || true
 else
-  sed -i '' "s/--version [0-9][0-9.]*/--version $VERSION/g" README.md
+  sed -i '' "s/--version [0-9]\{4\}\.[0-9][0-9.]*/--version $VERSION/g" README.md
   FILES_CHANGED+=(README.md)
 fi
 
@@ -124,7 +124,10 @@ echo "Updating install.sh..."
 if $DRY_RUN; then
   grep -n "\-\-version" install.sh || true
 else
-  sed -i '' "s/--version [0-9][0-9.]*/--version $VERSION/g" install.sh
+  # Anchored to a full CalVer (YYMM.N) so it can't match the "2" in a shell
+  # redirect like `--version 2>&1`, which it previously rewrote into
+  # `--version 2607.8>&1`.
+  sed -i '' "s/--version [0-9]\{4\}\.[0-9][0-9.]*/--version $VERSION/g" install.sh
   FILES_CHANGED+=(install.sh)
 fi
 


### PR DESCRIPTION
## Summary

Found while dry-running the release for the pfSense work.

`scripts/release.sh` bumped versions with `s/--version [0-9][0-9.]*/--version $VERSION/g`. That pattern also matches the `2` in `$($PYTHON --version 2>&1)`, rewriting it to:

```sh
info "Found Python: $PYTHON ($($PYTHON --version 2607.8>&1))"
```

`install.sh` has been shipping that since a previous release — the installer printed a broken version line and redirected stderr into a file literally named `8`.

## Fix

- Anchor the pattern to a full CalVer (`YYMM.N`), so `--version 2>&1` no longer matches while `--version 2607.8` still does. Applied to both the `install.sh` and `README.md` substitutions.
- Repair the already-corrupted line in `install.sh`.

Verified against a fixture containing both forms: real versions bump, the redirect is untouched. `sh -n install.sh` clean.

Worth catching now — the same bump would have corrupted the `--version 2>&1` line added in #113 on the very next release.