### PR TITLE
Release v2608.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,45 @@
 
 ## v2608.2 — 2026-08-04
 
-<!-- TODO: Fill in release notes before merging -->
+### Changed
+
+- **The client no longer depends on `pydantic`, so it installs without a
+  compiler.** `pydantic-core` is compiled Rust and publishes no FreeBSD wheel,
+  so `pip install hle-client` tried to build it from source. On a pfSense box
+  that meant downloading a Rust toolchain onto a firewall:
+
+  ```
+  Collecting pydantic-core==2.46.4
+    Downloading pydantic_core-2.46.4.tar.gz (471 kB)
+        Unsupported platform: 311
+        Rust not found, installing into a temporary directory
+  ```
+
+  The remaining four dependencies — `click`, `rich`, `httpx`, `websockets` —
+  are pure Python and install there without complaint. This one library was the
+  entire reason the agent could not run on pfSense, or on anything else with a
+  stock interpreter and no build tools.
+
+  The shared protocol models are now stdlib dataclasses over a small
+  serialisation base (`hle_common.wire`). Outside `TunnelRegistration` they were
+  plain data containers with no validators, used only for JSON in and out. The
+  method names are unchanged, so this is invisible to callers.
+
+  **The wire format is byte-for-byte identical.** A baseline captured while the
+  models were still pydantic is asserted against on every test run, covering all
+  39 message types: same JSON, same round-trip, same tolerance of unknown fields
+  from a newer peer. Old clients and old servers are unaffected.
+
+  `TunnelRegistration` keeps all four of its validators, including the
+  `service_label` normalisation. The two `Literal` fields that cross the wire
+  keep their checks, since dataclasses ignore `Literal`.
+
+  Two deliberate differences: constructing a model with an unknown keyword now
+  raises instead of silently dropping it, and a missing required argument raises
+  `TypeError` rather than `ValueError` — parsing from the wire still raises
+  `ValueError`.
+
+  On FreeBSD, `pkg install python311` is now the only prerequisite.
 
 ## v2608.1 — 2026-08-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2608.2 — 2026-08-04
+
+<!-- TODO: Fill in release notes before merging -->
+
 ## v2608.1 — 2026-08-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ curl -fsSL https://get.hle.world | sh
 Installs via pipx (preferred), uv, or pip-in-venv. Supports `--version`:
 
 ```bash
-curl -fsSL https://get.hle.world | sh -s -- --version 2608.1
+curl -fsSL https://get.hle.world | sh -s -- --version 2608.2
 ```
 
 ### pipx
@@ -93,7 +93,7 @@ and runs the right upgrade.
 ```bash
 hle update            # upgrade to the latest release
 hle update --check    # just report current vs. latest, don't change anything
-hle update --version 2608.1   # pin an exact version
+hle update --version 2608.2   # pin an exact version
 ```
 
 After updating, restart any running tunnels (e.g. `systemctl restart hle-<label>`)

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 #
 # Usage:
 #   curl -fsSL https://get.hle.world | sh
-#   curl -fsSL https://get.hle.world | sh -s -- --version 2608.1
+#   curl -fsSL https://get.hle.world | sh -s -- --version 2608.2
 #
 #   # Install the agent and run it as a service (prompts for the token):
 #   curl -fsSL https://get.hle.world | sh -s -- --agent

--- a/install.sh
+++ b/install.sh
@@ -93,32 +93,10 @@ detect_os() {
     esac
 }
 
-# FreeBSD (and therefore pfSense/OPNsense) has no prebuilt pydantic-core wheel
-# on PyPI, so a plain `pip install` would try to compile Rust on the firewall.
-# The dependencies are installed from pkg instead and the venv is given access
-# to them; pip then only has to place pure-Python code.
-FREEBSD_PKGS="python311 py311-pydantic2 py311-httpx py311-websockets py311-click py311-rich"
-
-freebsd_preflight() {
-    PYTHON="$1"
-    missing=""
-    for mod in pydantic httpx websockets click rich; do
-        "$PYTHON" -c "import $mod" >/dev/null 2>&1 || missing="$missing $mod"
-    done
-    [ -z "$missing" ] && return 0
-
-    error "Missing Python modules from pkg:$missing"
-    echo ""
-    echo "  Install them first (they ship as prebuilt packages, no compiler needed):"
-    echo ""
-    echo "    pkg install $FREEBSD_PKGS"
-    echo ""
-    echo "  If pkg reports any of these as unavailable, check your repo with:"
-    echo ""
-    echo "    pkg search py311-pydantic2"
-    echo ""
-    return 1
-}
+# FreeBSD (and therefore pfSense/OPNsense) ships no Python by default, but every
+# dependency is pure Python as of 2608.2, so pip can install them from PyPI with
+# no compiler involved. The interpreter is the only prerequisite.
+FREEBSD_PKGS="python311"
 
 # Find Python 3.11+
 find_python() {
@@ -203,16 +181,9 @@ install_with_venv() {
 
     info "Installing in isolated venv at $VENV_DIR..."
     rm -rf "$VENV_DIR"
-    if [ "$(detect_os)" = "freebsd" ]; then
-        # Reuse the pkg-installed dependencies rather than rebuilding them.
-        "$PYTHON" -m venv --system-site-packages "$VENV_DIR"
-        "$VENV_DIR/bin/pip" install --quiet --upgrade pip
-        "$VENV_DIR/bin/pip" install --quiet --no-deps "$INSTALL_SPEC"
-    else
-        "$PYTHON" -m venv "$VENV_DIR"
-        "$VENV_DIR/bin/pip" install --quiet --upgrade pip
-        "$VENV_DIR/bin/pip" install --quiet "$INSTALL_SPEC"
-    fi
+    "$PYTHON" -m venv "$VENV_DIR"
+    "$VENV_DIR/bin/pip" install --quiet --upgrade pip
+    "$VENV_DIR/bin/pip" install --quiet "$INSTALL_SPEC"
 
     # Verify before symlinking
     verify_install "$VENV_DIR/bin/python"
@@ -302,9 +273,8 @@ main() {
             exit 1
         }
         info "Found Python: $PYTHON ($($PYTHON --version 2>&1))"
-        freebsd_preflight "$PYTHON" || exit 1
-        # pipx/uv would each rebuild the dependency tree from PyPI, which is the
-        # thing that needs a Rust toolchain here. Always take the venv path.
+        # pipx and uv are rarely packaged here; the venv path needs nothing but
+        # the interpreter, and every dependency is pure Python.
         install_with_venv "$PYTHON"
     else
         PYTHON=$(find_python) || {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hle-client"
-version = "2608.1"
+version = "2608.2"
 description = "HomeLab Everywhere — Expose homelab services to the internet with built-in SSO"
 readme = "README.md"
 license = "MIT"

--- a/src/hle_client/__init__.py
+++ b/src/hle_client/__init__.py
@@ -1,3 +1,3 @@
 """HLE Client — HomeLab Everywhere tunnel client."""
 
-__version__ = "2608.1"
+__version__ = "2608.2"


### PR DESCRIPTION
Bump version to `2608.2` and update all version references.

When this PR is merged, a GitHub release will be created automatically,
which triggers PyPI publish and Homebrew formula update.