### PR TITLE
ci: move CI jobs from ARC to the homelab runner

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -17,7 +17,7 @@ jobs:
     if: >
       github.event.pull_request.merged == true &&
       startsWith(github.event.pull_request.head.ref, 'chore/release-')
-    runs-on: arc-runner-hle-client
+    runs-on: [self-hosted, homelab]
     # A release that never finishes is worse than one that fails: the tag is
     # absent, the checks are green, and only the verify job below says so.
     timeout-minutes: 15

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -8,7 +8,7 @@ permissions: {}
 
 jobs:
   update-formula:
-    runs-on: arc-runner-hle-client
+    runs-on: [self-hosted, homelab]
     container:
       image: python:3.13-slim
 

--- a/.github/workflows/notify-server.yml
+++ b/.github/workflows/notify-server.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   notify:
-    runs-on: arc-runner-hle-client
+    runs-on: [self-hosted, homelab]
     container:
       image: node:20-slim
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: arc-runner-hle-client
+    runs-on: [self-hosted, homelab]
     container:
       image: python:3.13-slim
     steps:
@@ -31,7 +31,7 @@ jobs:
 
   publish:
     needs: test
-    runs-on: arc-runner-hle-client
+    runs-on: [self-hosted, homelab]
     container:
       image: python:3.13-slim
     environment: pypi
@@ -77,7 +77,7 @@ jobs:
   notify-operator:
     name: Notify hle-operator
     needs: publish
-    runs-on: arc-runner-hle-client
+    runs-on: [self-hosted, homelab]
     container:
       image: python:3.13-slim
     env:
@@ -99,7 +99,7 @@ jobs:
   sync-hle-webapp:
     name: Trigger hle-webapp release
     needs: publish
-    runs-on: arc-runner-hle-client
+    runs-on: [self-hosted, homelab]
     container:
       image: python:3.13-slim
     env:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   bandit:
     name: Bandit (Python SAST)
-    runs-on: arc-runner-hle-client
+    runs-on: [self-hosted, homelab]
     timeout-minutes: 10
     container:
       image: python:3.13-slim
@@ -64,7 +64,7 @@ jobs:
 
   pip-audit:
     name: pip-audit (Dependencies)
-    runs-on: arc-runner-hle-client
+    runs-on: [self-hosted, homelab]
     timeout-minutes: 10
     container:
       image: python:3.13-slim
@@ -88,7 +88,7 @@ jobs:
 
   secrets-scan:
     name: TruffleHog (Secret Scanning)
-    runs-on: arc-runner-hle-client
+    runs-on: [self-hosted, homelab]
     timeout-minutes: 10
     container:
       image: python:3.13-slim

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: arc-runner-hle-client
+    runs-on: [self-hosted, homelab]
     # The suite takes about two minutes. This is not a limit on the tests, it is
     # a limit on a dead runner: when an ARC pod dies mid-job the job stays
     # "in_progress" forever, holds its slot, and starves the queue behind it in


### PR DESCRIPTION
Moves all `arc-runner-hle-client` jobs off the ARC pool on the VPS and onto the org-level self-hosted runner in the home lab. Nothing here touches VPS-local resources, so the whole set moves.

## What moves

| Workflow | Jobs |
|---|---|
| `test.yml` | test |
| `security.yml` | bandit, pip-audit, secrets-scan |
| `auto-release.yml` | release |
| `publish.yml` | test, publish, notify-operator, sync-hle-webapp |
| `homebrew.yml` | update-formula |
| `notify-server.yml` | notify |

`auto-release.yml`'s `verify` job stays on `ubuntu-latest` — it was never on ARC.

## Prerequisite

The homelab runner must advertise a `homelab` label, added to the org-level `github-runner` registration. Without it these jobs queue indefinitely.

## Security note

This repo is public and `test.yml`, `security.yml` and `auto-release.yml` trigger on `pull_request`, so a fork PR can now execute on the home lab runner. Org Settings → Actions → General → Fork pull request workflows must be set to require approval for outside collaborators before this merges.

## Risk

Every moved job uses `container:`. ARC ran these in Kubernetes container mode; a native runner needs Docker present and the runner user in the `docker` group.

No CHANGELOG entry — this is CI infrastructure with no effect on client behaviour.