### PR TITLE
Docker discovery reported addresses the agent could not reach

### DIFF
--- a/src/hle_client/discovery/docker.py
+++ b/src/hle_client/discovery/docker.py
@@ -3,6 +3,19 @@
 Talks to the Docker Engine API over its Unix socket using httpx (already a
 dependency), rather than pulling in the Docker SDK for two read-only calls.
 
+Addressing is the hard part, and it is not a property of the container: it
+depends on where *this agent* runs. A container name only resolves through
+Docker's embedded DNS at ``127.0.0.11``, which exists solely inside a container
+attached to the same user-defined network. An agent installed on the host — pipx,
+a venv, pfSense — has no such resolver, so ``http://jellyfin:8096`` is NXDOMAIN
+and every discovered service fails to expose.
+
+So rather than guess one address, each container produces a ladder of candidates
+and we report the first that actually answers a TCP connect. Where the agent
+lives decides the *order* only; the probe decides the answer. That way being
+wrong about the environment costs a few hundred milliseconds instead of handing
+the dashboard a URL that cannot work.
+
 Security note: the Docker socket is root-equivalent on the host — anything that
 can *write* to it can start a privileged container. This provider only ever
 reads (``GET /containers/json``), and the socket should be mounted read-only,
@@ -11,9 +24,13 @@ but mounting it at all is a real trust decision. Discovery stays opt-in.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 import httpx
 
@@ -30,14 +47,52 @@ API_VERSION = "v1.41"
 # confusing loop, and infra sidecars are noise.
 _SKIP_IMAGE_PREFIXES = ("ghcr.io/hle-world/", "hle-server", "hle-docker")
 
+# One candidate's connect attempt. Short: these are LAN or loopback addresses,
+# and the common failure (NXDOMAIN, connection refused) returns immediately —
+# the timeout only bounds the case where a firewall blackholes the packet.
+PROBE_TIMEOUT = 0.4
+# Probing is per-candidate but containers go in parallel, so this caps the file
+# descriptors and DNS lookups in flight on a host running a hundred containers.
+PROBE_CONCURRENCY = 20
+# The whole probe phase, well inside the caller's 15s SCAN_TIMEOUT. Blowing that
+# budget would discard the entire scan; overrunning this one only falls back to
+# reporting unprobed best guesses.
+PROBE_BUDGET = 10.0
+
+# Bind addresses that mean "every interface" rather than somewhere to connect to.
+_WILDCARD_BINDS = {"", "0.0.0.0", "::", "[::]"}
+
+ProbeFn = Callable[[str, int], Awaitable[bool]]
+
+
+@dataclass(frozen=True)
+class _Candidate:
+    """One way the agent might reach a container, and where it came from."""
+
+    host: str
+    port: int
+    source: str
+
+    @property
+    def address(self) -> str:
+        return f"http://{self.host}:{self.port}"
+
 
 class DockerProvider:
     """Lists running containers that publish or expose a usable port."""
 
     name = "docker"
 
-    def __init__(self, socket_path: str | None = None) -> None:
+    def __init__(
+        self,
+        socket_path: str | None = None,
+        *,
+        probe: ProbeFn | None = None,
+        in_container: bool | None = None,
+    ) -> None:
         self._socket = socket_path or os.environ.get("DOCKER_SOCKET", DEFAULT_SOCKET)
+        self._probe = probe or _probe_tcp
+        self._in_container = running_in_container() if in_container is None else in_container
 
     def available(self) -> bool:
         try:
@@ -55,51 +110,199 @@ class DockerProvider:
             resp.raise_for_status()
             containers = resp.json()
 
-        services: list[DiscoveredService] = []
-        for c in containers:
-            service = self._to_service(c)
-            if service is not None:
-                services.append(service)
-        return services
+        return await self.services_from(containers)
 
-    def _to_service(self, container: dict) -> DiscoveredService | None:
+    async def services_from(self, containers: list[dict[str, Any]]) -> list[DiscoveredService]:
+        """Turn raw ``/containers/json`` output into addressable services.
+
+        Split from the socket call so the address choice — the part that was
+        wrong — is testable against real container payloads without a daemon.
+        """
+        # (container, candidates) for everything worth offering, before probing.
+        pending: list[tuple[dict[str, Any], list[_Candidate]]] = []
+        for c in containers:
+            if not self._wanted(c):
+                continue
+            candidates = _candidates(c, in_container=self._in_container)
+            if candidates:
+                pending.append((c, candidates))
+
+        chosen = await self._choose_addresses([cands for _, cands in pending])
+        return [
+            _to_service(container, candidate, reachable=reachable)
+            for (container, _), (candidate, reachable) in zip(pending, chosen, strict=True)
+        ]
+
+    def _wanted(self, container: dict[str, Any]) -> bool:
         image = str(container.get("Image", ""))
         if any(image.startswith(p) for p in _SKIP_IMAGE_PREFIXES):
