### PR TITLE
security: resolve Semgrep findings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,17 @@
 version: 2
 updates:
+  # cooldown holds back updates to versions published in the last week. A
+  # freshly published package is where compromised releases surface, and a
+  # week is long enough for one to be caught and yanked before we adopt it.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -38,7 +38,7 @@ jobs:
         run: apt-get update && apt-get install -y git
 
       - name: Checkout homebrew-tap
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: hle-world/homebrew-tap
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
     container:
       image: python:3.13-slim
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install uv
         run: pip install uv
@@ -37,7 +37,7 @@ jobs:
     environment: pypi
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install build and publish tools
         run: pip install build twine

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -27,7 +27,7 @@ jobs:
     container:
       image: python:3.13-slim
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Bandit
         run: pip install bandit[toml]
@@ -69,7 +69,7 @@ jobs:
     container:
       image: python:3.13-slim
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install uv
         run: pip install uv
@@ -96,7 +96,7 @@ jobs:
       - name: Install git and curl
         run: apt-get update && apt-get install -y git curl
 
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
         python-version: ["3.11", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install uv
         run: pip install uv

--- a/src/hle_client/agent.py
+++ b/src/hle_client/agent.py
@@ -80,7 +80,9 @@ def load_agent_token() -> str | None:
         with open(path, "rb") as f:
             return tomllib.load(f).get("token")
     except (OSError, ValueError):
-        logger.debug("Failed to read agent token from %s", path)
+        # Logs the path, never the token. The rule fires on the word "token"
+        # appearing in the message.
+        logger.debug("Failed to read agent token from %s", path)  # nosemgrep
         return None
 
 

--- a/src/hle_client/service_cmd.py
+++ b/src/hle_client/service_cmd.py
@@ -23,7 +23,11 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
-from xml.sax.saxutils import escape as _xml_escape
+
+# escape() only quotes characters on the way OUT, when building the launchd
+# plist below. Nothing here parses XML, so there is no entity-expansion or
+# external-entity surface for defusedxml to protect against.
+from xml.sax.saxutils import escape as _xml_escape  # nosemgrep
 
 import click
 from rich.console import Console

--- a/src/hle_client/tunnel.py
+++ b/src/hle_client/tunnel.py
@@ -132,10 +132,14 @@ def _remove_api_key() -> bool:
         with os.fdopen(fd, "w") as f:
             f.writelines(new_lines)
 
-        logger.info("API key removed from %s", _CONFIG_FILE)
+        # Both of these log the config path, never the key itself. The rule
+        # fires on the words "API key" appearing in the message.
+        logger.info("API key removed from %s", _CONFIG_FILE)  # nosemgrep
         return True
     except Exception:
-        logger.warning("Failed to remove API key from %s", _CONFIG_FILE, exc_info=True)
+        logger.warning(  # nosemgrep
+            "Failed to remove API key from %s", _CONFIG_FILE, exc_info=True
+        )
         return False
 
 


### PR DESCRIPTION
Clears the 13 Semgrep findings in this repo.

These are not new code — they surfaced because `jspanos/hle` CI moved to a self-hosted runner whose persistent workspace leaves this submodule populated, so Semgrep now scans it. The ephemeral ARC pods never did, and this repo has no Semgrep job of its own, so none of this had been covered anywhere.

## Fixed

| Rule | Count | Change |
|---|---|---|
| `github-actions-mutable-action-tag` | 7 | Pinned `actions/checkout@v6.0.2` to `de0fac2e4500dabe0009e67214ff5f5447ce83dd` |
| `dependabot-missing-cooldown` | 1 | Added `cooldown: default-days: 7` to both ecosystems |

A tag can be silently repointed by the action owner — the mechanism behind the trivy-action and kics-github-action compromises. The cooldown gives a freshly published version a week to be caught and yanked before we adopt it.

## Suppressed as false positives

| Rule | Where | Why |
|---|---|---|
| `logger-credential-leak` | `agent.py:83`, `tunnel.py:135,138` | Log the config **path**; the rule fires on the words "token"/"API key" in the message |
| `use-defused-xml` | `service_cmd.py:26` | `xml.sax.saxutils.escape` quotes characters on the way **out** while building a launchd plist; nothing parses XML |

Each carries a comment explaining the reasoning. Bare `# nosemgrep` rather than the rule ID because the full ID exceeds the 100-char line limit.

## Verified

```
semgrep scan --config p/python --config p/javascript --config p/typescript \
  --config p/security-audit --config p/owasp-top-ten --error
Ran 233 rules on 45 files: 0 findings.
```

`ruff check` and `ruff format --check` both clean. No behaviour change — no CHANGELOG entry.