### PR TITLE
Make a failed relay discovery visible

### DIFF
--- a/src/hle_client/api.py
+++ b/src/hle_client/api.py
@@ -66,6 +66,15 @@ class ApiClient:
 
         Returns ``None`` when the endpoint is unavailable (404, timeout,
         network error), allowing the caller to fall back to the default relay.
+
+        Failures are logged at ``warning`` rather than ``debug``, because the
+        fallback is silent and correct-looking: the tunnel connects, everything
+        appears fine, and discovery has simply stopped working. Agent-managed
+        tunnels got a 401 here on every single reconnect for exactly this reason,
+        and it went unnoticed until a server-side error report surfaced it.
+
+        A 404 stays at debug — that means the relay predates the endpoint, which
+        is expected rather than wrong.
         """
         try:
             async with httpx.AsyncClient(timeout=5.0) as client:
@@ -75,11 +84,29 @@ class ApiClient:
                 )
                 resp.raise_for_status()
                 return RelayDiscoveryResponse.model_validate(resp.json())
-        except (httpx.HTTPStatusError, httpx.ConnectError, httpx.TimeoutException):
-            logger.debug("Relay discovery unavailable, will use default relay", exc_info=True)
+        except httpx.HTTPStatusError as exc:
+            status = exc.response.status_code
+            if status == 404:
+                logger.debug("Relay discovery not implemented by this relay (404)")
+            elif status in (401, 403):
+                logger.warning(
+                    "Relay discovery rejected our credential (HTTP %d) — using the default "
+                    "relay. The tunnel still works, but this relay cannot route us.",
+                    status,
+                )
+            else:
+                logger.warning("Relay discovery failed (HTTP %d), using the default relay", status)
+            return None
+        except (httpx.ConnectError, httpx.TimeoutException) as exc:
+            logger.warning(
+                "Relay discovery unreachable (%s), using the default relay",
+                type(exc).__name__,
+            )
             return None
         except Exception:
-            logger.debug("Relay discovery failed unexpectedly", exc_info=True)
+            logger.warning(
+                "Relay discovery failed unexpectedly, using the default relay", exc_info=True
+            )
             return None
 
     async def list_tunnels(self) -> list[dict[str, Any]]:

--- a/tests/unit/test_api_client.py
+++ b/tests/unit/test_api_client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import AsyncMock, patch
 
 import httpx
@@ -113,3 +114,101 @@ class TestApiClientMethods:
             pytest.raises(httpx.HTTPStatusError),
         ):
             await client.delete_access_rule("app-x7k", 999)
+
+
+class TestRelayDiscoveryFailureIsVisible:
+    """A failed discovery falls back silently and everything still looks fine.
+
+    Agent-managed tunnels were rejected here on every reconnect for months
+    without a single visible log line, because the failure was logged at debug.
+    """
+
+    @pytest.fixture
+    def client(self) -> ApiClient:
+        return ApiClient(ApiClientConfig(api_key="hle_testkey"))
+
+    def _response(self, status: int) -> httpx.Response:
+        return httpx.Response(
+            status, request=httpx.Request("GET", "https://hle.world/api/v1/connect")
+        )
+
+    async def test_a_rejected_credential_warns(self, client: ApiClient, caplog) -> None:
+        """The case that actually happened, and was invisible."""
+        with (
+            caplog.at_level(logging.WARNING, logger="hle_client.api"),
+            patch(
+                "httpx.AsyncClient.get", new_callable=AsyncMock, return_value=self._response(401)
+            ),
+        ):
+            assert await client.discover_relay() is None
+
+        assert "401" in caplog.text
+        # The operator needs to know the tunnel is fine, so they can judge urgency.
+        assert "default" in caplog.text.lower()
+
+    async def test_a_403_warns_too(self, client: ApiClient, caplog) -> None:
+        with (
+            caplog.at_level(logging.WARNING, logger="hle_client.api"),
+            patch(
+                "httpx.AsyncClient.get", new_callable=AsyncMock, return_value=self._response(403)
+            ),
+        ):
+            assert await client.discover_relay() is None
+        assert "403" in caplog.text
+
+    async def test_a_server_error_warns(self, client: ApiClient, caplog) -> None:
+        with (
+            caplog.at_level(logging.WARNING, logger="hle_client.api"),
+            patch(
+                "httpx.AsyncClient.get", new_callable=AsyncMock, return_value=self._response(500)
+            ),
+        ):
+            assert await client.discover_relay() is None
+        assert "500" in caplog.text
+
+    async def test_a_404_stays_quiet(self, client: ApiClient, caplog) -> None:
+        """A relay older than the endpoint is expected, not broken — warning on
+        it would train everyone to ignore the warning that matters."""
+        with (
+            caplog.at_level(logging.WARNING, logger="hle_client.api"),
+            patch(
+                "httpx.AsyncClient.get", new_callable=AsyncMock, return_value=self._response(404)
+            ),
+        ):
+            assert await client.discover_relay() is None
+        assert caplog.text == ""
+
+    async def test_an_unreachable_relay_warns(self, client: ApiClient, caplog) -> None:
+        with (
+            caplog.at_level(logging.WARNING, logger="hle_client.api"),
+            patch(
+                "httpx.AsyncClient.get",
+                new_callable=AsyncMock,
+                side_effect=httpx.ConnectError("no route"),
+            ),
+        ):
+            assert await client.discover_relay() is None
+        assert "unreachable" in caplog.text.lower()
+
+    async def test_success_says_nothing(self, client: ApiClient, caplog) -> None:
+        """No warning on the happy path, or the signal is worthless."""
+        ok = httpx.Response(
+            200,
+            json={
+                "relay_url": "wss://hle.world/_hle/tunnel",
+                "relay_region": "default",
+                "ttl": 300,
+                "fallback_urls": [],
+                "metadata": {},
+            },
+            request=httpx.Request("GET", "https://hle.world/api/v1/connect"),
+        )
+        with (
+            caplog.at_level(logging.WARNING, logger="hle_client.api"),
+            patch("httpx.AsyncClient.get", new_callable=AsyncMock, return_value=ok),
+        ):
+            result = await client.discover_relay()
+
+        assert result is not None
+        assert result.relay_url == "wss://hle.world/_hle/tunnel"
+        assert caplog.text == ""


### PR DESCRIPTION
## Summary

`discover_relay()` logged every failure at `debug` and returned `None`, and the caller falls back to the default relay. The tunnel connects, everything looks healthy, and discovery has quietly stopped working — there is no symptom to notice.

Agent-managed tunnels hit a **401 here on every single reconnect**, because the agent's `hlea_` token is a data-plane credential the REST API rejected. The client never said a word. It surfaced only from the other side, as a cluster of 401s in a server-side error report.

- Failures now log at `warning`, with the status code
- The message says the tunnel still works, so the reader can judge urgency instead of panicking
- **A 404 stays at `debug`** — that means the relay predates the endpoint, which is expected rather than broken. Warning on it would train everyone to ignore the warning that matters.

## Tests

Six. The ones that matter are the negatives: **the happy path stays silent** (a warning that fires on success is worth nothing) and **a 404 stays quiet**.

## Pre-existing failure, not from this change

`tests/unit/test_cli_commands.py::TestAgentList::test_json_output_is_machine_readable` fails locally because Rich emits ANSI colour *inside* the JSON when it detects a terminal:

```
'\x1b[1m[\x1b[0m\n  \x1b[1m{\x1b[0m\n    \x1b[32m"name"\x1b[0m: ...'
```

I verified this against a clean `origin/main` worktree — it fails there identically. CI has no TTY, so it is green there. Unrelated to this change, but worth a look separately: `--json` producing colour-wrapped output is a real bug for anyone piping it into `jq` from an interactive shell.

`594 passed` otherwise.

## Paired with

The server-side half, hle#333, which makes discovery accept agent tokens so this warning stops firing for the actual cause. This change is what would have told us years earlier.