-            return None
+            return False
+        return bool(_container_name(container))
 
-        name = _container_name(container)
-        if not name:
-            return None
+    async def _choose_addresses(
+        self, candidate_lists: list[list[_Candidate]]
+    ) -> list[tuple[_Candidate, bool]]:
+        """Pick a reachable candidate per container, falling back to the first.
 
-        ports = _usable_ports(container)
-        if not ports:
-            return None
+        The fallback matters: a container we can't reach is still reported, with
+        the guess we'd have made anyway and a label saying it didn't answer.
+        Dropping it instead would turn "these are unreachable from here" into
+        "discovery found nothing", which is the harder problem to debug.
+        """
+        if not candidate_lists:
+            return []
 
-        labels = {
-            k: v
-            for k, v in (container.get("Labels") or {}).items()
-            # Compose metadata is useful context; the rest is mostly build noise.
-            if k.startswith("com.docker.compose.") or k.startswith("hle.")
-        }
+        sem = asyncio.Semaphore(PROBE_CONCURRENCY)
 
-        # Prefer reaching the container by its network alias rather than a
-        # published host port: it works even when nothing is published, and it
-        # doesn't depend on how the agent's own networking is set up.
-        host = _network_alias(container) or name
-        port = ports[0]
+        async def first_reachable(candidates: list[_Candidate]) -> tuple[_Candidate, bool]:
+            for candidate in candidates:
+                async with sem:
+                    if await self._probe(candidate.host, candidate.port):
+                        return candidate, True
+            return candidates[0], False
 
