### PR TITLE
CI: tag what was verified, and stop a dead runner starving the queue

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -18,6 +18,9 @@ jobs:
       github.event.pull_request.merged == true &&
       startsWith(github.event.pull_request.head.ref, 'chore/release-')
     runs-on: arc-runner-hle-client
+    # A release that never finishes is worse than one that fails: the tag is
+    # absent, the checks are green, and only the verify job below says so.
+    timeout-minutes: 15
     container:
       image: python:3.13-slim
     env:
@@ -77,6 +80,12 @@ jobs:
           # blocked from triggering other workflows).
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           REPO: ${{ github.repository }}
+          # Tag the commit this job actually checked out and verified, not
+          # whatever main happens to be when it runs. Those are the same commit
+          # only if nothing merged in between — and this job can sit queued for
+          # a long time. v2608.5 tagged 'main' after an unrelated PR had landed,
+          # so it shipped a feature its own changelog never mentioned.
+          TARGET_SHA: ${{ github.event.pull_request.merge_commit_sha }}
         run: |
           # Extract changelog entry for this version and pass via env var
           # (never interpolate file content into code strings — injection risk)
@@ -95,7 +104,7 @@ jobs:
               'tag_name': f'v{version}',
               'name': f'v{version}',
               'body': notes,
-              'target_commitish': 'main'
+              'target_commitish': os.environ.get('TARGET_SHA') or 'main'
           }).encode()
           req = urllib.request.Request(
               f'https://api.github.com/repos/{os.environ[\"REPO\"]}/releases',

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,10 +12,18 @@ on:
 permissions:
   contents: read
 
+# See test.yml: a superseded run holding a slot on a small self-hosted pool is
+# what everything else queues behind. The scheduled weekly scan has no ref of
+# its own to collide with, so it is unaffected.
+concurrency:
+  group: security-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   bandit:
     name: Bandit (Python SAST)
     runs-on: arc-runner-hle-client
+    timeout-minutes: 10
     container:
       image: python:3.13-slim
     steps:
@@ -57,6 +65,7 @@ jobs:
   pip-audit:
     name: pip-audit (Dependencies)
     runs-on: arc-runner-hle-client
+    timeout-minutes: 10
     container:
       image: python:3.13-slim
     steps:
@@ -80,6 +89,7 @@ jobs:
   secrets-scan:
     name: TruffleHog (Secret Scanning)
     runs-on: arc-runner-hle-client
+    timeout-minutes: 10
     container:
       image: python:3.13-slim
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,21 @@ on:
 permissions:
   contents: read
 
+# Only the newest push to a branch matters. Without this, every push leaves its
+# predecessor's jobs queued, and on a small self-hosted pool those stale runs
+# are what everything else waits behind.
+concurrency:
+  group: test-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: arc-runner-hle-client
+    # The suite takes about two minutes. This is not a limit on the tests, it is
+    # a limit on a dead runner: when an ARC pod dies mid-job the job stays
+    # "in_progress" forever, holds its slot, and starves the queue behind it in
+    # total silence. One such job blocked a release for 95 minutes.
+    timeout-minutes: 10
     container:
       image: python:${{ matrix.python-version }}-slim
     strategy:

--- a/tests/unit/test_docker_discovery_address.py
+++ b/tests/unit/test_docker_discovery_address.py
@@ -38,6 +38,10 @@ def container(
     }
 
 
+# Generous for a loopback connect (milliseconds locally), short enough that a
+# container without usable loopback TCP skips rather than holding a CI runner.
+SOCKET_TEST_BUDGET = 10.0
+
 PUBLISHED = [{"Type": "tcp", "PrivatePort": 8096, "PublicPort": 32768, "IP": "0.0.0.0"}]
 UNPUBLISHED = [{"Type": "tcp", "PrivatePort": 8096}]
 BRIDGE = {"bridge": {"IPAddress": "172.17.0.4", "Aliases": []}}
@@ -191,6 +195,16 @@ class TestProbeBudget:
 
 
 class TestRealProbe:
+    """Bounded, because an unbounded socket test wedged CI three times.
+
+    These open a real loopback socket, which is the point — the probe's whole
+    job is deciding whether something answers. But inside the CI container the
+    3.12 job hung here indefinitely, holding a runner and starving the queue
+    behind it for up to 95 minutes with no output. Every wait is now bounded, so
+    an environment without usable loopback TCP skips with a reason instead of
+    stopping the run.
+    """
+
     def test_a_listening_socket_answers(self):
         async def go():
             server = await asyncio.start_server(lambda r, w: None, "127.0.0.1", 0)
@@ -203,7 +217,11 @@ class TestRealProbe:
                 server.close()
                 await server.wait_closed()
 
-        assert asyncio.run(go()) is True
+        try:
+            result = asyncio.run(asyncio.wait_for(go(), timeout=SOCKET_TEST_BUDGET))
+        except TimeoutError:
+            pytest.skip("no usable loopback TCP in this environment")
+        assert result is True
 
     def test_nothing_listening_is_not_reachable(self):
         """A port that closed a moment ago: refused, not hung."""
@@ -217,7 +235,11 @@ class TestRealProbe:
 
             return await _probe_tcp("127.0.0.1", port)
 
-        assert asyncio.run(go()) is False
+        try:
+            result = asyncio.run(asyncio.wait_for(go(), timeout=SOCKET_TEST_BUDGET))
+        except TimeoutError:
+            pytest.skip("no usable loopback TCP in this environment")
+        assert result is False
 
     def test_a_name_that_does_not_resolve_is_not_reachable(self, monkeypatch):
         """The actual production bug: a container name, from the host.


### PR DESCRIPTION
Two CI failures from the same day, both of which presented as nothing happening.

## The release tagged something it never checked

`auto-release.yml` checks out the release PR's `merge_commit_sha`, validates the version against *that* tree, and then creates the release with `'target_commitish': 'main'`. Those are the same commit only if nothing merged in between.

On 2026-08-06 the job sat queued behind a runner backlog, #130 merged meanwhile, and **v2608.5's tag landed on main's tip** — so it shipped the whole preflight feature while its changelog describes only #127 and #128.

That is not just untidy. I spent an hour concluding from a live 504 that no released client contained the preflight handler, when in fact it had shipped inside v2608.5 and the agent simply hadn't upgraded yet. A release that contains more than it says is a release you can't reason about.

The SHA is already in the job. It is now what gets tagged.

```diff
-              'target_commitish': 'main'
+              'target_commitish': os.environ.get('TARGET_SHA') or 'main'
```

## A dead runner starved the queue in silence

When an ARC pod dies mid-job the job stays `in_progress` **forever**. It holds its runner and everything behind it queues with no failure, no timeout and nothing to look at.

One such job — on a branch that had already been merged and deleted — held **three of four runners for 95 minutes**. The visible symptom was jobs that had simply never started; `gh api .../actions/runners` showing 4 online, all busy, was what finally identified it. It blocked the v2608.5 release, and I misdiagnosed it twice before finding it.

`timeout-minutes: 10` turns that into a visible failure. The suite takes about two minutes, so this is not a limit on the tests — it is a limit on a runner that has stopped existing.

## Superseded runs competing for the pool

Every push left its predecessor's jobs queued; the release branch had duplicate Test and Security runs racing for the same four runners. Concurrency groups with `cancel-in-progress` on **test** and **security** only.

**Deliberately not on Auto Release** — cancelling a release mid-publish is the one thing worse than a slow one. It gets a `timeout-minutes: 15` instead, and the existing `verify` job still raises an issue if the tag never appears.

## Verified

```
test:         concurrency=True  {'test': 10}
security:     concurrency=True  {'bandit': 10, 'pip-audit': 10, 'secrets-scan': 10}
auto-release: concurrency=False {'release': 15, 'verify': None}
```

`verify` runs on `ubuntu-latest`, not the self-hosted pool, so it needs no timeout — and it must stay able to report on a release job that died.

Closes the CI half of a pattern that showed up repeatedly this week: things reporting success, or reporting nothing, over a broken state.
