### PR TITLE
Make the agent service find its token, and the install tell the truth

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -120,30 +120,57 @@ ensure_local_bin() {
     case ":$PATH:" in
         *":$HOME/.local/bin:"*) ;;
         *)
-            SHELL_NAME=$(basename "$SHELL" 2>/dev/null || echo "sh")
-            # csh/tcsh use a different syntax and never read .profile — writing
-            # there looks like it worked and silently does nothing. pfSense
-            # gives root tcsh by default, so this is the common case there.
-            PATH_LINE='export PATH="$HOME/.local/bin:$PATH"'
+            SHELL_NAME=$(basename "${SHELL:-}" 2>/dev/null || echo "")
+            # $SHELL is the login shell from /etc/passwd, which is not always
+            # the shell you are typing into. pfSense's admin account has
+            # /etc/rc.initial — its console menu — and picking the shell option
+            # execs tcsh without updating $SHELL, so this used to resolve to
+            # "rc.initial", fall through to .profile, and write a file tcsh
+            # never reads. The install then reported success and changed
+            # nothing. Ask the parent process what it actually is whenever
+            # $SHELL names something that isn't a shell we know.
             case "$SHELL_NAME" in
-                zsh) RC_FILE="$HOME/.zshrc" ;;
-                bash) RC_FILE="$HOME/.bashrc" ;;
+                zsh|bash|fish|csh|tcsh|sh|ksh|dash) ;;
+                *)
+                    PARENT=$(ps -o comm= -p "$PPID" 2>/dev/null | tr -d ' ') || PARENT=""
+                    # A login shell shows up as "-tcsh"; the dash is not part
+                    # of the name.
+                    PARENT=${PARENT#-}
+                    [ -n "$PARENT" ] && SHELL_NAME=$(basename "$PARENT")
+                    ;;
+            esac
+
+            # csh/tcsh use a different syntax and never read .profile.
+            PATH_LINE='export PATH="$HOME/.local/bin:$PATH"'
+            RELOAD_HINT="restart your shell or run: . $HOME/.profile"
+            case "$SHELL_NAME" in
+                zsh) RC_FILE="$HOME/.zshrc"; RELOAD_HINT="restart your shell" ;;
+                bash) RC_FILE="$HOME/.bashrc"; RELOAD_HINT="restart your shell" ;;
                 fish)
                     RC_FILE="$HOME/.config/fish/config.fish"
                     PATH_LINE='set -gx PATH $HOME/.local/bin $PATH'
+                    RELOAD_HINT="restart your shell"
                     ;;
                 csh|tcsh)
                     RC_FILE="$HOME/.cshrc"
                     PATH_LINE='set path = ( $HOME/.local/bin $path )'
+                    # tcsh caches what is on the path and will keep saying
+                    # "Command not found." until told to look again.
+                    RELOAD_HINT="run: rehash"
                     ;;
                 *) RC_FILE="$HOME/.profile" ;;
             esac
             if [ -n "$RC_FILE" ]; then
                 if prompt_yn "Add ~/.local/bin to PATH in $RC_FILE?"; then
                     echo "$PATH_LINE" >> "$RC_FILE"
-                    info "Added to $RC_FILE — restart your shell or run: source $RC_FILE"
+                    info "Added to $RC_FILE — $RELOAD_HINT"
                 else
-                    info "Skipped. You may need to add ~/.local/bin to your PATH manually."
+                    # Say exactly what to do, in the right syntax. "Add it
+                    # yourself" leaves csh users to discover that the obvious
+                    # export line does nothing.
+                    info "Skipped. Either use the full path $HOME/.local/bin/hle, or add:"
+                    info "    $PATH_LINE"
+                    info "  to $RC_FILE"
                 fi
             fi
             export PATH="$HOME/.local/bin:$PATH"

--- a/install.sh
+++ b/install.sh
@@ -21,6 +21,7 @@ AGENT=0
 AGENT_TOKEN=""
 INSTALL_SERVICE=1
 SERVICE_SCOPE=""   # "", "--user", or "--system"; empty lets the CLI auto-detect