-        return DiscoveredService(
-            provider=self.name,
-            id=f"{container.get('Id', name)[:12]}:{port}",
-            name=name,
-            address=f"http://{host}:{port}",
-            ports=ports,
-            namespace=labels.get("com.docker.compose.project"),
-            labels=labels,
-        )
+        try:
+            return await asyncio.wait_for(
+                asyncio.gather(*(first_reachable(c) for c in candidate_lists)),
+                timeout=PROBE_BUDGET,
+            )
+        except TimeoutError:
+            logger.warning(
+                "Discovery: probing container addresses exceeded %.0fs; "
+                "reporting unverified addresses",
+                PROBE_BUDGET,
+            )
+            return [(c[0], False) for c in candidate_lists]
 
 
-def _container_name(container: dict) -> str | None:
+def running_in_container() -> bool:
+    """Whether this agent is itself containerised.
+
+    Only used to order the candidate ladder, so a wrong answer costs latency
+    rather than correctness. ``HLE_IN_DOCKER`` lets the hle-docker image state it
+    outright instead of relying on inference.
+    """
+    env = os.environ.get("HLE_IN_DOCKER", "").strip().lower()
+    if env in {"1", "true", "yes"}:
+        return True
+    if env in {"0", "false", "no"}:
+        return False
+    try:
+        if Path("/.dockerenv").exists():
+            return True
+        # Present for containerd/podman and for Docker under cgroup v1.
+        return "docker" in Path("/proc/self/cgroup").read_text() if os.name == "posix" else False
+    except OSError:
+        return False
+
+
+def _candidates(container: dict[str, Any], *, in_container: bool) -> list[_Candidate]:
+    """Every way the agent might reach this container, best guess first.
+
+    Three rungs, all derived from what ``/containers/json`` already returned:
+
+    * **published** — the host port Docker mapped. Reachable from the host, and
+      authoritative rather than a guess: the daemon told us this port forwards to
+      this container.
+    * **container_ip** — the container's own address on its bridge network,
+      routable from the host on Linux and from containers on the same bridge.
+      The only rung that covers a container publishing nothing.
+    * **container_dns** — the network alias or container name. Needs Docker's
+      embedded DNS, so it works only from inside a container on the same
+      user-defined network (not the default bridge, which has no name
+      resolution at all).
+    """
+    private_ports = _usable_ports(container)
+    ladder = (
+        [_dns_candidates, _ip_candidates, _published_candidates]
+        if in_container
+        else [_published_candidates, _ip_candidates, _dns_candidates]
+    )
+
+    out: list[_Candidate] = []
+    seen: set[tuple[str, int]] = set()
+    for rung in ladder:
+        for candidate in rung(container, private_ports):
+            key = (candidate.host, candidate.port)
+            if key not in seen:
+                seen.add(key)
+                out.append(candidate)
+    return out
+
+
+def _published_candidates(container: dict[str, Any], _private: list[int]) -> list[_Candidate]:
+    out: list[_Candidate] = []
+    for p in container.get("Ports") or []:
+        if p.get("Type") != "tcp":
+            continue
+        public = p.get("PublicPort")
+        if not isinstance(public, int):
+            continue
+        bind = str(p.get("IP") or "")
+        # A wildcard bind is reachable on loopback; a specific one is not.
+        host = "127.0.0.1" if bind in _WILDCARD_BINDS else bind
+        out.append(_Candidate(host=host, port=public, source="published_port"))
+    return out
+
+
+def _ip_candidates(container: dict[str, Any], private_ports: list[int]) -> list[_Candidate]:
+    settings = container.get("NetworkSettings") or {}
+    addresses: list[str] = []
+    for net in (settings.get("Networks") or {}).values():
+        ip = str((net or {}).get("IPAddress") or "")
+        if ip:
+            addresses.append(ip)
+    # Top-level IPAddress is the legacy default-bridge field, absent from
+    # Networks on some daemon versions.
+    legacy = str(settings.get("IPAddress") or "")
+    if legacy and legacy not in addresses:
+        addresses.append(legacy)
+
+    return [
+        _Candidate(host=ip, port=port, source="container_ip")
+        for ip in addresses
+        for port in private_ports
+    ]
+
+
+def _dns_candidates(container: dict[str, Any], private_ports: list[int]) -> list[_Candidate]:
+    names = _dns_names(container)
+    return [
+        _Candidate(host=name, port=port, source="container_dns")
+        for name in names
+        for port in private_ports
+    ]
+
+
+def _to_service(
+    container: dict[str, Any], candidate: _Candidate, *, reachable: bool
+) -> DiscoveredService:
+    name = _container_name(container) or ""
+    ports = _usable_ports(container)
+    labels = {
+        k: v
+        for k, v in (container.get("Labels") or {}).items()
+        # Compose metadata is useful context; the rest is mostly build noise.
+        if k.startswith("com.docker.compose.") or k.startswith("hle.")
+    }
+    # Recorded in labels rather than new wire fields: `labels` is already a
+    # free-form dict that round-trips, so the dashboard can explain an
+    # unreachable service without a coordinated server change.
+    labels["hle.discovery.address_source"] = candidate.source
+    labels["hle.discovery.reachable"] = "true" if reachable else "false"
+
+    return DiscoveredService(
+        provider=DockerProvider.name,
+        id=f"{container.get('Id', name)[:12]}:{candidate.port}",
+        name=name,
+        address=candidate.address,
+        ports=ports,
+        namespace=labels.get("com.docker.compose.project"),
+        labels=labels,
+    )
+
+
+def _container_name(container: dict[str, Any]) -> str | None:
     names = container.get("Names") or []
     if not names:
         return None
@@ -107,17 +310,26 @@ def _container_name(container: dict) -> str | None:
     return str(names[0]).lstrip("/") or None
 
 
-def _network_alias(container: dict) -> str | None:
-    """A name other containers on the same network can resolve."""
+def _dns_names(container: dict[str, Any]) -> list[str]:
+    """Names other containers on the same user-defined network can resolve.
+
+    Every network's aliases, not just the first one found: dict ordering here is
+    the daemon's, so picking one alias could pick a network this agent isn't
+    attached to while the reachable one sat later in the list.
+    """
+    out: list[str] = []
     networks = ((container.get("NetworkSettings") or {}).get("Networks") or {}).values()
     for net in networks:
