### PR TITLE
Release v2608.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,32 @@
 
 ## v2608.1 — 2026-08-04
 
-<!-- TODO: Fill in release notes before merging -->
+### Added
+
+- **The agent runs as a service on FreeBSD, pfSense and OPNsense.**
+  `hle service install --agent` previously knew only systemd and launchd, so on
+  a FreeBSD-based firewall the agent had to be started by hand and did not
+  survive a reboot. It now generates an rc.d script, enabled through `sysrc`
+  and supervised by `daemon(8)`, which restarts it if it exits — the same
+  behaviour the systemd unit has. `uninstall`, `status` and `list` work there
+  too. rc.d has no per-user services, so `--user` is rejected with an
+  explanation rather than failing later on a permission error.
+- **The installer handles FreeBSD.** `pydantic` has no FreeBSD wheel on PyPI,
+  so a plain `pip install` would try to build Rust on the firewall. On FreeBSD
+  the dependencies now come from `pkg` as prebuilt packages, the venv is
+  created with `--system-site-packages` to see them, and pip installs the
+  client with `--no-deps` — pure Python only, no compiler. Missing packages are
+  reported up front with the exact `pkg install` line.
+
+  See the [pfSense guide](https://hle.world/docs/integrations/pfsense/).
+
+### Fixed
+
+- **The release script no longer corrupts shell redirects.** Its version bump
+  matched the `2` in `$($PYTHON --version 2>&1)` and rewrote it to
+  `--version 2607.8>&1`, which `install.sh` had been shipping since an earlier
+  release. The pattern is now anchored to a full CalVer, and the mangled line
+  is repaired.
 
 ## v2607.8 — 2026-07-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2608.1 — 2026-08-04
+
+<!-- TODO: Fill in release notes before merging -->
+
 ## v2607.8 — 2026-07-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ curl -fsSL https://get.hle.world | sh
 Installs via pipx (preferred), uv, or pip-in-venv. Supports `--version`:
 
 ```bash
-curl -fsSL https://get.hle.world | sh -s -- --version 2607.8
+curl -fsSL https://get.hle.world | sh -s -- --version 2608.1
 ```
 
 ### pipx
@@ -93,7 +93,7 @@ and runs the right upgrade.
 ```bash
 hle update            # upgrade to the latest release
 hle update --check    # just report current vs. latest, don't change anything
-hle update --version 2607.8   # pin an exact version
+hle update --version 2608.1   # pin an exact version
 ```
 
 After updating, restart any running tunnels (e.g. `systemctl restart hle-<label>`)

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 #
 # Usage:
 #   curl -fsSL https://get.hle.world | sh
-#   curl -fsSL https://get.hle.world | sh -s -- --version 2607.8
+#   curl -fsSL https://get.hle.world | sh -s -- --version 2608.1
 #
 #   # Install the agent and run it as a service (prompts for the token):
 #   curl -fsSL https://get.hle.world | sh -s -- --agent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hle-client"
-version = "2607.8"
+version = "2608.1"
 description = "HomeLab Everywhere — Expose homelab services to the internet with built-in SSO"
 readme = "README.md"
 license = "MIT"

--- a/src/hle_client/__init__.py
+++ b/src/hle_client/__init__.py
@@ -1,3 +1,3 @@
 """HLE Client — HomeLab Everywhere tunnel client."""
 
-__version__ = "2607.8"
+__version__ = "2608.1"


### PR DESCRIPTION
Bump version to `2608.1` and update all version references.

When this PR is merged, a GitHub release will be created automatically,
which triggers PyPI publish and Homebrew formula update.