+MODIFY_PATH=1      # every published instruction says to run `hle`; make it work
 
 usage() {
     cat <<'EOF'
@@ -32,6 +33,7 @@ Options:
   --token <token>   Agent enrollment token (hlea_...); implies --agent.
                     Without it, --agent prompts on the terminal.
   --no-service      With --agent: enroll only, don't install a service
+  --no-modify-path  Don't add ~/.local/bin to your shell's PATH
   --user            Install a per-user service (no sudo; needs linger on Linux)
   --system          Install a system-wide service (starts at boot; needs sudo)
   -h, --help        Show this help
@@ -49,6 +51,7 @@ while [ $# -gt 0 ]; do
         --token) AGENT_TOKEN="$2"; AGENT=1; shift 2 ;;
         --token=*) AGENT_TOKEN="${1#*=}"; AGENT=1; shift ;;
         --no-service) INSTALL_SERVICE=0; shift ;;
+        --no-modify-path) MODIFY_PATH=0; shift ;;
         --user) SERVICE_SCOPE="--user"; shift ;;
         --system) SERVICE_SCOPE="--system"; shift ;;
         -h|--help) usage; exit 0 ;;
@@ -160,18 +163,27 @@ ensure_local_bin() {
                     ;;
                 *) RC_FILE="$HOME/.profile" ;;
             esac
-            if [ -n "$RC_FILE" ]; then
-                if prompt_yn "Add ~/.local/bin to PATH in $RC_FILE?"; then
-                    echo "$PATH_LINE" >> "$RC_FILE"
-                    info "Added to $RC_FILE — $RELOAD_HINT"
+            # Written without asking. Every instruction we publish says to run
+            # `hle`, so an install that leaves it off PATH has not finished the
+            # job — and the prompt defaulted to No, which meant the common
+            # answer was the broken one. --no-modify-path opts out.
+            if [ "$MODIFY_PATH" -eq 1 ] && [ -n "$RC_FILE" ]; then
+                if [ -f "$RC_FILE" ] && grep -qF '.local/bin' "$RC_FILE" 2>/dev/null; then
+                    info "PATH already set up in $RC_FILE"
+                elif echo "$PATH_LINE" >> "$RC_FILE" 2>/dev/null; then
+                    info "Added ~/.local/bin to PATH in $RC_FILE"
+                    info "  For this shell: $RELOAD_HINT"
                 else
-                    # Say exactly what to do, in the right syntax. "Add it
-                    # yourself" leaves csh users to discover that the obvious
-                    # export line does nothing.
-                    info "Skipped. Either use the full path $HOME/.local/bin/hle, or add:"
-                    info "    $PATH_LINE"
-                    info "  to $RC_FILE"
+                    warn "Could not write $RC_FILE. Add this line yourself:"
+                    warn "    $PATH_LINE"
                 fi
+            elif [ "$MODIFY_PATH" -eq 0 ]; then
+                # Say exactly what to run, in the right syntax. "Add it
+                # yourself" leaves csh users to discover that the obvious
+                # export line does nothing.
+                info "Left PATH alone (--no-modify-path). Use $HOME/.local/bin/hle, or add:"
+                info "    $PATH_LINE"
+                info "  to $RC_FILE"
             fi
             export PATH="$HOME/.local/bin:$PATH"
             ;;