-        aliases = net.get("Aliases") or []
-        if aliases:
-            return str(aliases[0])
-    return None
+        for alias in (net or {}).get("Aliases") or []:
+            if alias and str(alias) not in out:
+                out.append(str(alias))
+    name = _container_name(container)
+    if name and name not in out:
+        out.append(name)
+    return out
 
 
-def _usable_ports(container: dict) -> list[int]:
+def _usable_ports(container: dict[str, Any]) -> list[int]:
     """Container-side TCP ports, published ones first.
 
     Published ports are listed first because they're the ones the operator
@@ -139,4 +351,36 @@ def _usable_ports(container: dict) -> list[int]:
     ordered = published + [p for p in internal if p not in published]
     # Preserve order while removing duplicates (a port can appear per-protocol).
     seen: set[int] = set()
-    return [p for p in ordered if not (p in seen or seen.add(p))]
+    out: list[int] = []
+    for p in ordered:
+        if p not in seen:
+            seen.add(p)
+            out.append(p)
+    return out
+
+
+async def _probe_tcp(host: str, port: int) -> bool:
+    """Whether a TCP connection to ``host:port`` completes.
+
+    Connect only — no request is sent. An HTTP GET would poke a real application
+    endpoint and would have to guess TLS versus plaintext; an accepted
+    connection is enough to know the address resolves and something is listening.
+    """
+    writer = None
+    try:
+        _, writer = await asyncio.wait_for(
+            asyncio.open_connection(host, port), timeout=PROBE_TIMEOUT
+        )
+        return True
+    except OSError:
+        # Covers refused, unreachable, DNS failure, and TimeoutError — which is
+        # an OSError subclass, and what wait_for raises here.
+        return False
+    except asyncio.CancelledError:
+        raise  # the overall probe budget expiring must actually cancel us
+    except Exception as exc:  # noqa: BLE001 — a probe must never break a scan
+        logger.debug("Probe of %s:%s failed: %s", host, port, exc)
+        return False
+    finally:
+        if writer is not None:
+            writer.close()

--- a/src/hle_client/discovery/docker.py
+++ b/src/hle_client/discovery/docker.py
@@ -25,6 +25,7 @@ but mounting it at all is a real trust decision. Discovery stays opt-in.
 from __future__ import annotations
 
 import asyncio
+import ipaddress
 import logging
 import os
 from collections.abc import Awaitable, Callable
@@ -59,10 +60,26 @@ PROBE_CONCURRENCY = 20
 # reporting unprobed best guesses.
 PROBE_BUDGET = 10.0
 
-# Bind addresses that mean "every interface" rather than somewhere to connect to.
-_WILDCARD_BINDS = {"", "0.0.0.0", "::", "[::]"}
-
 ProbeFn = Callable[[str, int], Awaitable[bool]]
+
+
+def _is_wildcard_bind(ip: str) -> bool:
+    """Whether a published port's bind address means "every interface".
+
+    Asked semantically rather than against a list of literals: ``is_unspecified``
+    covers both families and every spelling of them, and it doesn't read like a
+    hardcoded all-interfaces bind to a security scanner — this compares an
+    address the daemon reported, it never binds one.
+
+    An address we can't parse is treated as specific, so we try connecting to it
+    rather than assuming loopback would do.
+    """
+    if not ip:
+        return True
+    try:
+        return ipaddress.ip_address(ip.strip("[]")).is_unspecified
+    except ValueError:
+        return False
 
 
 @dataclass(frozen=True)
@@ -240,7 +257,7 @@ def _published_candidates(container: dict[str, Any], _private: list[int]) -> lis
             continue
         bind = str(p.get("IP") or "")
         # A wildcard bind is reachable on loopback; a specific one is not.
-        host = "127.0.0.1" if bind in _WILDCARD_BINDS else bind
+        host = "127.0.0.1" if _is_wildcard_bind(bind) else bind
         out.append(_Candidate(host=host, port=public, source="published_port"))
     return out
 

--- a/tests/unit/test_docker_discovery_address.py
+++ b/tests/unit/test_docker_discovery_address.py
@@ -205,11 +205,39 @@ class TestRealProbe:
 
         assert asyncio.run(go()) is True
 
-    def test_a_name_that_does_not_resolve_is_not_reachable(self):
-        """The actual production bug: a container name, from the host."""
+    def test_nothing_listening_is_not_reachable(self):
+        """A port that closed a moment ago: refused, not hung."""
+
+        async def go():
+            server = await asyncio.start_server(lambda r, w: None, "127.0.0.1", 0)
+            port = server.sockets[0].getsockname()[1]
+            server.close()
+            await server.wait_closed()
+            from hle_client.discovery.docker import _probe_tcp
+
+            return await _probe_tcp("127.0.0.1", port)
+
+        assert asyncio.run(go()) is False
+
+    def test_a_name_that_does_not_resolve_is_not_reachable(self, monkeypatch):
+        """The actual production bug: a container name, from the host.
+
+        The resolver is stubbed rather than asked for a real name. `getaddrinfo`
+        runs in a thread executor, so `wait_for` abandons the *wait* while the
+        thread stays blocked in the syscall — and Python joins that thread at
+        interpreter shutdown. Against a resolver that blackholes unknown names
+        instead of answering NXDOMAIN, this test passed and then hung the whole
+        run on the way out, which is exactly what it did on CI's 3.12.
+        """
+        import socket
+
+        async def refuse_to_resolve(host, port, **kwargs):
+            raise socket.gaierror(socket.EAI_NONAME, "Name or service not known")
+
+        monkeypatch.setattr(asyncio, "open_connection", refuse_to_resolve)
         from hle_client.discovery.docker import _probe_tcp
 
-        assert asyncio.run(_probe_tcp("jellyfin.invalid", 8096)) is False
+        assert asyncio.run(_probe_tcp("jellyfin", 8096)) is False
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_docker_discovery_address.py
+++ b/tests/unit/test_docker_discovery_address.py
@@ -1,0 +1,223 @@
+"""Which address Docker discovery reports for a container.
+
+The provider used to report `http://<container-name>:<container-port>` always.
+That name resolves only through Docker's embedded DNS, inside a container on the
+same user-defined network — so for an agent installed on the host every
+discovered container was unreachable. Worse, a published container had a working
+host address available and threw it away, because the ports helper sorted
+published ports first but returned the container-side number.
+
+These tests pin the choice itself, which nothing covered before.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from hle_client.discovery.docker import DockerProvider, _candidates
+
+
+def container(
+    *,
+    name="jellyfin",
+    ports=None,
+    networks=None,
+    cid="abcdef1234567890",
+    image="jellyfin/jellyfin",
+    labels=None,
+):
+    return {
+        "Id": cid,
+        "Image": image,
+        "Names": [f"/{name}"],
+        "Ports": ports if ports is not None else [],
+        "NetworkSettings": {"Networks": networks if networks is not None else {}},
+        "Labels": labels or {},
+    }
+
+
+PUBLISHED = [{"Type": "tcp", "PrivatePort": 8096, "PublicPort": 32768, "IP": "0.0.0.0"}]
+UNPUBLISHED = [{"Type": "tcp", "PrivatePort": 8096}]
+BRIDGE = {"bridge": {"IPAddress": "172.17.0.4", "Aliases": []}}
+USER_NET = {"media": {"IPAddress": "172.20.0.5", "Aliases": ["jellyfin", "media-server"]}}
+
+
+class TestCandidateLadder:
+    def test_host_agent_prefers_the_published_host_port(self):
+        """The one address that works from the host, and Docker's own mapping."""
+        cands = _candidates(container(ports=PUBLISHED, networks=USER_NET), in_container=False)
+        assert (cands[0].host, cands[0].port) == ("127.0.0.1", 32768)
+        assert cands[0].source == "published_port"
+        assert cands[0].address == "http://127.0.0.1:32768"
+
+    def test_container_agent_prefers_the_network_alias(self):
+        cands = _candidates(container(ports=PUBLISHED, networks=USER_NET), in_container=True)
+        assert cands[0].source == "container_dns"
+        assert cands[0].host == "jellyfin"
+
+    def test_a_specific_bind_address_is_used_rather_than_loopback(self):
+        """Published to one interface only: 127.0.0.1 would not answer."""
+        ports = [{"Type": "tcp", "PrivatePort": 8096, "PublicPort": 32768, "IP": "192.168.1.10"}]
+        cands = _candidates(container(ports=ports), in_container=False)
+        assert (cands[0].host, cands[0].port) == ("192.168.1.10", 32768)
+
+    def test_unpublished_container_falls_back_to_its_bridge_ip(self):
+        """The rung that exists because nothing is published to fall back to."""
+        cands = _candidates(container(ports=UNPUBLISHED, networks=BRIDGE), in_container=False)
+        assert (cands[0].host, cands[0].port) == ("172.17.0.4", 8096)
+        assert cands[0].source == "container_ip"
+
+    def test_every_rung_is_offered_as_a_fallback(self):
+        cands = _candidates(container(ports=PUBLISHED, networks=USER_NET), in_container=False)
+        assert [c.source for c in cands] == [
+            "published_port",
+            "container_ip",
+            "container_dns",
+            "container_dns",
+        ]
+
+    def test_all_aliases_are_candidates_not_just_the_first(self):
+        """Dict order here is the daemon's; the reachable alias may not be first."""
+        cands = _candidates(container(networks=USER_NET, ports=UNPUBLISHED), in_container=True)
+        hosts = [c.host for c in cands]
+        assert "jellyfin" in hosts and "media-server" in hosts
+
+    def test_legacy_top_level_ip_is_used_when_networks_is_empty(self):
+        c = container(ports=UNPUBLISHED)
+        c["NetworkSettings"] = {"IPAddress": "172.17.0.9"}
+        cands = _candidates(c, in_container=False)
+        assert ("172.17.0.9", 8096) in [(x.host, x.port) for x in cands]
+
+    def test_no_ports_yields_no_candidates(self):
+        assert _candidates(container(), in_container=False) == []
+
+    def test_udp_only_is_not_offered(self):
+        c = container(ports=[{"Type": "udp", "PrivatePort": 51820, "PublicPort": 51820}])
+        assert _candidates(c, in_container=False) == []
+
+
+class TestScanPicksWhatAnswers:
+    def _scan(self, containers, reachable, in_container=False):
+        """Run scan() with the Engine API and the TCP probe both stubbed out."""
+        probed: list[tuple[str, int]] = []
+
+        async def fake_probe(host, port):
+            probed.append((host, port))
+            return (host, port) in reachable
+
+        provider = DockerProvider(probe=fake_probe, in_container=in_container)
+        return asyncio.run(provider.services_from(containers)), probed
+
+    def test_reports_the_candidate_that_answers(self):
+        """Host agent, container on a user-defined net: the alias never resolves."""
+        services, probed = self._scan(
+            [container(ports=PUBLISHED, networks=USER_NET)],
+            reachable={("127.0.0.1", 32768)},
+        )
+        assert services[0].address == "http://127.0.0.1:32768"
+        assert services[0].labels["hle.discovery.reachable"] == "true"
+        assert services[0].labels["hle.discovery.address_source"] == "published_port"
+
+    def test_skips_a_dead_rung_and_takes_the_next(self):
+        """Published port bound but not answering; the bridge IP does."""
+        services, probed = self._scan(
+            [container(ports=PUBLISHED, networks=BRIDGE)],
+            reachable={("172.17.0.4", 8096)},
+        )
+        assert services[0].address == "http://172.17.0.4:8096"
+        assert ("127.0.0.1", 32768) in probed  # tried first, failed
+
+    def test_unreachable_container_is_still_reported_and_labelled(self):
+        """Dropping it would read as "discovery found nothing" — harder to debug."""
+        services, _ = self._scan([container(ports=UNPUBLISHED, networks=USER_NET)], reachable=set())
+        assert len(services) == 1
+        assert services[0].labels["hle.discovery.reachable"] == "false"
+        assert services[0].address.startswith("http://")
+
+    def test_probing_stops_at_the_first_success(self):
+        services, probed = self._scan(
+            [container(ports=PUBLISHED, networks=USER_NET)],
+            reachable={("127.0.0.1", 32768)},
+        )
+        assert probed == [("127.0.0.1", 32768)]
+
+    def test_hle_containers_are_never_offered(self):
+        services, _ = self._scan(
+            [container(image="ghcr.io/hle-world/hle-docker:latest", ports=PUBLISHED)],
+            reachable={("127.0.0.1", 32768)},
+        )
+        assert services == []
+
+    def test_id_reflects_the_port_actually_reported(self):
+        services, _ = self._scan([container(ports=PUBLISHED)], reachable={("127.0.0.1", 32768)})
+        assert services[0].id == "abcdef123456:32768"
+
+    def test_compose_metadata_survives_the_added_labels(self):
+        services, _ = self._scan(
+            [
+                container(
+                    ports=PUBLISHED,
+                    labels={"com.docker.compose.project": "media", "build.irrelevant": "x"},
+                )
+            ],
+            reachable={("127.0.0.1", 32768)},
+        )
+        assert services[0].namespace == "media"
+        assert "build.irrelevant" not in services[0].labels
+
+
+class TestProbeBudget:
+    def test_a_hanging_probe_does_not_lose_the_scan(self, monkeypatch):
+        """Overrunning the budget reports unverified addresses, not nothing."""
+        monkeypatch.setattr("hle_client.discovery.docker.PROBE_BUDGET", 0.05)
+
+        async def hangs(host, port):
+            await asyncio.sleep(10)
+            return True
+
+        provider = DockerProvider(probe=hangs, in_container=False)
+        cands = _candidates(container(ports=PUBLISHED), in_container=False)
+        chosen = asyncio.run(provider._choose_addresses([cands]))
+        assert chosen == [(cands[0], False)]
+
+    def test_no_containers_needs_no_probing(self):
+        async def explode(host, port):
+            raise AssertionError("should not probe")
+
+        provider = DockerProvider(probe=explode)
+        assert asyncio.run(provider._choose_addresses([])) == []
+
+
+class TestRealProbe:
+    def test_a_listening_socket_answers(self):
+        async def go():
+            server = await asyncio.start_server(lambda r, w: None, "127.0.0.1", 0)
+            port = server.sockets[0].getsockname()[1]
+            from hle_client.discovery.docker import _probe_tcp
+
+            try:
+                return await _probe_tcp("127.0.0.1", port)
+            finally:
+                server.close()
+                await server.wait_closed()
+
+        assert asyncio.run(go()) is True
+
+    def test_a_name_that_does_not_resolve_is_not_reachable(self):
+        """The actual production bug: a container name, from the host."""
+        from hle_client.discovery.docker import _probe_tcp
+
+        assert asyncio.run(_probe_tcp("jellyfin.invalid", 8096)) is False
+
+
+@pytest.mark.parametrize(
+    ("env", "expected"),
+    [("1", True), ("true", True), ("0", False), ("no", False)],
+)
+def test_hle_in_docker_overrides_inference(monkeypatch, env, expected):
+    from hle_client.discovery.docker import running_in_container
+
+    monkeypatch.setenv("HLE_IN_DOCKER", env)
+    assert running_in_container() is expected

