### PR TITLE
hle update offers to restart what it just made stale

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -21,6 +21,7 @@ AGENT=0
 AGENT_TOKEN=""
 INSTALL_SERVICE=1
 SERVICE_SCOPE=""   # "", "--user", or "--system"; empty lets the CLI auto-detect
+SYSTEM_LINK=""     # set when hle was linked into a directory already on PATH
 MODIFY_PATH=1      # every published instruction says to run `hle`; make it work
 
 usage() {
@@ -126,6 +127,12 @@ ensure_local_bin() {
     case ":$PATH:" in
         *":$HOME/.local/bin:"*) ;;
         *)
+            # Already reachable from a system directory, so there is nothing to
+            # add and no shell to guess at.
+            if [ -n "${SYSTEM_LINK:-}" ]; then
+                export PATH="$HOME/.local/bin:$PATH"
+                return 0
+            fi
             SHELL_NAME=$(basename "${SHELL:-}" 2>/dev/null || echo "")
             # $SHELL is the login shell from /etc/passwd, which is not always
             # the shell you are typing into. pfSense's admin account has
@@ -242,8 +249,41 @@ install_with_venv() {
     verify_install "$VENV_DIR/bin/python"
 
     # Symlink the hle binary
-    ensure_local_bin
+    mkdir -p "$HOME/.local/bin"
     ln -sf "$VENV_DIR/bin/hle" "$HOME/.local/bin/hle"
+    link_into_system_path "$VENV_DIR/bin/hle"
+    ensure_local_bin
+}
+
+# Put hle somewhere already on PATH, rather than trusting a shell rc file.
+#
+# Editing an rc file is a guess about which shell will read it, and on FreeBSD
+# firewalls the guess was wrong: pfSense and OPNsense give root csh/tcsh, which
+# never reads .profile, so the install reported success and `hle` was still not
+# found. A symlink in a directory that is already on the default PATH needs no
+# guess and works in every shell, including the console menu's.
+link_into_system_path() {
+    target="$1"
+    # Root only: writing outside $HOME as a normal user is not ours to do.
+    [ "$(id -u)" -eq 0 ] || return 0
+    for d in /usr/local/bin /usr/bin; do
+        case ":$PATH:" in
+            *":$d:"*) ;;
+            *) continue ;;
+        esac
+        [ -d "$d" ] && [ -w "$d" ] || continue
+        # Never clobber something we did not put there.
+        if [ -e "$d/hle" ] && [ ! -L "$d/hle" ]; then
+            warn "$d/hle exists and is not a symlink — leaving it alone."
+            return 0
+        fi
+        if ln -sf "$target" "$d/hle" 2>/dev/null; then
+            info "Linked $d/hle — available in every shell, no PATH change needed"
+            SYSTEM_LINK="$d/hle"
+            return 0
+        fi
+    done
+    return 0
 }
 
 # --- Agent setup ---
@@ -367,6 +407,12 @@ main() {
     if command -v hle >/dev/null 2>&1; then
         success "HLE client installed successfully!"
         info "Version: $(hle --version)"
+        # csh/tcsh cache the executables on PATH and keep reporting a new one
+        # as missing until told to look again. pfSense and OPNsense both give
+        # root tcsh, so this is the common case on a firewall.
+        case "$(basename "${SHELL:-}" 2>/dev/null)" in
+            csh|tcsh) info "In this shell, run 'rehash' first so it finds hle." ;;
+        esac
     else
         success "HLE client installed. Restart your shell or run:"
         info "  export PATH=\"\$HOME/.local/bin:\$PATH\""

--- a/install.sh
+++ b/install.sh
@@ -96,10 +96,13 @@ detect_os() {
     esac
 }
 
