### PR TITLE
hle update reported success after upgrading nothing

### DIFF
--- a/src/hle_client/service_cmd.py
+++ b/src/hle_client/service_cmd.py
@@ -792,13 +792,20 @@ def restart_service(name: str) -> bool:
     return _systemctl(True, "restart", name).returncode == 0
 
 
-def _resolve_label(label: str | None, agent_mode: bool) -> str:
-    """Resolve the label for uninstall/status: --agent implies the agent label."""
+def _resolve_label(label: str | None, agent_mode: bool, *, extra_hint: str = "") -> str:
+    """Resolve the label for uninstall/status/restart: --agent implies the agent label.
+
+    ``extra_hint`` names any other way out that the calling command offers, so the
+    error doesn't hide the flag that is usually the right answer.
+    """
     if label:
         return label
     if agent_mode:
         return AGENT_LABEL
-    console.print("[red]--label is required[/red] (or pass --agent for the agent service).")
+    console.print(
+        f"[red]--label is required[/red] (or pass --agent for the agent service{extra_hint})."
+    )
+    console.print("[dim]hle service list[/dim] shows what is installed.")
     raise SystemExit(1)
 
 
@@ -1106,7 +1113,7 @@ def restart(agent_mode: bool, label: str | None, name: str | None, restart_all: 
         return
 
     plat = current_platform()
-    label = _resolve_label(label, agent_mode)
+    label = _resolve_label(label, agent_mode, extra_hint=", or --all for every service")
     if plat == "freebsd":
         svc = rc_service_name(label, name)
     elif plat == "darwin":

--- a/src/hle_client/update_cmd.py
+++ b/src/hle_client/update_cmd.py
@@ -141,8 +141,47 @@ def update(check: bool, target_version: str | None, yes: bool) -> None:
         console.print("[red]Upgrade command failed.[/red]")
         raise SystemExit(result.returncode)
 
-    new_version = _installed_version(sys.executable) or "unknown"
-    console.print(f"[green]Updated to {new_version}.[/green]")
+    # Exit code 0 is not the same as "the new version is installed". `pipx
+    # upgrade` and `uv tool upgrade` both exit 0 while reporting "already at
+    # latest version" when their view of the index is behind PyPI's — which
+    # happens for minutes after a release, and for as long as pip's HTTP cache
+    # holds a stale index page. Trusting the exit code printed a green
+    # "Updated to 2608.3." immediately under "Latest on PyPI: 2608.4".
+    expected = target_version or latest
+    new_version = _installed_version(sys.executable)
+
+    if expected and new_version and new_version != expected:
+        console.print(
+            f"[yellow]{cmd[0]} reported success but {expected} is not installed "
+            f"(still {new_version}).[/yellow]"
+        )
+        pinned = build_upgrade_command(method, sys.executable, version=expected)
+        if pinned != cmd:
+            # The pinned form can't no-op: it names the version outright rather
+            # than asking the tool whether it thinks an upgrade is due.
+            console.print(f"[dim]$ {' '.join(pinned)}[/dim]")
+            retry = subprocess.run(pinned, check=False)  # noqa: S603 — argv built internally
+            if retry.returncode == 0:
+                new_version = _installed_version(sys.executable)
+
+    if expected and new_version and new_version != expected:
+        console.print(
+            f"[red]Still on {new_version}, not {expected}.[/red] The package index this "
+            f"machine sees is behind PyPI — usually a stale cache, or a release "
+            f"published moments ago. Retry in a minute, or force it:\n"
+            f"  {' '.join(build_upgrade_command(method, sys.executable, version=expected))}"
+        )
+        raise SystemExit(1)
+
+    if new_version is None:
+        # No evidence of failure, so don't claim one — but don't claim success
+        # either, which is what "Updated to unknown." amounted to.
+        console.print(
+            "[yellow]Upgraded, but the installed version could not be read.[/yellow] "
+            "Check with: hle --version"
+        )
+    else:
+        console.print(f"[green]Updated to {new_version}.[/green]")
 
     # A service started before the upgrade is still running the old code, and
     # nothing about it looks wrong — `hle --version` reports the new one while

--- a/tests/unit/test_service_cmd.py
+++ b/tests/unit/test_service_cmd.py
@@ -299,25 +299,35 @@ class TestRestartWithoutATarget:
     `--all`, which is what somebody restarting after an upgrade actually wants.
     """
 
-    def _run(self):
+    def _run(self, subcommand):
+        """Invoke the subcommand with the platform check stubbed out.
+
+        Without this the test only proves what the CI container lacks: the test
+        image has no systemctl, so `_require_supported` exits with "needs
+        systemd" before argument handling runs. That made the assertion fail on
+        Linux and — worse — made the negative test below pass for the wrong
+        reason, since the systemd message happens not to contain "--all".
+        """
+        from unittest.mock import patch
+
         from click.testing import CliRunner
 
         from hle_client.cli import main
 
-        return CliRunner().invoke(main, ["service", "restart"])
+        with patch("hle_client.service_cmd._require_supported", return_value="linux"):
+            return CliRunner().invoke(main, ["service", subcommand])
 
     def test_mentions_all_and_how_to_look(self):
-        result = self._run()
+        result = self._run("restart")
         assert result.exit_code == 1
         out = " ".join(_ANSI.sub("", result.output).split())
+        assert "--label is required" in out
         assert "--all" in out
         assert "hle service list" in out
 
     def test_uninstall_does_not_claim_an_all_flag_it_lacks(self):
-        from click.testing import CliRunner
-
-        from hle_client.cli import main
-
-        result = CliRunner().invoke(main, ["service", "uninstall"])
+        result = self._run("uninstall")
         out = " ".join(_ANSI.sub("", result.output).split())
+        # Proves the hint is per-command, and that we got past the platform gate.
+        assert "--label is required" in out
         assert "--all" not in out

--- a/tests/unit/test_service_cmd.py
+++ b/tests/unit/test_service_cmd.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+
 import pytest
 
 from hle_client.service_cmd import (
@@ -16,6 +18,10 @@ from hle_client.service_cmd import (
     resolve_user_mode,
     unit_name,
 )
+
+# Rich colours numbers and wraps at the console width, so raw substring
+# assertions on its output fail for reasons the user never sees.
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
 
 
 class TestBuildFpArgs:
@@ -283,3 +289,35 @@ class TestServiceWiring:
 
         assert "service" in main.commands
         assert "install" in main.commands["service"].commands
+
+
+class TestRestartWithoutATarget:
+    """The error has to name every way out, or it sends people the long way round.
+
+    Reported from a live box: a bare `hle service restart` answered "--label is
+    required (or pass --agent for the agent service)" and never mentioned
+    `--all`, which is what somebody restarting after an upgrade actually wants.
+    """
+
+    def _run(self):
+        from click.testing import CliRunner
+
+        from hle_client.cli import main
+
+        return CliRunner().invoke(main, ["service", "restart"])
+
+    def test_mentions_all_and_how_to_look(self):
+        result = self._run()
+        assert result.exit_code == 1
+        out = " ".join(_ANSI.sub("", result.output).split())
+        assert "--all" in out
+        assert "hle service list" in out
+
+    def test_uninstall_does_not_claim_an_all_flag_it_lacks(self):
+        from click.testing import CliRunner
+
+        from hle_client.cli import main
+
+        result = CliRunner().invoke(main, ["service", "uninstall"])
+        out = " ".join(_ANSI.sub("", result.output).split())
+        assert "--all" not in out

--- a/tests/unit/test_update_restart.py
+++ b/tests/unit/test_update_restart.py
@@ -8,11 +8,25 @@ gap open until somebody acted on it.
 
 from __future__ import annotations
 
+import re
 from unittest.mock import patch
 
 from click.testing import CliRunner
 
 from hle_client.cli import main
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def plain(output: str) -> str:
+    """Rich output as readable text.
+
+    Rich highlights numbers, so it injects colour codes *inside* a phrase —
+    ``Updated to \x1b[1;36m9999.1\x1b[0m.`` — and wraps at the console width.
+    Asserting on the raw string fails for reasons that have nothing to do with
+    what the user sees.
+    """
+    return " ".join(_ANSI.sub("", output).split())
 
 
 class TestUpdateRestartsServices:
@@ -66,3 +80,74 @@ class TestUpdateRestartsServices:
         assert result.exit_code == 0, result.output
         assert "No hle services installed" in result.output
         restart.assert_not_called()
+
+
+class TestUpgradeIsVerified:
+    """Exit code 0 is not the same as "the new version is installed".
+
+    Reported from a live box: `pipx upgrade` answered "hle-client is already at
+    latest version 2608.3" and exited 0 while PyPI served 2608.4 — the release
+    had finished publishing eleven seconds earlier and the index pipx resolved
+    through was still behind. `hle update` printed a green "Updated to 2608.3."
+    directly under "Latest on PyPI: 2608.4", then offered to restart services
+    onto code it had not replaced.
+    """
+
+    def _run(self, installed_after, method="pipx", extra_args=(), returncodes=(0, 0)):
+        runner = CliRunner()
+        with (
+            patch("hle_client.update_cmd.pypi_latest_version", return_value="9999.1"),
+            patch("hle_client.update_cmd.detect_install_method", return_value=method),
+            patch("hle_client.update_cmd.subprocess.run") as mock_run,
+            patch("hle_client.update_cmd._installed_version", side_effect=list(installed_after)),
+            patch("hle_client.service_cmd.installed_services", return_value=[]),
+            patch("hle_client.service_cmd.restart_service", return_value=True),
+        ):
+            mock_run.side_effect = [type("R", (), {"returncode": rc})() for rc in returncodes]
+            result = runner.invoke(main, ["update", *extra_args], input="y\ny\n")
+        return result, mock_run
+
+    def test_a_no_op_upgrade_is_retried_with_the_version_pinned(self):
+        """The pinned form names the version instead of asking if one is due."""
+        result, mock_run = self._run(installed_after=["2608.3", "9999.1"])
+        assert result.exit_code == 0, result.output
+        assert "is not installed (still 2608.3)" in plain(result.output)
+        assert mock_run.call_count == 2
+        assert mock_run.call_args_list[1].args[0] == [
+            "pipx",
+            "install",
+            "--force",
+            "hle-client==9999.1",
+        ]
+        assert "Updated to 9999.1" in plain(result.output)
+
+    def test_a_no_op_that_stays_a_no_op_fails_loudly(self):
+        result, _ = self._run(installed_after=["2608.3", "2608.3"])
+        assert result.exit_code == 1
+        out = plain(result.output)
+        assert "Still on 2608.3, not 9999.1" in out
+        # Says what to do about it, not just that it happened.
+        assert "pipx install --force hle-client==9999.1" in out
+
+    def test_no_pointless_retry_when_the_command_was_already_pinned(self):
+        """`--version X` already builds the deterministic command."""
+        result, mock_run = self._run(installed_after=["2608.3"], extra_args=("--version", "9999.1"))
+        assert result.exit_code == 1
+        assert mock_run.call_count == 1
+        assert "Still on 2608.3" in plain(result.output)
+
+    def test_an_unreadable_version_is_not_reported_as_success(self):
+        """No evidence of failure, so don't invent one — but don't claim success."""
+        result, _ = self._run(installed_after=[None])
+        assert result.exit_code == 0, result.output
+        out = plain(result.output)
+        assert "could not be read" in out
+        assert "Updated to unknown" not in out
+
+    def test_a_successful_upgrade_still_says_so_once(self):
+        result, mock_run = self._run(installed_after=["9999.1"])
+        assert result.exit_code == 0, result.output
+        assert mock_run.call_count == 1
+        out = plain(result.output)
+        assert "Updated to 9999.1" in out
+        assert "is not installed" not in out


### PR DESCRIPTION
`hle update` reported success after upgrading nothing. From a live box, minutes after v2608.4 shipped:

```
Installed: 2608.3  (install method: pipx)
Latest on PyPI: 2608.4
Upgrade hle-client to 2608.4? [y/N]: y
$ pipx upgrade hle-client
hle-client is already at latest version 2608.3
Updated to 2608.3.
```

A green `Updated to 2608.3.` directly under `Latest on PyPI: 2608.4`, and then — because of the restart prompt added in #125 — an offer to restart services onto code that had not been replaced. Exit code 0 throughout.

## Why it passed

`pipx upgrade` and `uv tool upgrade` both exit **0** when they decide no upgrade is due. The only check was `returncode != 0`. The version printed afterwards came from reading the installed package, so it printed whatever was actually there and styled it as success either way.

## Why it no-opped

Not a bug — a race, worth recording because it will recur every release:

- our check reads PyPI's **JSON API**, which advertised 2608.4 the instant the release was cut
- pipx resolves through the **simple index**, which trails it
- that box ran `hle update` **11 seconds before the publish job finished** (18:03:50Z vs 18:04:01Z)
- pip then cached the index page it saw, and `cache-control: max-age=600` held the stale answer for ten minutes — so the retry with an explicit `==2608.4` failed too, with `No matching distribution found`

## The fix

Verify the installed version against the one that was asked for. On a mismatch, retry **once** with the version pinned — `pipx install --force pkg==X` names the version outright instead of asking the tool whether an upgrade is due, so it cannot no-op. If it still hasn't moved:

```
Still on 2608.3, not 2608.4. The package index this machine sees is behind
PyPI — usually a stale cache, or a release published moments ago. Retry in a
minute, or force it:
  pipx install --force hle-client==2608.4
```

…and exit 1.

No pointless retry when `--version X` was passed, since that command was already the deterministic one.

Also kills `Updated to unknown.` — an unreadable version isn't evidence of failure, so it doesn't exit 1, but it no longer claims success either.

## Tests

Six new, covering the no-op-then-retry path, the retry that stays a no-op, the already-pinned case that must not retry, the unreadable version, and ordinary success still saying so exactly once.

**The existing tests passed throughout this bug** because they mocked the installed version as already matching the target — the one arrangement in which it's invisible. That's the same shape as the Docker discovery tests in #127, which asserted the broken behaviour outright.

Assertions now go through a helper that strips ANSI and collapses whitespace: Rich highlights numbers, so it injects colour codes *inside* a phrase (`Updated to \x1b[1;36m9999.1\x1b[0m.`) and wraps at the console width. Raw substring assertions fail there for reasons no user ever sees — which cost me a debugging round on this very PR.
