### PR TITLE
Set safe.directory before git touches the repo

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -39,10 +39,15 @@ jobs:
           REPO: ${{ github.repository }}
           SHA: ${{ github.event.pull_request.merge_commit_sha }}
         run: |
+          # safe.directory FIRST. The container runs as a different uid than
+          # the workspace owner, so git refuses to touch the repo with
+          # "detected dubious ownership" — and it refuses at checkout, which
+          # is before the line that used to set this. The clone appeared to
+          # work and the job died on the next command.
+          git config --global --add safe.directory "$PWD"
           git clone --no-checkout \
             "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" .
           git checkout --detach "$SHA"
-          git config --global --add safe.directory "$PWD"
 
       - name: Extract and validate version
         run: |


### PR DESCRIPTION
## Summary

My checkout rewrite in #120 broke the first release that used it. The clone succeeded, then `git checkout` failed:

```
fatal: detected dubious ownership in repository at '/__w/hle-client/hle-client'
```

The container runs as a different uid than the workspace owner, so git refuses to operate on the repo until the path is marked safe. I put `git config --global --add safe.directory "$PWD"` **after** the checkout — the order it reads, not the order it runs.

Result: v2608.3 merged and never published.

## The part that worked

The `verify` job did exactly what it was added for — noticed no release existed and opened hle-world/hle-client#123 rather than letting the release disappear quietly. That failure mode is what #120 was about, and it held.

## Fix

`safe.directory` first, then clone, then checkout.

v2608.3 is being published separately via the documented `--tag` fallback, since re-running the failed job would use the workflow file from the merge commit — which still has the bug.