-# FreeBSD (and therefore pfSense/OPNsense) ships no Python by default, but every
-# dependency is pure Python as of 2608.2, so pip can install them from PyPI with
-# no compiler involved. The interpreter is the only prerequisite.
-FREEBSD_PKGS="python311"
+# Any 3.11+ interpreter will do, and which one is available differs by
+# platform: pfSense 2.7 carries python311 as a dependency of unbound, while
+# OPNsense ships python313 and has no python311 package at all. So never name a
+# version — suggest the meta-package and a search, or the advice is wrong on
+# somebody's box. Every dependency is pure Python as of 2608.2, so pip needs no
+# compiler; the interpreter is the only prerequisite.
+FREEBSD_PKGS="python3"
 
 # Find Python 3.11+
 find_python() {
@@ -331,6 +334,10 @@ main() {
             error "Python ${MIN_PYTHON_MAJOR}.${MIN_PYTHON_MINOR}+ is required but not found."
             echo ""
             echo "    pkg install $FREEBSD_PKGS"
+            echo ""
+            echo "  If that package does not exist on this system, find one that does:"
+            echo ""
+            echo "    pkg search '^python3'"
             echo ""
             exit 1
         }

--- a/src/hle_client/service_cmd.py
+++ b/src/hle_client/service_cmd.py
@@ -728,6 +728,70 @@ def _rcd_list() -> None:
         console.print(svc)
 
 
+# --------------------------------------------------------------------------- #
+# Enumerate and restart, for `hle update`
+# --------------------------------------------------------------------------- #
+def installed_services() -> list[str]:
+    """Every hle service installed on this machine, as its manager names it.
+
+    Used by ``hle update``: a client upgraded underneath a running service is
+    still the old code in memory, and the only sign is a version that never
+    changes. Knowing what is installed lets the upgrade offer to restart it
+    instead of printing advice the user has to act on later.
+    """
+    plat = current_platform()
+    if plat == "freebsd":
+        if not _RCD_DIR.exists():
+            return []
+        return sorted(p.name for p in _RCD_DIR.glob("hle_*"))
+    if plat == "darwin":
+        result = subprocess.run(  # noqa: S603 — argv built internally
+            ["launchctl", "list"], check=False, capture_output=True, text=True
+        )
+        return sorted(
+            ln.split()[-1] for ln in result.stdout.splitlines() if _LAUNCHD_LABEL_PREFIX in ln
+        )
+    result = subprocess.run(  # noqa: S603 — argv built internally
+        ["systemctl", "list-units", "--type=service", "--all", "--plain", "--no-legend", "hle-*"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    units = [ln.split()[0] for ln in result.stdout.splitlines() if ln.strip()]
+    if units:
+        return sorted(units)
+    # Fall back to per-user units, which a non-root install uses.
+    result = subprocess.run(  # noqa: S603 — argv built internally
+        [
+            "systemctl",
+            "--user",
+            "list-units",
+            "--type=service",
+            "--all",
+            "--plain",
+            "--no-legend",
+            "hle-*",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return sorted(ln.split()[0] for ln in result.stdout.splitlines() if ln.strip())
+
+
+def restart_service(name: str) -> bool:
+    """Restart one service by the name ``installed_services()`` returned."""
+    plat = current_platform()
+    if plat == "freebsd":
+        return _service_cmd(name, "restart").returncode == 0
+    if plat == "darwin":
+        domain = "system" if os.geteuid() == 0 else f"gui/{os.getuid()}"
+        return _launchctl("kickstart", "-k", f"{domain}/{name}").returncode == 0
+    if _systemctl(False, "restart", name).returncode == 0:
+        return True
+    return _systemctl(True, "restart", name).returncode == 0
+
+
 def _resolve_label(label: str | None, agent_mode: bool) -> str:
     """Resolve the label for uninstall/status: --agent implies the agent label."""
     if label:
@@ -1013,6 +1077,47 @@ def status(
                 "running it is restarting in a loop."
             )
             console.print("Fix with: [cyan]hle agent enroll <token>[/cyan], then restart it.")
+
+
+@service.command("restart")
+@click.option("--agent", "agent_mode", is_flag=True, default=False, help="Target the agent service")
+@click.option("--label", default=None, help="Service label")
+@click.option("--name", default=None, help="Explicit unit/plist name")
+@click.option("--all", "restart_all", is_flag=True, default=False, help="Restart every hle service")
+def restart(agent_mode: bool, label: str | None, name: str | None, restart_all: bool) -> None:
+    """Restart a background service, or all of them with --all.
+
+    Exists because there was no way to do this through the CLI: the docs told
+    people to reach for systemctl or service(8) directly, which differs per
+    platform and is the sort of detail a tool should absorb.
+    """
+    _require_supported()
+    if restart_all:
+        services = installed_services()
+        if not services:
+            console.print("No hle services installed.")
+            return
+        failed = [svc for svc in services if not restart_service(svc)]
+        for svc in services:
+            mark = "[red]failed[/red]" if svc in failed else "[green]restarted[/green]"
+            console.print(f"{svc}: {mark}")
+        if failed:
+            raise SystemExit(1)
+        return
+
+    plat = current_platform()
+    label = _resolve_label(label, agent_mode)
+    if plat == "freebsd":
+        svc = rc_service_name(label, name)
+    elif plat == "darwin":
+        svc = launchd_label(label, name)
+    else:
+        svc = unit_name(label, name)
+    if restart_service(svc):
+        console.print(f"[green]Restarted[/green] {svc}")
+    else:
+        console.print(f"[red]Could not restart[/red] {svc}")
+        raise SystemExit(1)
 
 
 @service.command("list")

--- a/src/hle_client/update_cmd.py
+++ b/src/hle_client/update_cmd.py
@@ -143,7 +143,42 @@ def update(check: bool, target_version: str | None, yes: bool) -> None:
 
     new_version = _installed_version(sys.executable) or "unknown"
     console.print(f"[green]Updated to {new_version}.[/green]")
-    console.print(
-        "[yellow]Restart any running tunnels[/yellow] so they pick up the new version "
-        "(e.g. restart the systemd service, or stop and re-run 'hle expose ...')."
-    )
+
+    # A service started before the upgrade is still running the old code, and
+    # nothing about it looks wrong — `hle --version` reports the new one while
+    # the process serving traffic is the previous release. Telling people to
+    # "restart any running tunnels" left that gap open until they acted on it.
+    from hle_client.service_cmd import installed_services, restart_service
+
+    try:
+        services = installed_services()
+    except Exception:
+        services = []
+
+    if not services:
+        console.print(
+            "[dim]No hle services installed. Restart anything you started by hand "
+            "(e.g. re-run 'hle expose ...') so it picks up the new version.[/dim]"
+        )
+        return
+
+    listed = ", ".join(services)
+    console.print(f"Still running the previous version: [bold]{listed}[/bold]")
+    if not (yes or click.confirm(f"Restart {len(services)} service(s) now?", default=True)):
+        console.print("[yellow]Left running the old version.[/yellow] Restart later with:")
+        console.print("  hle service restart --all")
+        return
+
+    failed = []
+    for svc in services:
+        if restart_service(svc):
+            console.print(f"  [green]restarted[/green] {svc}")
+        else:
+            failed.append(svc)
+            console.print(f"  [red]failed[/red] {svc}")
+    if failed:
+        console.print(
+            "[yellow]Some services did not restart.[/yellow] They are still on the old "
+            "version — check 'hle service status --agent' and the service log."
+        )
+        raise SystemExit(1)

--- a/tests/unit/test_update_restart.py
+++ b/tests/unit/test_update_restart.py
@@ -1,0 +1,68 @@
+"""`hle update` offers to restart what it just made stale.
+
+An upgrade replaces the code on disk, not the process already running it. The
+service keeps serving the previous release while `hle --version` reports the new
+one, so nothing looks wrong. Printing "restart any running tunnels" left that
+gap open until somebody acted on it.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from hle_client.cli import main
+
+
+class TestUpdateRestartsServices:
+    def _run(self, services, confirm_reply, restart_ok=True, extra_args=()):
+        runner = CliRunner()
+        with (
+            patch("hle_client.update_cmd.pypi_latest_version", return_value="9999.1"),
+            patch("hle_client.update_cmd.detect_install_method", return_value="venv"),
+            patch("hle_client.update_cmd.subprocess.run") as mock_run,
+            patch("hle_client.update_cmd._installed_version", return_value="9999.1"),
+            patch("hle_client.service_cmd.installed_services", return_value=services),
+            patch("hle_client.service_cmd.restart_service", return_value=restart_ok) as restart,
+        ):
+            mock_run.return_value.returncode = 0
+            result = runner.invoke(main, ["update", *extra_args], input=confirm_reply)
+        return result, restart
+
+    def test_offers_to_restart_and_does_it(self):
+        result, restart = self._run(["hle_agent"], confirm_reply="y\ny\n")
+        assert result.exit_code == 0, result.output
+        assert "Still running the previous version" in result.output
+        restart.assert_called_once_with("hle_agent")
+        assert "restarted" in result.output
+
+    def test_declining_says_how_to_do_it_later(self):
+        """Not restarting is a valid choice, but it must not be a silent one."""
+        result, restart = self._run(["hle_agent"], confirm_reply="y\nn\n")
+        assert result.exit_code == 0, result.output
+        assert "hle service restart --all" in result.output
+        restart.assert_not_called()
+
+    def test_yes_flag_restarts_without_asking(self):
+        result, restart = self._run([], confirm_reply="", extra_args=("--yes",))
+        assert result.exit_code == 0, result.output
+        restart.assert_not_called()  # nothing installed to restart
+
+    def test_restarts_every_installed_service(self):
+        result, restart = self._run(["hle_agent", "hle_jellyfin"], confirm_reply="y\ny\n")
+        assert result.exit_code == 0, result.output
+        assert restart.call_count == 2
+
+    def test_a_failed_restart_is_loud(self):
+        """Otherwise the old version keeps serving and the upgrade looks done."""
+        result, _ = self._run(["hle_agent"], confirm_reply="y\ny\n", restart_ok=False)
+        assert result.exit_code == 1
+        assert "failed" in result.output
+        assert "still on the old" in result.output
+
+    def test_no_services_explains_the_manual_case(self):
+        result, restart = self._run([], confirm_reply="y\n")
+        assert result.exit_code == 0, result.output
+        assert "No hle services installed" in result.output
+        restart.assert_not_called()


### PR DESCRIPTION
## Summary

An upgrade replaces the code on disk, not the process already running it. A service started before `hle update` keeps serving the previous release while `hle --version` reports the new one — so nothing looks wrong. The old advice, *"Restart any running tunnels"*, left that gap open until somebody acted on it.

`hle update` now:

- lists the services still running the old version
- offers to restart them (defaults to yes; `--yes` skips the prompt)
- prints `hle service restart --all` if you decline, so the choice isn't a dead end
- **exits non-zero if a restart fails**, saying the service is still on the old version — a silent failure here means traffic keeps being served by code you believe you replaced

## Adds `hle service restart`

It didn't exist. The docs told people to use `systemctl restart` or `service hle_agent restart` directly — which differs per platform and is exactly the detail a tool should absorb. `--all` restarts every hle service. `hle update` reuses it via `installed_services()` / `restart_service()`, which enumerate rc.d scripts, launchd labels, or systemd units (system, then per-user) depending on the platform.

## Also: stop naming a Python version

From a real OPNsense install:

```
root@OPNsense:~ # pkg install python311
pkg: No packages available to install matching 'python311' have been found
root@OPNsense:~ # fetch -o - https://get.hle.world | sh -s -- --agent
[hle] Found Python: python3.13 (Python 3.13.14)
```

pfSense 2.7 carries `python311` as an `unbound` dependency; OPNsense ships `python313` and has no `python311` at all. The installer's "not found" message named `python311` regardless, which is wrong on any box that doesn't happen to have that version.

It now suggests the `python3` meta-package and, failing that, `pkg search '^python3'` to find whatever the system does offer. Naming one version guarantees the advice is wrong somewhere.

## Verification

502 passing, plus 6 new tests: restart offered and performed, declining printing the follow-up command, `--yes`, multiple services, a failed restart exiting non-zero, and the no-services case explaining the manual path.

The single failure is the pre-existing `test_json_output_is_machine_readable` under Python 3.14 — fails identically on `main`, green in CI on 3.11–3.13, tracked separately.