@@ -285,6 +297,18 @@ setup_agent() {
         error "Agent enrollment failed. The client is installed; you can retry with:"
         error "  hle agent enroll"
         error "  hle service install --agent"
+        exit 1
+    fi
+
+    # Confirm a token actually landed before installing anything that depends
+    # on one. A service started without a token does not fail — it respawns
+    # forever, logging "No agent token" while `service ... status` reports a
+    # healthy pid, so the install looks successful and the agent never
+    # connects. Better to stop here and say so.
+    if ! hle agent status >/dev/null 2>&1; then
+        error "Enrollment reported success but no agent token is readable."
+        error "Not installing the service: it would restart forever without one."
+        error "Retry with:  hle agent enroll"
         exit 1
     fi
     success "Agent enrolled."

--- a/src/hle_client/agent.py
+++ b/src/hle_client/agent.py
@@ -13,6 +13,7 @@ import asyncio
 import contextlib
 import json
 import logging
+import os
 import tomllib
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -46,28 +47,46 @@ WS_MAX_MESSAGE_SIZE = 4 * 1024 * 1024
 AGENT_CONFIG_PATH = Path.home() / ".config" / "hle" / "agent.toml"
 AGENT_TOKEN_PREFIX = "hlea_"
 
+# Set by `hle service install --agent` to the file the token was actually found
+# in, so the service does not have to reconstruct the path from HOME. A service
+# manager starts processes with an environment of its own choosing: on pfSense
+# the agent enrolls as `admin` and runs from rc.d, and if those two disagree
+# about HOME the token is written to one path and read from another. The agent
+# then restarts forever reporting "No agent token" while the file it needs is
+# sitting on disk. An absolute path removes the guesswork.
+AGENT_CONFIG_ENV = "HLE_AGENT_CONFIG"
+
+
+def agent_config_path() -> Path:
+    """The token file to read or write, honouring an explicit override."""
+    override = os.environ.get(AGENT_CONFIG_ENV)
+    return Path(override).expanduser() if override else AGENT_CONFIG_PATH
+
 
 def save_agent_token(token: str) -> None:
     """Persist the agent enrollment token (0600)."""
-    AGENT_CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-    AGENT_CONFIG_PATH.write_text(f'token = "{token}"\n')
-    AGENT_CONFIG_PATH.chmod(0o600)
+    path = agent_config_path()
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    path.write_text(f'token = "{token}"\n')
+    path.chmod(0o600)
 
 
 def load_agent_token() -> str | None:
-    if not AGENT_CONFIG_PATH.exists():
+    path = agent_config_path()
+    if not path.exists():
         return None
     try:
-        with open(AGENT_CONFIG_PATH, "rb") as f:
+        with open(path, "rb") as f:
             return tomllib.load(f).get("token")
     except (OSError, ValueError):
-        logger.debug("Failed to read agent token from %s", AGENT_CONFIG_PATH)
+        logger.debug("Failed to read agent token from %s", path)
         return None
 
 
 def remove_agent_token() -> bool:
-    if AGENT_CONFIG_PATH.exists():
-        AGENT_CONFIG_PATH.unlink()
+    path = agent_config_path()
+    if path.exists():
+        path.unlink()
         return True
     return False
 

--- a/src/hle_client/cli.py
+++ b/src/hle_client/cli.py
@@ -442,6 +442,10 @@ def agent_status() -> None:
         console.print(f"Token: [dim]{masked}[/dim]")
     else:
         console.print("[dim]No agent token configured. Run 'hle agent enroll'.[/dim]")
+        # Non-zero so a script can act on it. Without this the installer could
+        # confirm enrollment "succeeded", install a service, and leave it
+        # restarting forever on a missing token.
+        raise SystemExit(1)
 
 
 @agent.command("list")

--- a/src/hle_client/service_cmd.py
+++ b/src/hle_client/service_cmd.py
@@ -235,6 +235,7 @@ def render_unit(
     run_args: list[str],
     user_mode: bool,
     run_as_user: str | None,
+    agent_config: str | None = None,
     description: str | None = None,
     restart: str = "on-failure",
 ) -> str:
@@ -252,6 +253,11 @@ def render_unit(
         f"Restart={restart}",
         "RestartSec=5",
     ]
+    # The token file by absolute path, resolved while running as whoever
+    # enrolled. A system unit runs as root with its own HOME, so deriving the
+    # path at runtime finds the wrong one whenever those differ.
+    if agent_config:
+        lines.append(f"Environment=HLE_AGENT_CONFIG={agent_config}")
     # System units run as root by default; pin an explicit user when asked so
     # the tunnel reads that user's ~/.config/hle/config.toml (API key).
     if not user_mode and run_as_user:
@@ -291,12 +297,14 @@ def _systemd_install(
     start: bool,
     description: str | None = None,
     restart: str = "on-failure",
+    agent_config: str | None = None,
 ) -> None:
     run_as_user = run_as or (None if user_mode else getpass.getuser())
     unit = render_unit(
         label=label,
         hle_path=find_hle_path(),
         run_args=run_args,
+        agent_config=agent_config,
         user_mode=user_mode,
         run_as_user=run_as_user,
         description=description,
@@ -369,6 +377,7 @@ def render_launchd_plist(
     run_args: list[str],
     run_as_user: str | None,
     log_dir: str,
+    agent_config: str | None = None,
 ) -> str:
     """Render a launchd plist. Pure function (unit-testable).
 
@@ -398,6 +407,17 @@ def render_launchd_plist(
     ]
     if run_as_user:
         lines += ["    <key>UserName</key>", f"    <string>{_xml_escape(run_as_user)}</string>"]
+    # The token file by absolute path. launchd hands a daemon its own
+    # environment, so deriving the path from HOME at runtime can resolve
+    # somewhere the enrolling user never wrote to.
+    if agent_config:
+        lines += [
+            "    <key>EnvironmentVariables</key>",
+            "    <dict>",
+            "        <key>HLE_AGENT_CONFIG</key>",
+            f"        <string>{_xml_escape(agent_config)}</string>",
+            "    </dict>",
+        ]
     lines += [
         "    <key>StandardOutPath</key>",
         f"    <string>{_xml_escape(out_log)}</string>",
@@ -438,6 +458,7 @@ def _launchd_install(
     user_mode: bool,
     run_as: str | None,
     start: bool,
+    agent_config: str | None = None,
 ) -> None:
     # Per-user agents run as the invoking user already; only system daemons
     # need an explicit UserName so the tunnel reads that user's config.
@@ -450,6 +471,7 @@ def _launchd_install(
         run_args=run_args,
         run_as_user=run_as_user,
         log_dir=_launchd_log_dir(user_mode),
+        agent_config=agent_config,
     )
     path = _launchd_dir(user_mode) / f"{plabel}.plist"
     try:
@@ -538,6 +560,7 @@ def render_rc_script(
     run_args: list[str],
     run_as_user: str | None = None,
     home: str | None = None,
+    agent_config: str | None = None,
     name: str | None = None,
     description: str | None = None,
     restart: bool = True,
@@ -579,6 +602,11 @@ def render_rc_script(
         f': ${{{svc}_user:="{user}"}}',
         # Overridable via sysrc, e.g. after moving the config to another user.
         f": ${{{svc}_home:={_rc_quote(home_dir)}}}",
+        # The token file as found at install time, by absolute path. HOME alone
+        # was not enough: enrolment and the service can run with different
+        # environments, and then the agent restarts forever looking for a file
+        # that exists somewhere else.
+        f": ${{{svc}_config:={_rc_quote(agent_config or '')}}}",
         "",
         'pidfile="/var/run/${name}.pid"',
         'logfile="/var/log/${name}.log"',
@@ -590,6 +618,7 @@ def render_rc_script(
         # env(1) supplies HOME because rc.d does not.
         f'command_args="{daemon_flags} -P ${{pidfile}} -p /var/run/${{name}}.child.pid '
         f"-o ${{logfile}} /usr/bin/env HOME=${{{svc}_home}} "
+        f"HLE_AGENT_CONFIG=${{{svc}_config}} "
         f'${{hle_command}} {args}"',
         'procname="/usr/sbin/daemon"',
         "",
@@ -630,6 +659,7 @@ def _rcd_install(
     start: bool,
     description: str | None = None,
     restart: bool = True,
+    agent_config: str | None = None,
 ) -> None:
     svc = rc_service_name(label, name)
     script = render_rc_script(
@@ -637,6 +667,7 @@ def _rcd_install(
         hle_path=find_hle_path(),
         run_args=run_args,
         run_as_user=run_as,
+        agent_config=agent_config,
         name=name,
         description=description,
         restart=restart,
@@ -861,6 +892,20 @@ def install(
         description = f"HLE tunnel: {label}"
         restart = "on-failure"
 
+    # Resolve the token file here, while still running as the user who enrolled,
+    # and hand the service an absolute path. Deriving it later from whatever
+    # environment the service manager supplies is what left agents restarting
+    # forever next to a token file they could not see.
+    from hle_client.agent import agent_config_path
+
+    agent_config = str(agent_config_path()) if agent_mode else None
+    if agent_mode and not Path(str(agent_config)).exists():
+        console.print(
+            f"[yellow]No agent token at {agent_config}.[/yellow] "
+            "The service will start and immediately exit until you run "
+            "[cyan]hle agent enroll <token>[/cyan]."
+        )
+
     if plat == "freebsd":
         _rcd_reject_user_mode(user_mode)
         _rcd_install(
@@ -871,6 +916,7 @@ def install(
             start=start,
             description=description,
             restart=restart != "no",
+            agent_config=agent_config,
         )
     elif plat == "darwin":
         _launchd_install(
@@ -880,6 +926,7 @@ def install(
             user_mode=user_mode,
             run_as=run_as,
             start=start,
+            agent_config=agent_config,
         )
     else:
         _systemd_install(
@@ -891,6 +938,7 @@ def install(
             start=start,
             description=description,
             restart=restart,
+            agent_config=agent_config,
         )
 
     if agent_mode:
@@ -952,6 +1000,19 @@ def status(
         _launchd_status(label=label, name=name, user_mode=user_mode)
     else:
         _systemd_status(label=label, name=name, user_mode=user_mode)
+
+    # A service manager reports on a process, not on whether it works. An agent
+    # with no token exits immediately and is restarted forever, so "running as
+    # pid 87998" is true, reassuring, and useless. Say the part it cannot know.
+    if agent_mode:
+        from hle_client.agent import load_agent_token
+
+        if not os.environ.get("HLE_AGENT_TOKEN") and load_agent_token() is None:
+            console.print(
+                "\n[yellow]No agent token is configured[/yellow] — if the service is "
+                "running it is restarting in a loop."
+            )
+            console.print("Fix with: [cyan]hle agent enroll <token>[/cyan], then restart it.")
 
 
 @service.command("list")

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -469,11 +469,17 @@ class TestAgentCli:
         assert "Invalid agent token" in result.output
 
     def test_status_no_token(self, tmp_path: Path) -> None:
+        """Exits non-zero, so a script can tell enrolled from not.
+
+        This used to exit 0, which is how the installer could confirm
+        enrollment "worked", install a service, and leave it restarting
+        forever on a token that was never saved.
+        """
         runner = CliRunner()
         cfg = tmp_path / "missing.toml"
         with patch("hle_client.agent.AGENT_CONFIG_PATH", cfg):
             result = runner.invoke(main, ["agent", "status"])
-        assert result.exit_code == 0
+        assert result.exit_code == 1
         assert "No agent token" in result.output
 
     def test_run_requires_token(self, tmp_path: Path) -> None:

--- a/tests/unit/test_service_rcd.py
+++ b/tests/unit/test_service_rcd.py
@@ -120,6 +120,28 @@ class TestRenderRcScript:
         script = self._script(home="/root")
         assert script.index("/usr/bin/env HOME=") < script.index("${hle_command}")
 
+    def test_token_file_is_passed_by_absolute_path(self):
+        """HOME alone was not enough.
+
+        Enrollment and the service can run with different environments — on
+        pfSense the agent enrolls as ``admin`` and runs from rc.d — and then
+        the token is written to one path and read from another. The agent
+        restarts forever reporting "No agent token" while the file sits on
+        disk. The path is resolved at install time and passed explicitly.
+        """
+        script = self._script(agent_config="/root/.config/hle/agent.toml")
+        assert ": ${hle_agent_config:='/root/.config/hle/agent.toml'}" in script
+        assert "HLE_AGENT_CONFIG=${hle_agent_config}" in script
+
+    def test_token_path_is_quoted(self):
+        script = self._script(agent_config="/home/user with space/agent.toml")
+        assert ": ${hle_agent_config:='/home/user with space/agent.toml'}" in script
+
+    def test_no_token_path_leaves_the_default_in_charge(self):
+        """An empty value must not override the agent's own default."""
+        script = self._script()
+        assert ": ${hle_agent_config:=''}" in script
+
     def test_home_defaults_to_the_installing_users_home(self):
         script = self._script()
         assert f": ${{hle_agent_home:='{Path.home()}'}}" in script


### PR DESCRIPTION
## Summary

Found by a real user on pfSense 26.03: the agent installed, reported success, and left a service restarting every few seconds logging `No agent token` — while `/root/.config/hle/agent.toml` sat on disk, 56 bytes, mode 0600.

Confirmed end to end on his box:

```
$ grep home /usr/local/etc/rc.d/hle_agent      # nothing — no HOME at all
$ env HOME=/root /root/.local/bin/hle agent run
Agent registered: public_id=f950ad88-… endpoints=0
```

**The fix for that already exists in `main` (#118) and has never been released.** `get.hle.world` still serves 2608.2, so every FreeBSD install today hits it. That makes a release the real deliverable here.

## The deeper fix

Setting `HOME` treats the symptom. Enrollment and the service can run under different environments — on pfSense you enroll as `admin` and the service starts from rc.d — and any path derived from `HOME` can disagree between the two.

So the token file is now resolved **at install time**, while still running as whoever enrolled, and passed to the service as an absolute path via `HLE_AGENT_CONFIG`:

- **rc.d** — `: ${hle_agent_config:='…'}` plus `HLE_AGENT_CONFIG=` in the `env(1)` wrapper, overridable with `sysrc`
- **systemd** — `Environment=HLE_AGENT_CONFIG=…`
- **launchd** — an `EnvironmentVariables` dict

`agent_config_path()` honours the variable for read, write and delete, so `enroll`, `run` and `logout` all agree on one file.

## Why it stayed invisible

Three separate things reported success over a broken agent:

| | Before | Now |
|---|---|---|
| `hle agent status` | exit 0 with no token | exits 1 — scripts can tell |
| `hle service status --agent` | "running as pid 87998" during a crash loop | says when no token is configured |
| installer | installed a service after enrollment silently failed | verifies a token exists first, refuses otherwise |

## Also: the PATH prompt was wrong on the platform it named

The installer offered `Add ~/.local/bin to PATH in /root/.profile?` **on a tcsh box**, where `.profile` is never read. Answering yes would have written the file, reported success, and changed nothing.

`$SHELL` is the login shell from `/etc/passwd`. pfSense's `admin` account has `/etc/rc.initial` — the console menu — which execs tcsh without updating `$SHELL`, so `basename` gave `rc.initial` and fell through to the default. It now asks the parent process whenever `$SHELL` isn't a shell it recognises.

PATH is also now configured **without asking**: every instruction we publish says to run `hle`, so an install that leaves it off PATH hasn't finished the job — and the prompt defaulted to No, making the broken answer the likely one. `--no-modify-path` opts out.

## Verification

496 passing. One pre-existing failure, `TestAgentList::test_json_output_is_machine_readable`, which fails identically on unmodified `main` under Python 3.14 and passes in CI on 3.11–3.13 — tracked separately, not from this change.

New tests cover the token path reaching the rc.d script, its quoting, and the empty case leaving the agent's own default in charge.