### PR TITLE
fix(service): set HOME in the rc.d script, and pick the right shell rc file

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -121,15 +121,26 @@ ensure_local_bin() {
         *":$HOME/.local/bin:"*) ;;
         *)
             SHELL_NAME=$(basename "$SHELL" 2>/dev/null || echo "sh")
+            # csh/tcsh use a different syntax and never read .profile — writing
+            # there looks like it worked and silently does nothing. pfSense
+            # gives root tcsh by default, so this is the common case there.
+            PATH_LINE='export PATH="$HOME/.local/bin:$PATH"'
             case "$SHELL_NAME" in
                 zsh) RC_FILE="$HOME/.zshrc" ;;
                 bash) RC_FILE="$HOME/.bashrc" ;;
-                fish) RC_FILE="$HOME/.config/fish/config.fish" ;;
+                fish)
+                    RC_FILE="$HOME/.config/fish/config.fish"
+                    PATH_LINE='set -gx PATH $HOME/.local/bin $PATH'
+                    ;;
+                csh|tcsh)
+                    RC_FILE="$HOME/.cshrc"
+                    PATH_LINE='set path = ( $HOME/.local/bin $path )'
+                    ;;
                 *) RC_FILE="$HOME/.profile" ;;
             esac
             if [ -n "$RC_FILE" ]; then
                 if prompt_yn "Add ~/.local/bin to PATH in $RC_FILE?"; then
-                    echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$RC_FILE"
+                    echo "$PATH_LINE" >> "$RC_FILE"
                     info "Added to $RC_FILE — restart your shell or run: source $RC_FILE"
                 else
                     info "Skipped. You may need to add ~/.local/bin to your PATH manually."