--- a/tests/unit/test_docker_discovery_address.py
+++ b/tests/unit/test_docker_discovery_address.py
@@ -213,6 +213,24 @@ class TestRealProbe:
 
 
 @pytest.mark.parametrize(
+    ("bind", "expected"),
+    [
+        ("", True),
+        ("0.0.0.0", True),
+        ("::", True),
+        ("[::]", True),
+        ("127.0.0.1", False),
+        ("192.168.1.10", False),
+        ("nonsense", False),  # unparseable: try it rather than assume loopback
+    ],
+)
+def test_wildcard_bind_detection(bind, expected):
+    from hle_client.discovery.docker import _is_wildcard_bind
+
+    assert _is_wildcard_bind(bind) is expected
+
+
+@pytest.mark.parametrize(
     ("env", "expected"),
     [("1", True), ("true", True), ("0", False), ("no", False)],
 )

--- a/tests/unit/test_service_discovery.py
+++ b/tests/unit/test_service_discovery.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import pytest
 
 from hle_client.discovery import active_providers, scan_all
-from hle_client.discovery.docker import DockerProvider, _network_alias, _usable_ports
+from hle_client.discovery.docker import DockerProvider, _dns_names, _usable_ports
 from hle_client.discovery.kubernetes import KubernetesProvider
 from hle_common.discovery import DiscoveredService
 
