### PR TITLE
Release v2608.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2608.6 — 2026-08-10
+
+<!-- TODO: Fill in release notes before merging -->
+
 ## v2608.5 — 2026-08-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,27 @@
 
 ## v2608.6 — 2026-08-10
 
-<!-- TODO: Fill in release notes before merging -->
+### Fixed
+
+- **A failed relay discovery said nothing at all.** On every connection the
+  client asks the relay where to connect, and falls back to the default relay
+  when that fails. The failure was logged at `debug`, so the fallback was
+  completely silent: the tunnel connects, everything looks healthy, and
+  discovery has simply stopped working with no symptom to notice.
+
+  Agent-managed tunnels were being turned away here on *every single reconnect*,
+  because an agent's token is a credential for carrying traffic that the REST
+  API did not accept. No client ever mentioned it. It came to light only from
+  the relay's side, as a cluster of rejections in a server error report.
+
+  Discovery failures now log at `warning` with the status code, and say the
+  tunnel still works so the message can be read calmly rather than as an
+  outage. A 404 stays quiet — that means the relay is older than the endpoint,
+  which is expected rather than broken, and warning about it would only teach
+  you to ignore the warning that matters.
+
+  The matching relay-side fix shipped in server v2608.23, so the specific
+  rejection this exposed is already gone.
 
 ## v2608.5 — 2026-08-05
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ curl -fsSL https://get.hle.world | sh
 Installs via pipx (preferred), uv, or pip-in-venv. Supports `--version`:
 
 ```bash
-curl -fsSL https://get.hle.world | sh -s -- --version 2608.5
+curl -fsSL https://get.hle.world | sh -s -- --version 2608.6
 ```
 
 ### pipx
@@ -93,7 +93,7 @@ and runs the right upgrade.
 ```bash
 hle update            # upgrade to the latest release
 hle update --check    # just report current vs. latest, don't change anything
-hle update --version 2608.5   # pin an exact version
+hle update --version 2608.6   # pin an exact version
 ```
 
 After updating, restart any running tunnels (e.g. `systemctl restart hle-<label>`)

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 #
 # Usage:
 #   curl -fsSL https://get.hle.world | sh
-#   curl -fsSL https://get.hle.world | sh -s -- --version 2608.5
+#   curl -fsSL https://get.hle.world | sh -s -- --version 2608.6
 #
 #   # Install the agent and run it as a service (prompts for the token):
 #   curl -fsSL https://get.hle.world | sh -s -- --agent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hle-client"
-version = "2608.5"
+version = "2608.6"
 description = "HomeLab Everywhere — Expose homelab services to the internet with built-in SSO"
 readme = "README.md"
 license = "MIT"

--- a/src/hle_client/__init__.py
+++ b/src/hle_client/__init__.py
@@ -1,3 +1,3 @@
 """HLE Client — HomeLab Everywhere tunnel client."""
 
-__version__ = "2608.5"
+__version__ = "2608.6"


### PR DESCRIPTION
Bump version to `2608.6` and update all version references.

When this PR is merged, a GitHub release will be created automatically,
which triggers PyPI publish and Homebrew formula update.