--- a/src/hle_client/service_cmd.py
+++ b/src/hle_client/service_cmd.py
@@ -537,6 +537,7 @@ def render_rc_script(
     hle_path: str,
     run_args: list[str],
     run_as_user: str | None = None,
+    home: str | None = None,
     name: str | None = None,
     description: str | None = None,
     restart: bool = True,
@@ -546,10 +547,17 @@ def render_rc_script(
     ``hle`` runs in the foreground, so daemon(8) does the backgrounding. With
     ``restart`` it also re-launches the process if it exits, which is the rc.d
     equivalent of systemd's ``Restart=on-failure``.
+
+    ``HOME`` is set explicitly. rc.d starts services with a near-empty
+    environment and daemon(8) adds nothing, so without it the agent looks for
+    its token somewhere other than the home directory it was enrolled in and
+    fails with "No agent token" on every restart.
     """
     svc = rc_service_name(label, name)
     args = " ".join(_rc_quote(a) for a in run_args)
     daemon_flags = "-f" + (" -r" if restart else "")
+    user = run_as_user or "root"
+    home_dir = home or str(Path.home())
     lines = [
         "#!/bin/sh",
         "#",
@@ -568,7 +576,9 @@ def render_rc_script(
         "load_rc_config $name",
         "",
         f': ${{{svc}_enable:="NO"}}',
-        f': ${{{svc}_user:="{run_as_user or "root"}"}}',
+        f': ${{{svc}_user:="{user}"}}',
+        # Overridable via sysrc, e.g. after moving the config to another user.
+        f': ${{{svc}_home:={_rc_quote(home_dir)}}}',
         "",
         'pidfile="/var/run/${name}.pid"',
         'logfile="/var/log/${name}.log"',
@@ -577,8 +587,10 @@ def render_rc_script(
         'command="/usr/sbin/daemon"',
         # -P tracks the daemon(8) supervisor, -p the hle process itself, so
         # `service ... status` reports on the thing that actually matters.
+        # env(1) supplies HOME because rc.d does not.
         f'command_args="{daemon_flags} -P ${{pidfile}} -p /var/run/${{name}}.child.pid '
-        f'-o ${{logfile}} ${{hle_command}} {args}"',
+        f"-o ${{logfile}} /usr/bin/env HOME=${{{svc}_home}} "
+        f'${{hle_command}} {args}"',
         'procname="/usr/sbin/daemon"',
         "",
         'run_rc_command "$1"',

--- a/src/hle_client/service_cmd.py
+++ b/src/hle_client/service_cmd.py
@@ -578,7 +578,7 @@ def render_rc_script(
         f': ${{{svc}_enable:="NO"}}',
         f': ${{{svc}_user:="{user}"}}',
         # Overridable via sysrc, e.g. after moving the config to another user.
-        f': ${{{svc}_home:={_rc_quote(home_dir)}}}',
+        f": ${{{svc}_home:={_rc_quote(home_dir)}}}",
         "",
         'pidfile="/var/run/${name}.pid"',
         'logfile="/var/log/${name}.log"',

--- a/tests/unit/test_service_rcd.py
+++ b/tests/unit/test_service_rcd.py
@@ -7,6 +7,8 @@ covered here rather than discovered on a firewall.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from hle_client.service_cmd import (
@@ -104,6 +106,27 @@ class TestRenderRcScript:
 
     def test_explicit_user_is_honoured(self):
         assert ': ${hle_agent_user:="hle"}' in self._script(run_as_user="hle")
+
+    def test_home_is_set_explicitly(self):
+        """rc.d starts services with almost no environment and daemon(8) adds
+        nothing, so without HOME the agent looks for its token in the wrong
+        place and fails with "No agent token" on every restart."""
+        script = self._script(home="/root")
+        assert ": ${hle_agent_home:='/root'}" in script
+        assert "/usr/bin/env HOME=${hle_agent_home}" in script
+
+    def test_env_precedes_the_hle_command(self):
+        """env(1) has to wrap the command, not follow it."""
+        script = self._script(home="/root")
+        assert script.index("/usr/bin/env HOME=") < script.index("${hle_command}")
+
+    def test_home_defaults_to_the_installing_users_home(self):
+        script = self._script()
+        assert f": ${{hle_agent_home:='{Path.home()}'}}" in script
+
+    def test_home_is_quoted(self):
+        script = self._script(home="/home/user with space")
+        assert "'/home/user with space'" in script
 
     def test_no_token_is_baked_into_the_script(self):
         """The agent reads its token at runtime; rc.d scripts are world-readable."""


### PR DESCRIPTION
## Summary

Two bugs found running the agent on a real pfSense 2.7.2 box. Both are the kind that only show up on hardware.

## 1. The service started and never connected

`service hle_agent status` reported it running, but the log was this on a loop:

```
Error: No agent token. Run hle agent enroll first.
Error: No agent token. Run hle agent enroll first.
...
```

The token *was* enrolled, and the identical command worked in the foreground:

```
$ ~/.local/bin/hle agent run
Agent registered: public_id=c77907d9-… endpoints=0
```

**Cause:** rc.d starts services with almost no environment, and `daemon(8)` adds nothing. With `HOME` unset the agent looked for `~/.config/hle/agent.toml` somewhere other than the home directory it was enrolled in.

The script now sets `HOME` explicitly through `env(1)`, overridable with `sysrc <service>_home`. The script already declared a `_user` variable it never used — that's now wired to the same place instead of being decorative.

## 2. `hle: Command not found` right after a successful install

The installer wrote its PATH line to `~/.profile` for any shell it didn't recognise. csh and tcsh never read that file, and use different syntax anyway — so the line looked like it worked and did nothing.

pfSense gives root `tcsh` by default, so this was the *common* case there, not an edge case. csh/tcsh now get `~/.cshrc` with `set path`, and fish gets its own `set -gx` rather than a bare `export`.

## Tests

Six new cases covering the `HOME` handling specifically: that it's set, that `env` wraps rather than follows the command, that it defaults to the installing user's home, and that it survives a path with spaces. 494 pass, ruff clean, `sh -n` clean.

## Related

`get.hle.world` serves a *copy* of this installer from the server repo, which had drifted since 25 Jul — which is why the released FreeBSD support appeared to be missing (`Unsupported OS: FreeBSD`). Fixed separately in the server repo, with a CI check so the two can't silently diverge again.