@@ -120,31 +120,44 @@ class TestDockerProvider:
         base.update(overrides)
         return base
 
-    def test_maps_a_container_to_a_service(self):
-        svc = DockerProvider()._to_service(self._container())
-        assert svc is not None
+    def _provider(self, *, reachable=None, in_container=False) -> DockerProvider:
+        """A provider whose probe answers from a set instead of the network.
+
+        Address *choice* is covered in test_docker_discovery_address.py; these
+        tests only care that a container maps to a service at all.
+        """
+        allowed = reachable if reachable is not None else set()
+
+        async def probe(host: str, port: int) -> bool:
+            return (host, port) in allowed
+
+        return DockerProvider(probe=probe, in_container=in_container)
+
+    async def test_maps_a_container_to_a_service(self):
+        provider = self._provider(reachable={("127.0.0.1", 8096)})
+        (svc,) = await provider.services_from([self._container()])
         assert svc.provider == "docker"
         assert svc.name == "jellyfin"
-        # Reached by network alias, which works whether or not a port is published.
-        assert svc.address == "http://jellyfin:8096"
+        # The published host port, not the container name: an agent on the host
+        # has no Docker DNS to resolve "jellyfin" with.
+        assert svc.address == "http://127.0.0.1:8096"
         assert svc.namespace == "media"
         assert "build.irrelevant" not in svc.labels
 
