### PR TITLE
Release v2608.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,29 @@
 
 ## v2608.4 — 2026-08-05
 
-<!-- TODO: Fill in release notes before merging -->
+### Fixed
+
+- **`hle` is now on the path on pfSense and OPNsense.** The installer wrote
+  `~/.local/bin` into a shell startup file, which pfSense's `tcsh` root login
+  never read — so `hle: Command not found.` immediately after an install that
+  reported success. When running as root the installer now also symlinks
+  `/usr/local/bin/hle`, which is on the default path for every shell on the
+  system and survives changing shells. An existing non-symlink at that path is
+  left alone rather than clobbered. The startup-file edit remains as the
+  fallback for non-root installs, with `--no-modify-path` to skip it.
+
+### Added
+
+- **`hle update` offers to restart what it just made stale.** Upgrading replaces
+  the code on disk, not the process already running it: the service kept serving
+  the previous release while `hle --version` reported the new one, and nothing
+  looked wrong. `update` now lists the installed services and offers to restart
+  them, defaulting to yes. Declining prints the command to do it later; a
+  restart that fails exits non-zero and says the old version is still serving,
+  rather than reporting a successful upgrade.
+
+- **`hle service restart [--all]`**, so restarting doesn't mean knowing the
+  platform's own service manager and the generated unit's name.
 
 ## v2608.3 — 2026-08-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2608.4 — 2026-08-05
+
+<!-- TODO: Fill in release notes before merging -->
+
 ## v2608.3 — 2026-08-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ curl -fsSL https://get.hle.world | sh
 Installs via pipx (preferred), uv, or pip-in-venv. Supports `--version`:
 
 ```bash
-curl -fsSL https://get.hle.world | sh -s -- --version 2608.3
+curl -fsSL https://get.hle.world | sh -s -- --version 2608.4
 ```
 
 ### pipx
@@ -93,7 +93,7 @@ and runs the right upgrade.
 ```bash
 hle update            # upgrade to the latest release
 hle update --check    # just report current vs. latest, don't change anything
-hle update --version 2608.3   # pin an exact version
+hle update --version 2608.4   # pin an exact version
 ```
 
 After updating, restart any running tunnels (e.g. `systemctl restart hle-<label>`)

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 #
 # Usage:
 #   curl -fsSL https://get.hle.world | sh
-#   curl -fsSL https://get.hle.world | sh -s -- --version 2608.3
+#   curl -fsSL https://get.hle.world | sh -s -- --version 2608.4
 #
 #   # Install the agent and run it as a service (prompts for the token):
 #   curl -fsSL https://get.hle.world | sh -s -- --agent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hle-client"
-version = "2608.3"
+version = "2608.4"
 description = "HomeLab Everywhere — Expose homelab services to the internet with built-in SSO"
 readme = "README.md"
 license = "MIT"

--- a/src/hle_client/__init__.py
+++ b/src/hle_client/__init__.py
@@ -1,3 +1,3 @@
 """HLE Client — HomeLab Everywhere tunnel client."""
 
-__version__ = "2608.3"
+__version__ = "2608.4"


### PR DESCRIPTION
Bump version to `2608.4` and update all version references.

When this PR is merged, a GitHub release will be created automatically,
which triggers PyPI publish and Homebrew formula update.