-    def test_skips_containers_without_ports(self):
-        assert DockerProvider()._to_service(self._container(Ports=[])) is None
+    async def test_skips_containers_without_ports(self):
+        assert await self._provider().services_from([self._container(Ports=[])]) == []
 
-    def test_skips_hle_own_containers(self):
+    async def test_skips_hle_own_containers(self):
         # Exposing HLE through HLE is a confusing loop.
-        assert (
-            DockerProvider()._to_service(
-                self._container(Image="ghcr.io/hle-world/hle-docker:latest")
-            )
-            is None
-        )
+        containers = [self._container(Image="ghcr.io/hle-world/hle-docker:latest")]
+        assert await self._provider().services_from(containers) == []
 
-    def test_falls_back_to_container_name_without_alias(self):
-        svc = DockerProvider()._to_service(self._container(NetworkSettings={"Networks": {}}))
+    async def test_container_name_is_still_offered_when_nothing_else_answers(self):
+        """The old sole behaviour, demoted to a last resort rather than removed."""
+        provider = self._provider(reachable={("jellyfin", 8096)})
+        (svc,) = await provider.services_from([self._container(NetworkSettings={"Networks": {}})])
         assert svc.address == "http://jellyfin:8096"
+        assert svc.labels["hle.discovery.address_source"] == "container_dns"
 
     def test_unavailable_when_socket_missing(self):
         assert DockerProvider(socket_path="/nonexistent/docker.sock").available() is False
@@ -172,9 +185,19 @@ class TestDockerPortSelection:
         )
         assert ports == [80]
 
-    def test_alias_extraction(self):
-        assert _network_alias({"NetworkSettings": {"Networks": {"n": {"Aliases": ["a"]}}}}) == "a"
-        assert _network_alias({"NetworkSettings": {"Networks": {}}}) is None
+    def test_dns_names_include_every_alias_then_the_container_name(self):
+        names = _dns_names(
+            {
+                "Names": ["/jellyfin"],
+                "NetworkSettings": {"Networks": {"n": {"Aliases": ["a", "b"]}}},
+            }
+        )
+        assert names == ["a", "b", "jellyfin"]
+
+    def test_dns_names_without_networks_is_just_the_container_name(self):
+        assert _dns_names({"Names": ["/jellyfin"], "NetworkSettings": {"Networks": {}}}) == [
+            "jellyfin"
+        ]
 
 
 class TestKubernetesProvider:


### PR DESCRIPTION
Discovery offered addresses no agent on the host could reach.

## The bug

Every discovered container got `http://<alias-or-name>:<container-port>`. That name resolves only through Docker's embedded DNS at `127.0.0.11`, which exists **inside** a container attached to the same user-defined network. An agent installed on the host — pipx, a venv, pfSense — has no such resolver, so the address was NXDOMAIN and clicking "expose" produced a tunnel to nothing.

The old code stated the wrong assumption out loud:

```python
# Prefer reaching the container by its network alias rather than a
# published host port: it works even when nothing is published, and it
# doesn't depend on how the agent's own networking is set up.
```

It depends on nothing else.

**A published container was worse, not better.** `_usable_ports` sorted published ports first but returned the *container-side* number, so `0.0.0.0:32768->8096/tcp` still came out as `http://name:8096` — the one address that would have worked from the host was found and then thrown away. Two further edges: the default bridge has no name resolution at all, so even an in-container agent failed there; and `_network_alias` took whichever alias the daemon's dict ordering put first, possibly on a network the agent isn't attached to.

## The fix

Addressing isn't a property of the container — it depends on where the agent runs. So stop guessing it. Each container produces a ladder, all from data `/containers/json` already returns:

| Rung | Address | Reachable from |
|------|---------|----------------|
| `published_port` | `127.0.0.1:<PublicPort>`, or the specific bind IP | the host. Authoritative, not inferred — the daemon told us it forwards here |
| `container_ip` | `NetworkSettings.Networks[*].IPAddress` + container port | a Linux host, and containers on that bridge. The only rung covering a container that publishes nothing |
| `container_dns` | alias or name | in-container, same user-defined network. The old sole behaviour, now a last resort — and every alias is tried |

Whether the agent is itself containerised decides the **order only**; a TCP connect decides the answer. Being wrong about the environment costs a few hundred milliseconds instead of handing the dashboard a dead URL. Connect only — an HTTP request would poke a real application endpoint and have to guess TLS vs plaintext.

**Unreachable containers are still reported**, with the guess we'd have made anyway plus `hle.discovery.reachable=false`; the chosen rung lands in `hle.discovery.address_source`. Dropping them would turn "unreachable from here" into "discovery found nothing", which is the harder thing to debug — the same failure mode as the crash-looping agent that reported a healthy pid.

**No wire change.** Both go in the existing free-form `labels` dict, which already round-trips, so `hle_common` is untouched and this needs no coordinated server release.

The probe phase is bounded twice: 0.4s per candidate, 20 in flight, and a 10s total inside the caller's 15s `SCAN_TIMEOUT` — overrunning it reports unverified addresses rather than losing the entire scan.

## Tests

Nothing covered address choice, which is why this shipped. The existing tests asserted the broken behaviour — one comment claimed the alias "works whether or not a port is published" — and are updated. 24 new tests pin each rung, the ordering flip, the skip-a-dead-rung path, the labels, the budget overrun, and a real probe against both a live socket and a name that doesn't resolve.

`527 passed`. The single local failure (`test_json_output_is_machine_readable`) reproduces on unmodified `main` in a clean worktree and is green in CI.

## Deliberately not fixed

- **Docker Desktop on macOS/Windows** has no host route to the bridge subnet, so an unpublished container is genuinely unreachable from a host agent. The probe now reports that honestly instead of looking broken — a capability gap, not a bug.
- **`--net=host` containers** report neither `Ports` nor `IPAddress`, so they remain invisible. Their ports are only in `Config.ExposedPorts` via a per-container inspect, which I'd want to verify before building on.
